### PR TITLE
feat: add VR Bow State RE

### DIFF
--- a/include/RE/P/PlayerCharacter.h
+++ b/include/RE/P/PlayerCharacter.h
@@ -83,6 +83,14 @@ namespace RE
 		kInvalidMarker
 	};
 
+	enum VR_Bow_State : std::uint32_t
+	{
+		kNone,
+		kNoAmmo,
+		kIdle,
+		kArrowKnocked,
+	};
+
 	struct VR_NODE_DATA
 	{
 #define VR_NODE_DATA_CONTENT                                                                                                                                                  \
@@ -145,7 +153,8 @@ namespace RE
 	std::uint32_t              unk5B0;                          /* 5B0 */                                                                                                     \
 	std::uint32_t              unk5B4;                          /* 5B4 */                                                                                                     \
 	std::uint64_t              unk5B8;                          /* 5B8 */                                                                                                     \
-	std::uint64_t              unk5C0;                          /* 5C0 */                                                                                                     \
+	VR_Bow_State               bowState;                        /* 5C0 */                                                                                                     \
+	std::uint32_t              unk5C4;                          /* 5C4 */                                                                                                     \
 	NiPointer<NiNode>          BowAimNode;                      /* 5C8 */                                                                                                     \
 	NiPointer<NiNode>          BowRotationNode;                 /* 5D0 */                                                                                                     \
 	NiPointer<NiNode>          ArrowSnapNode;                   /* 5D8 */                                                                                                     \
@@ -155,9 +164,10 @@ namespace RE
 	NiPointer<NiNode>          ArrowHoldOffsetNode;             /* 5F8 */                                                                                                     \
 	NiPointer<NiNode>          ArrowHoldNode;                   /* 600 */                                                                                                     \
 	std::uint64_t              unk608;                          /* 608 */                                                                                                     \
-	float                      unkFloat610;                     /* 610 */                                                                                                     \
+	float                      currentArrowSnapDistance;        /* 610 */                                                                                                     \
 	std::uint32_t              unk614;                          /* 614 */                                                                                                     \
-	std::uint64_t              unk618;                          /* 618 */                                                                                                     \
+	float                      currentBowDrawAmount;            /* 618 - 0 to 1 */                                                                                            \
+	float                      lastRumbleBowDrawAmount;         /* 61C - 0 to 1 */                                                                                            \
 	std::uint64_t              unk620;                          /* 620 */                                                                                                     \
 	std::uint64_t              unk628;                          /* 628 */                                                                                                     \
 	std::uint64_t              unk630;                          /* 630 */                                                                                                     \


### PR DESCRIPTION
This PR brings VR bow state RE work that Atom provided on the RE Discord and granted permission to integrate into CommonLib. I have personally tested it (specifically the bow state enum and draw distance portion) by using it in my WIP Blade and Blunt port.

An equivalent PR for the VR only branch will be submitted later after I have time to set that up. Hopefully very shortly.