### PR TITLE
fix: fix`InputContext::GetNumDeviceMappings()`

### DIFF
--- a/include/RE/C/ControlMap.h
+++ b/include/RE/C/ControlMap.h
@@ -53,7 +53,7 @@ namespace RE
 				if SKYRIM_REL_VR_CONSTEXPR (REL::Module::IsVR()) {
 					return INPUT_DEVICES::kTotal;
 				} else {
-					return static_cast<std::size_t>(INPUT_DEVICES::kVirtualKeyboard) + 1;
+					return INPUT_DEVICES::kFlatTotal;
 				}
 #endif
 			}

--- a/include/RE/I/InputDevices.h
+++ b/include/RE/I/InputDevices.h
@@ -8,20 +8,35 @@ namespace RE
 		{
 			kNone = static_cast<std::underlying_type_t<INPUT_DEVICE>>(-1),
 			kKeyboard = 0,
-			kMouse,
-			kGamepad,
+			kMouse = 1,
+			kGamepad = 2,
+			kFlatVirtualKeyboard = 3,
+			kFlatTotal = 4,
 #ifdef ENABLE_SKYRIM_VR
-			kVivePrimary,
-			kViveSecondary,
-			kOculusPrimary,
-			kOculusSecondary,
-			kWMRPrimary,
-			kWMRSecondary,
+			kVivePrimary = 3,
+			kViveSecondary = 4,
+			kOculusPrimary = 5,
+			kOculusSecondary = 6,
+			kWMRPrimary = 7,
+			kWMRSecondary = 8,
+			kVRVirtualKeyboard = 9,
+			kVRTotal = 10,
+			kTotal = 10,
+#else
+			kTotal = 4,
 #endif
-			kVirtualKeyboard,
-			kTotal
 		};
 		static_assert(sizeof(INPUT_DEVICE) == 0x4);
+
+	public:
+		[[nodiscard]] static SKYRIM_REL_VR INPUT_DEVICE VirtualKeyboard()
+		{
+			if SKYRIM_REL_VR_CONSTEXPR (REL::Module::IsVR()) {
+				return static_cast<INPUT_DEVICE>(INPUT_DEVICES::kTotal - 1);
+			} else {
+				return INPUT_DEVICES::kFlatVirtualKeyboard;
+			}
+		}
 	};
 	using INPUT_DEVICE = INPUT_DEVICES::INPUT_DEVICE;
 }

--- a/src/RE/B/BSInputDeviceManager.cpp
+++ b/src/RE/B/BSInputDeviceManager.cpp
@@ -71,7 +71,7 @@ namespace RE
 
 	BSWin32VirtualKeyboardDevice* BSInputDeviceManager::GetVirtualKeyboard()
 	{
-		return static_cast<BSWin32VirtualKeyboardDevice*>(devices[stl::to_underlying(INPUT_DEVICE::kVirtualKeyboard)]);
+		return static_cast<BSWin32VirtualKeyboardDevice*>(devices[stl::to_underlying(INPUT_DEVICES::VirtualKeyboard())]);
 	}
 
 	bool BSInputDeviceManager::IsGamepadConnected()


### PR DESCRIPTION
Previously, `GetNumDeviceMappings` would unconditionally return `INPUT_DEVICE::kTotal = 10` when VR support is enabled, which is incorrect in non-VR versions. 

Now it correctly returns 4 on SE and AE, but still 10 on VR. Also added `INPUT_DEVICES::VirtualKeyboard()` which returns the correct enum value for the virtual keyboard based on runtime version.