### PR TITLE
fix: add missing VR device

### DIFF
--- a/include/RE/B/BSInputDeviceManager.h
+++ b/include/RE/B/BSInputDeviceManager.h
@@ -64,6 +64,6 @@ namespace RE
 #ifndef SKYRIMVR
 	static_assert(sizeof(BSInputDeviceManager) == 0xF0);
 #else
-	static_assert(sizeof(BSInputDeviceManager) == 0x108);
+	static_assert(sizeof(BSInputDeviceManager) == 0x120);
 #endif
 }

--- a/include/RE/C/ControlMap.h
+++ b/include/RE/C/ControlMap.h
@@ -50,7 +50,7 @@ namespace RE
 #ifndef SKYRIMVR
 		static_assert(sizeof(InputContext) == 0x60);
 #else
-		static_assert(sizeof(InputContext) == 0xA8);
+		static_assert(sizeof(InputContext) == 0xF0);
 #endif
 
 		struct LinkedMapping

--- a/include/RE/I/InputDevices.h
+++ b/include/RE/I/InputDevices.h
@@ -10,13 +10,15 @@ namespace RE
 			kKeyboard = 0,
 			kMouse,
 			kGamepad,
-			kVirtualKeyboard,
 #ifdef SKYRIMVR
-			kVRRight = 5,
-			kVRLeft = 6,
-			kWMRRight = 7,
-			kWMRLeft = 8,
+			kVivePrimary,
+			kViveSecondary,
+			kOculusPrimary,
+			kOculusSecondary,
+			kWMRPrimary,
+			kWMRSecondary,
 #endif
+			kVirtualKeyboard,
 			kTotal
 		};
 	private:


### PR DESCRIPTION
Function observing 10 devices: `RE::BGSPerk **__fastcall sub_140C51E60(RE::BSInputDeviceManager *a1)`

INPUT_DEVICE matches SKSEVR: https://github.com/SkyrimAlternativeDevelopers/sksevr-mirror/blob/master/skse64/GameInput.h#L19C1-L33C3