### PR TITLE
fix: correct control map AE version comparison

### DIFF
--- a/include/RE/C/ControlMap.h
+++ b/include/RE/C/ControlMap.h
@@ -149,7 +149,7 @@ namespace RE
 		[[nodiscard]] inline const RUNTIME_DATA& GetRuntimeData() const noexcept
 		{
 			if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {
-				if (REL::Module::get().version().compare(SKSE::RUNTIME_SSE_1_6_629) != std::strong_ordering::less) {
+				if (REL::Module::get().version().compare(SKSE::RUNTIME_SSE_1_6_1130) != std::strong_ordering::less) {
 					return REL::RelocateMember<RUNTIME_DATA>(this, 0xf0);
 				}
 			}


### PR DESCRIPTION
I'm guessing this comparison is supposed to use the same version as line 142.

---

Edit to add more context:
https://github.com/alandtse/CommonLibVR/blob/98c327b5c1c632ee8be4cda16ac03c219a3072cf/include/RE/C/ControlMap.h#L139C1-L147
https://github.com/alandtse/CommonLibVR/blob/98c327b5c1c632ee8be4cda16ac03c219a3072cf/include/RE/C/ControlMap.h#L149C2-L157

These are const and non-const versions of the same function, but the const one has a comparison against RUNTIME_SSE_1_6_629, while the non-const one compares against RUNTIME_SSE_1_6_1130. I'm guessing the intent is to compare against RUNTIME_SSE_1_6_1130 in both cases.