### PR TITLE
feat: add opt in to require minimal VR address lib version

### DIFF
--- a/include/REL/ID.h
+++ b/include/REL/ID.h
@@ -152,6 +152,23 @@ namespace REL
 			return static_cast<std::size_t>(it->offset);
 		}
 
+#ifdef SKYRIMVR
+		bool IsVRAddressLibraryAtLeastVersion(const char* pluginName, const char* minimalVRAddressLibVersion, bool showWindowsMessage = false) const
+		{
+			const auto minimalVersion = REL::Version(minimalVRAddressLibVersion);
+
+			bool validVersion = minimalVersion <= _vrAddressLibraryVersion;
+
+			if (!validVersion && showWindowsMessage) {
+				REX::W32::MessageBoxA(NULL, std::format("You need version: {} of VR Address Library for SKSEVR, you have version: {}", minimalVersion.string(), _vrAddressLibraryVersion.string()).c_str(), pluginName, 0x00000000L | 0x00000030L);
+				REX::W32::TerminateProcess(REX::W32::GetCurrentProcess(), 0);
+				return false;
+			}
+
+			return validVersion;
+		}
+#endif  // SKYRIMVR
+
 	private:
 		friend Offset2ID;
 
@@ -249,6 +266,7 @@ namespace REL
 			auto        mapname = L"CommonLibSSEOffsets-v2-"s;
 			mapname += a_version.wstring();
 			in.read_row(address_count, version);
+			_vrAddressLibraryVersion = Version(version);
 			const auto byteSize = static_cast<std::size_t>(address_count * sizeof(mapping_t));
 			if (!_mmap.open(mapname, byteSize) &&
 				!_mmap.create(mapname, byteSize)) {
@@ -399,6 +417,10 @@ namespace REL
 
 		detail::memory_map   _mmap;
 		std::span<mapping_t> _id2offset;
+
+#ifdef SKYRIMVR
+		Version _vrAddressLibraryVersion;
+#endif  // SKYRIMVR
 	};
 
 	class ID

--- a/include/REL/Version.h
+++ b/include/REL/Version.h
@@ -19,6 +19,32 @@ namespace REL
 			_impl{ a_v1, a_v2, a_v3, a_v4 }
 		{}
 
+		explicit constexpr Version(std::string_view a_version)
+		{
+			std::array<value_type, 4> powers{ 1, 1, 1, 1 };
+			std::size_t               position = 0;
+			for (std::size_t i = 0; i < a_version.size(); ++i) {
+				if (a_version[i] == '.') {
+					if (++position == powers.size()) {
+						throw std::invalid_argument("Too many parts in version number.");
+					}
+				} else {
+					powers[position] *= 10;
+				}
+			}
+			position = 0;
+			for (std::size_t i = 0; i < a_version.size(); ++i) {
+				if (a_version[i] == '.') {
+					++position;
+				} else if (a_version[i] < '0' || a_version[i] > '9') {
+					throw std::invalid_argument("Invalid character in version number.");
+				} else {
+					powers[position] /= 10;
+					_impl[position] += static_cast<value_type>((a_version[i] - '0') * powers[position]);
+				}
+			}
+		}
+
 		[[nodiscard]] constexpr reference       operator[](std::size_t a_idx) noexcept { return _impl[a_idx]; }
 		[[nodiscard]] constexpr const_reference operator[](std::size_t a_idx) const noexcept { return _impl[a_idx]; }
 


### PR DESCRIPTION
Usage:

Add this in `SKSEPlugin_Query`

```cpp
#	ifdef SKYRIMVR
	if (!REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion(Version::PROJECT.data(), "0.134.0", true))
	{
		return false;
	}
#	endif
```

`showWindowsMessage` is default false, but if set to true like example above this will pop up when game is started: (Will also stop SkyrimVR process)

![image](https://github.com/alandtse/CommonLibVR/assets/964655/81b5359e-7fc5-4d32-adfe-031911fd3687)

Tested this by manually editing first data row of `version-1-4-15-0.csv` to 0.132.0, I added VR support on this specific mod in "0.134.0"