### PR TITLE
build: Remove boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
 endif()
 
 find_package(binary_io REQUIRED CONFIG)
-find_package(Boost MODULE REQUIRED)
 find_package(spdlog REQUIRED CONFIG)
 
 include(cmake/sourcelist.cmake)
@@ -47,7 +46,6 @@ add_library("${PROJECT_NAME}::${PROJECT_NAME}" ALIAS "${PROJECT_NAME}")
 target_compile_definitions(
 	"${PROJECT_NAME}"
 	PUBLIC
-		BOOST_STL_INTERFACES_DISABLE_CONCEPTS
 		WINVER=0x0601	# windows 7, minimum supported version by skyrim special edition
 		_WIN32_WINNT=0x0601
 		"$<$<BOOL:${SKSE_SUPPORT_XBYAK}>:SKSE_SUPPORT_XBYAK=1>"
@@ -116,7 +114,6 @@ target_link_libraries(
 	"${PROJECT_NAME}"
 	PUBLIC
 		binary_io::binary_io
-		Boost::headers
 		spdlog::spdlog
 		Version.lib
 )

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ This a version of CommonLibVR that is based off of the latest CommonLibSSE after
 ## Build Dependencies
 
 - [binary_io](https://github.com/Ryan-rsm-McKenzie/binary_io)
-- [Boost](https://www.boost.org/)
-  - Stl_interfaces
 - [spdlog](https://github.com/gabime/spdlog)
 - [fmt](https://github.com/fmtlib/fmt)
 - [Visual Studio Community 2022](https://visualstudio.microsoft.com/vs/preview/) (or later)

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -2,5 +2,4 @@ include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 include(CMakeFindDependencyMacro)
 
 find_dependency(binary_io CONFIG)
-find_dependency(Boost MODULE)
 find_dependency(spdlog CONFIG)

--- a/include/RE/B/BSTHashMap.h
+++ b/include/RE/B/BSTHashMap.h
@@ -113,25 +113,14 @@ namespace RE
 		};
 
 		template <class U>
-		class iterator_base :
-			public boost::stl_interfaces::iterator_interface<
-				iterator_base<U>,
-				std::forward_iterator_tag,
-				U>
+		class iterator_base
 		{
-		private:
-			using super =
-				boost::stl_interfaces::iterator_interface<
-					iterator_base<U>,
-					std::forward_iterator_tag,
-					U>;
-
 		public:
-			using difference_type = typename super::difference_type;
-			using value_type = typename super::value_type;
-			using pointer = typename super::pointer;
-			using reference = typename super::reference;
-			using iterator_category = typename super::iterator_category;
+			using difference_type = std::ptrdiff_t;
+			using value_type = std::remove_const_t<U>;
+			using pointer = value_type*;
+			using reference = value_type&;
+			using iterator_category = std::forward_iterator_tag;
 
 			iterator_base() = default;
 			~iterator_base() = default;
@@ -176,7 +165,17 @@ namespace RE
 				return *this;
 			}
 
-			using super::operator++;
+			iterator_base operator++(int) noexcept
+			{
+				iterator_base result = *this;
+				++result;
+				return result;
+			}
+
+			[[nodiscard]] pointer operator->() const noexcept
+			{
+				return &**this;
+			}
 
 		protected:
 			friend class BSTScatterTable;
@@ -740,7 +739,7 @@ namespace RE
 	namespace detail
 	{
 		using _dummy_bsthashmap = BSTHashMap<int, int>;
-		BOOST_STL_INTERFACES_STATIC_ASSERT_CONCEPT(_dummy_bsthashmap::iterator, std::forward_iterator);
+		static_assert(std::forward_iterator<_dummy_bsthashmap::iterator>);
 	}
 
 	template <

--- a/include/SKSE/Impl/PCH.h
+++ b/include/SKSE/Impl/PCH.h
@@ -60,7 +60,6 @@ static_assert(
 
 #pragma warning(push)
 #include <binary_io/file_stream.hpp>
-#include <boost/stl_interfaces/iterator_interface.hpp>
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
 #pragma warning(pop)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "supports": "windows & x64",
   "dependencies": [
-    "boost-stl-interfaces",
     "fmt",
     "rsm-binary-io",
     "spdlog",


### PR DESCRIPTION
Cherry pick @Qudix's commit to po3's fork into VR CLib https://github.com/powerof3/CommonLibSSE/commit/f63f0f2a9f008fc7a42b0a981855c112194a0308

Boost is a massive dependency that is only used in one place in CLib, and it's already removed from NG (both Charmed's fork & the ng branch here) + po3's fork. In particular, it makes it easier to work across multiple CLib forks and submit the same RE changes to all of them.

Verified by building this commit with BUILD_SKYRIMVR ON
```
[build] [339/339] Linking CXX static library _deps\clib-build\CommonLibVR.lib
[driver] Build completed: 00:00:11.807
[build] Build finished with exit code 0
```