### PR TITLE
fix: move REL::Module::reset outside of testing definition

### DIFF
--- a/include/REL/Module.h
+++ b/include/REL/Module.h
@@ -191,13 +191,13 @@ namespace REL
 
 			return true;
 		}
+#endif
 
 		static void reset()
 		{
 			_initialized = false;
 			_instance.clear();
 		}
-#endif
 
 		[[nodiscard]] std::uintptr_t base() const noexcept { return _base; }
 


### PR DESCRIPTION
Needed for https://github.com/ersh1/OpenAnimationReplacer/pull/12