### PR TITLE
RE BSSoundHandle::Pause()

### DIFF
--- a/include/RE/B/BSSoundHandle.h
+++ b/include/RE/B/BSSoundHandle.h
@@ -42,7 +42,7 @@ namespace RE
 		bool               SetVolume(float a_volume);
 		bool               Stop();
 		bool               Play();
-		bool			   Pause();
+		bool               Pause();
 
 		// members
 		std::uint32_t                                 soundID;        // 00

--- a/include/RE/B/BSSoundHandle.h
+++ b/include/RE/B/BSSoundHandle.h
@@ -42,6 +42,7 @@ namespace RE
 		bool               SetVolume(float a_volume);
 		bool               Stop();
 		bool               Play();
+		bool			   Pause();
 
 		// members
 		std::uint32_t                                 soundID;        // 00

--- a/include/RE/Offsets.h
+++ b/include/RE/Offsets.h
@@ -318,6 +318,7 @@ namespace RE
 			inline constexpr REL::ID Play(static_cast<std::uint64_t>(67616));
 			inline constexpr REL::ID SetObjectToFollow(static_cast<std::uint64_t>(67636));
 			inline constexpr REL::ID SetPosition(static_cast<std::uint64_t>(67631));
+			inline constexpr REL::ID Pause(static_cast<std::uint64_t>(67618));
 			inline constexpr REL::ID Stop(static_cast<std::uint64_t>(67619));
 		}
 

--- a/include/RE/Offsets.h
+++ b/include/RE/Offsets.h
@@ -1389,6 +1389,7 @@ namespace RE
 			inline constexpr REL::ID Play(static_cast<std::uint64_t>(66355));
 			inline constexpr REL::ID SetObjectToFollow(static_cast<std::uint64_t>(66375));
 			inline constexpr REL::ID SetPosition(static_cast<std::uint64_t>(66370));
+			inline constexpr REL::ID Pause(static_cast<std::uint64_t>(66357));
 			inline constexpr REL::ID Stop(static_cast<std::uint64_t>(66358));
 		}
 

--- a/include/RE/Offsets_VR.h
+++ b/include/RE/Offsets_VR.h
@@ -330,6 +330,7 @@ namespace RE
 			inline constexpr REL::Offset Play(static_cast<std::uint64_t>(0xC283E0));
 			inline constexpr REL::Offset SetObjectToFollow(static_cast<std::uint64_t>(0xC289C0));
 			inline constexpr REL::Offset SetPosition(static_cast<std::uint64_t>(0xC287D0));
+			inline constexpr REL::Offset Pause(static_cast<std::uint64_t>(0xC28470));
 			inline constexpr REL::Offset Stop(static_cast<std::uint64_t>(0xC284B0));
 		}
 

--- a/src/RE/B/BSSoundHandle.cpp
+++ b/src/RE/B/BSSoundHandle.cpp
@@ -81,4 +81,11 @@ namespace RE
 		REL::Relocation<func_t> func{ Offset::BSSoundHandle::Play };
 		return func(this);
 	}
+
+	bool BSSoundHandle::Pause()
+	{
+		using func_t = decltype(&BSSoundHandle::Pause);
+		REL::Relocation<func_t> func{ Offset::BSSoundHandle::Pause };
+		return func(this);
+	}
 }


### PR DESCRIPTION
Same as https://github.com/powerof3/CommonLibSSE/pull/101 but with VR offset added to Offsets_VR. Verified that the offset worked specifically in VR (sound on):

https://github.com/alandtse/CommonLibVR/assets/3292122/9106c08e-e1ae-49f1-9993-3f0c428fe29d

