### PR TITLE
fix: fix return path compile error

### DIFF
--- a/src/RE/T/TESDataHandler.cpp
+++ b/src/RE/T/TESDataHandler.cpp
@@ -116,6 +116,7 @@ namespace RE
 			}
 			return nullptr;
 		}
+		return nullptr;
 	}
 
 	const TESFile* TESDataHandler::LookupLoadedModByIndex(std::uint8_t a_index)
@@ -194,6 +195,7 @@ namespace RE
 				}
 			}
 		}
+		return nullptr;
 #endif
 	}
 


### PR DESCRIPTION
LookupLoadedModByName and LookupLoadedLightModByIndex will now correctly return nullptr if no file can be found