### PR TITLE
fix: add missing handler

### DIFF
--- a/include/RE/M/MenuControls.h
+++ b/include/RE/M/MenuControls.h
@@ -69,15 +69,25 @@ namespace RE
 		MenuOpenHandler*            menuOpenHandler;       // 68
 		FavoritesHandler*           favoritesHandler;      // 70
 		ScreenshotHandler*          screenshotHandler;     // 78
-		bool                        isProcessing;          // 80
-		bool                        beastForm;             // 81
-		bool                        remapMode;             // 82
-		std::uint8_t                unk83;                 // 83
-		std::uint32_t               unk84;                 // 84
+#ifdef SKYRIMVR
+		std::uint64_t occlusionCullingToggleHandler;  // 80
+#endif
+		bool          isProcessing;  // 80
+		bool          beastForm;     // 81
+		bool          remapMode;     // 82
+		std::uint8_t  unk83;         // 83
+		std::uint32_t unk84;         // 84
 	private:
 		KEEP_FOR_RE()
 	};
 	static_assert(offsetof(MenuControls, handlers) == 0x18);
-	static_assert(offsetof(MenuControls, remapMode) == 0x82);
+
+#ifndef SKYRIMVR
 	static_assert(sizeof(MenuControls) == 0x88);
+	static_assert(offsetof(MenuControls, remapMode) == 0x82);
+#else
+	static_assert(offsetof(MenuControls, remapMode) == 0x8A);
+	static_assert(sizeof(MenuControls) == 0x90);
+#endif
+
 }

--- a/src/RE/W/WorldSpaceMenu.cpp
+++ b/src/RE/W/WorldSpaceMenu.cpp
@@ -12,7 +12,6 @@ namespace RE
 			if (menuNode.get()->parent) {
 				menuNode.get()->parent->DetachChild2(menuNode.get());
 			}
-			menuNode->DeleteThis();
 			menuNode.reset();
 		}
 


### PR DESCRIPTION
Additionally, added a fix for CTD when deleting a WorldSpaceMenu, such as in QuicklootVR. The menu's `menuNode` is already deleted when the pointer is reset if it has no ref counts, leading to code that calls `DeleteThis` twice:

```c++
// Decompiled C code from QuickLoot DLL
if ( v3 )
    {
      (v3->DetachChild2)(v3);
      this->menuNode._ptr->DeleteThis(this->menuNode._ptr);
      v4 = this->menuNode._ptr;
      if ( v4 )
      {
        if ( _InterlockedExchangeAdd(&v4->_refCount, 0xFFFFFFFF) == 1 )
          v4->DeleteThis(v4);
        this->menuNode._ptr = 0i64;
      }
    }
```

Removed the explicit `DeleteThis` call to fix this.