### PR TITLE
fix: fix some defines and runtime fixes

### DIFF
--- a/include/RE/A/ActivateHandler.h
+++ b/include/RE/A/ActivateHandler.h
@@ -26,9 +26,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(ActivateHandler) == 0x20);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(ActivateHandler) == 0x38);
 #else
 	static_assert(sizeof(ActivateHandler) == 0x20);

--- a/include/RE/A/Actor.h
+++ b/include/RE/A/Actor.h
@@ -790,6 +790,8 @@ namespace RE
 	};
 #ifndef ENABLE_SKYRIM_AE
 	static_assert(sizeof(Actor) == 0x2B0);
+#else
+	static_assert(sizeof(Actor) == 0x78);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/A/ActorEquipManager.h
+++ b/include/RE/A/ActorEquipManager.h
@@ -26,7 +26,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(ActorEquipManager) == 0x2);
 #endif
 }

--- a/include/RE/A/Archive.h
+++ b/include/RE/A/Archive.h
@@ -34,7 +34,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(Archive) == 0x230);
 #endif
 }

--- a/include/RE/A/AttackBlockHandler.h
+++ b/include/RE/A/AttackBlockHandler.h
@@ -44,9 +44,8 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(AttackBlockHandler) == 0x48);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_AE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
+	static_assert(sizeof(AttackBlockHandler) == 0x60);
 #else
 	static_assert(sizeof(AttackBlockHandler) == 0x48);
 #endif

--- a/include/RE/A/AutoMoveHandler.h
+++ b/include/RE/A/AutoMoveHandler.h
@@ -17,9 +17,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(AutoMoveHandler) == 0x10);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(AutoMoveHandler) == 0x28);
 #else
 	static_assert(sizeof(AutoMoveHandler) == 0x10);

--- a/include/RE/B/BGSDecalNode.h
+++ b/include/RE/B/BGSDecalNode.h
@@ -54,9 +54,9 @@ namespace RE
 		RUNTIME_DATA_CONTENT  // 128, 150
 #endif
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BGSDecalNode) == 0x148);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BGSDecalNode) == 0x170);
 #endif
 }

--- a/include/RE/B/BGSDefaultObjectManager.h
+++ b/include/RE/B/BGSDefaultObjectManager.h
@@ -193,7 +193,7 @@ namespace RE
 			kKeywordFurnitureForces1stPerson = 180,
 			kKeywordFurnitureForces3rdPerson = 181,
 			kKeywordActivatorFurnitureNoPlayer = 182,
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 			kTelekinesisGrabSound = 183,
 			kTelekinesisThrowSound = 184,
 			kWorldMapWeather = 185,
@@ -383,7 +383,7 @@ namespace RE
 			kModsHelpFormList = 363,
 			kTotal = 364
 #	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 			kisJarlChair = 184,
 			kFurnitureAnimatesFast = 185,
 			isCartTravelPlayer = 186,
@@ -1086,8 +1086,16 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BGSDefaultObjectManager) == 0xD20);
+#elif defined(EXCLUSIVE_SKYRIM_FLAT)
+#	if defined(EXCLUSIVE_SKYRIM_AE)
+	static_assert(sizeof(BGSDefaultObjectManager) == 0xD08);
+#	elif defined(EXCLUSIVE_SKYRIM_SE)
+	static_assert(sizeof(BGSDefaultObjectManager) == 0xCF0);
+#	else
+	static_assert(sizeof(BGSDefaultObjectManager) == 0xCF0);
+#	endif
 #else
 	static_assert(sizeof(BGSDefaultObjectManager) == 0xCF0);
 #endif

--- a/include/RE/B/BGSSaveLoadGame.h
+++ b/include/RE/B/BGSSaveLoadGame.h
@@ -153,19 +153,19 @@ namespace RE
 		}
 
 // members
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		RUNTIME_DATA_CONTENT;
 		RUNTIME_DATA2_CONTENT;
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		VR_RUNTIME_DATA_CONTENT;
 		RUNTIME_DATA2_CONTENT;
 #endif
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BGSSaveLoadGame) == 0x348);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BGSSaveLoadGame) == 0x518);
 #else
 	static_assert(sizeof(BGSSaveLoadGame) == 0x1);

--- a/include/RE/B/BGSSaveLoadManager.h
+++ b/include/RE/B/BGSSaveLoadManager.h
@@ -229,7 +229,7 @@ namespace RE
 		std::uint32_t unk2A0;                                                               // 2A0
 		std::uint32_t unk2A4;                                                               // 2A4
 		std::uint64_t unk2A8;                                                               // 2A8
-#if defined(ENABLE_SKYRIM_AE) && !(defined(ENABLE_SKYRIM_SE) || defined(ENABLE_SKYRIM_VR))  // AE 1130 specific change
+#if defined(EXCLUSIVE_SKYRIM_AE)  // AE 1130 specific change
 		std::uint16_t   unk2B0;                                                             // 2B0
 		std::uint16_t   unk2B2;                                                             // 2B2
 		std::uint64_t   unk2B8;                                                             // 2B8
@@ -247,14 +247,13 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(BGSSaveLoadManager) == 0x3D8);
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+#	if defined(EXCLUSIVE_SKYRIM_AE)
+	static_assert(sizeof(BGSSaveLoadManager) == 0x420);
 #	else
-	static_assert(sizeof(BGSSaveLoadManager) == 0x418);
-	char (*__kaboom)[sizeof(BGSSaveLoadManager)] = 1;
+	static_assert(sizeof(BGSSaveLoadManager) == 0x3D8);
 #	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BGSSaveLoadManager) == 0x3D8);
 #else
 	static_assert(sizeof(BGSSaveLoadManager) == 0x2B0);

--- a/include/RE/B/BGSStoryTeller.h
+++ b/include/RE/B/BGSStoryTeller.h
@@ -46,7 +46,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BGSStoryTeller) == 0xD8);
 #else
 	//static_assert(sizeof(BGSStoryTeller) == 0xE0);

--- a/include/RE/B/BSDismemberSkinInstance.h
+++ b/include/RE/B/BSDismemberSkinInstance.h
@@ -69,9 +69,9 @@ namespace RE
 		RUNTIME_DATA_CONTENT  // 88, 68
 #endif
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BSDismemberSkinInstance) == 0xA0);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BSDismemberSkinInstance) == 0x80);
 #endif
 }

--- a/include/RE/B/BSDynamicTriShape.h
+++ b/include/RE/B/BSDynamicTriShape.h
@@ -52,9 +52,9 @@ namespace RE
 		RUNTIME_DATA_CONTENT;  // 160, 1A8
 #endif
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BSDynamicTriShape) == 0x180);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BSDynamicTriShape) == 0x1C8);
 #endif
 }

--- a/include/RE/B/BSFaceGenNiNode.h
+++ b/include/RE/B/BSFaceGenNiNode.h
@@ -60,9 +60,9 @@ namespace RE
 		RUNTIME_DATA_CONTENT  // 128, 150
 #endif
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BSFaceGenNiNode) == 0x168);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BSFaceGenNiNode) == 0x190);
 #endif
 }

--- a/include/RE/B/BSFadeNode.h
+++ b/include/RE/B/BSFadeNode.h
@@ -73,9 +73,9 @@ namespace RE
 		RUNTIME_DATA_CONTENT  // 128, 150
 #endif
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BSFadeNode) == 0x158);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BSFadeNode) == 0x180);
 #endif
 }

--- a/include/RE/B/BSGeometry.h
+++ b/include/RE/B/BSGeometry.h
@@ -50,7 +50,7 @@ namespace RE
 
 		struct MODEL_DATA
 		{
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 #	define MODEL_DATA_CONTENT        \
 		NiBound  modelBound; /* 0 */  \
 		NiPoint3 unk148;     /* 10 */ \
@@ -60,9 +60,9 @@ namespace RE
 #endif
 			MODEL_DATA_CONTENT
 		};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		static_assert(sizeof(MODEL_DATA) == 0x10);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		static_assert(sizeof(MODEL_DATA) == 0x28);
 #endif
 
@@ -159,7 +159,7 @@ namespace RE
 		std::uint8_t                         pad31;  // 151
 		std::uint16_t                        pad32;  // 152
 		std::uint32_t                        pad34;  // 154
-#	elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#	elif defined(EXCLUSIVE_SKYRIM_VR)
 		stl::enumeration<Type, std::uint32_t> type;   // 190
 		std::uint8_t                          pad31;  // 194
 		std::uint16_t                         pad32;  // 195
@@ -167,9 +167,9 @@ namespace RE
 #	endif
 #endif
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BSGeometry) == 0x158);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BSGeometry) == 0x1A0);
 #endif
 }

--- a/include/RE/B/BSInputDeviceManager.h
+++ b/include/RE/B/BSInputDeviceManager.h
@@ -83,7 +83,7 @@ namespace RE
 		std::uint32_t   pad5C;       // 5C
 		BSIInputDevice* devices[4];  // 60
 #ifndef SKYRIM_CROSS_VR
-#	if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#	if defined(EXCLUSIVE_SKYRIM_VR)
 		BSTrackedControllerDevice* unkDevice;     // 80
 		BSTrackedControllerDevice* vrDevices[2];  // 88
 		RUNTIME_DATA_CONTENT                      // 98
@@ -92,9 +92,9 @@ namespace RE
 #	endif
 #endif
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BSInputDeviceManager) == 0xF0);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BSInputDeviceManager) == 0x108);
 #else
 	static_assert(sizeof(BSInputDeviceManager) == 0x80);

--- a/include/RE/B/BSInputEventQueue.h
+++ b/include/RE/B/BSInputEventQueue.h
@@ -145,9 +145,9 @@ namespace RE
 			}
 		}
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(BSInputEventQueue) == 0x20);
-#elif !defined(ENABLE_SKYRIM_SE) && !defined(ENABLE_SKYRIM_AE)
+#if defined(EXCLUSIVE_SKYRIM_SE)
+	static_assert(sizeof(BSInputEventQueue) == 0x390);
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BSInputEventQueue) == 0x580);
 #else
 	static_assert(sizeof(BSInputEventQueue) == 0x20);

--- a/include/RE/B/BSInstanceTriShape.h
+++ b/include/RE/B/BSInstanceTriShape.h
@@ -24,9 +24,9 @@ namespace RE
 		SKYRIM_REL_VR_VIRTUAL std::uint32_t AddGroup(std::uint32_t a_numInstances, std::uint16_t& a_instanceData, std::uint32_t a_arg3, float a_arg4);  // 3C
 		SKYRIM_REL_VR_VIRTUAL void          RemoveGroup(std::uint32_t a_numInstance);                                                                   // 3D
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BSInstanceTriShape) == 0x160);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BSInstanceTriShape) == 0x1A8);
 #endif
 }

--- a/include/RE/B/BSMultiBoundNode.h
+++ b/include/RE/B/BSMultiBoundNode.h
@@ -38,7 +38,7 @@ namespace RE
 		bool              RegisterStreamables(NiStream& a_stream) override;   // 1A
 		void              SaveBinary(NiStream& a_stream) override;            // 1B
 		bool              IsEqual(NiObject* a_object) override;               // 1C
-#if !defined(ENABLE_SKYRIM_VR) || (!defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_VR))
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		// The following are virtual functions past the point where VR compatibility breaks.
 		void UpdateDownwardPass(NiUpdateData& a_data, std::uint32_t a_arg2) override;  // 2C
 		void UpdateWorldBound() override;                                              // 2F
@@ -67,9 +67,9 @@ namespace RE
 		RUNTIME_DATA_CONTENT  // 128, 150
 #endif
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BSMultiBoundNode) == 0x138);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BSMultiBoundNode) == 0x160);
 #endif
 }

--- a/include/RE/B/BSMultiIndexTriShape.h
+++ b/include/RE/B/BSMultiIndexTriShape.h
@@ -47,7 +47,7 @@ namespace RE
 		// override (BSGeometry)
 		const NiRTTI* GetRTTI() const override;                           // 02
 		NiObject*     CreateClone(NiCloningProcess& a_cloning) override;  // 17
-#if !defined(ENABLE_SKYRIM_VR) || (!defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_VR))
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		// Compatibility between VR and non-VR breaks beyond this point.
 		BSMultiIndexTriShape* AsMultiIndexTriShape() override;  // 35 - { return this; }
 #endif
@@ -67,9 +67,9 @@ namespace RE
 		RUNTIME_DATA_CONTENT  // 160, 1A8
 #endif
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BSMultiIndexTriShape) == 0x1D8);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BSMultiIndexTriShape) == 0x220);
 #endif
 }

--- a/include/RE/B/BSMultiStreamInstanceTriShape.h
+++ b/include/RE/B/BSMultiStreamInstanceTriShape.h
@@ -31,7 +31,7 @@ namespace RE
 		// override (BSInstanceTriShape)
 		const NiRTTI* GetRTTI() const override;                           // 02
 		NiObject*     CreateClone(NiCloningProcess& a_cloning) override;  // 17
-#if !defined(ENABLE_SKYRIM_VR) || (!defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_VR))
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		// The following are virtual functions past the point where VR compatibility breaks.
 		void OnVisible(NiCullingProcess& a_process) override;  // 34
 
@@ -60,9 +60,9 @@ namespace RE
 		RUNTIME_DATA_CONTENT  // 160, 1A8
 #endif
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BSMultiStreamInstanceTriShape) == 0x1A0);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BSMultiStreamInstanceTriShape) == 0x1E8);
 #endif
 }

--- a/include/RE/B/BSNiNode.h
+++ b/include/RE/B/BSNiNode.h
@@ -18,9 +18,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BSNiNode) == 0x128);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BSNiNode) == 0x150);
 #endif
 }

--- a/include/RE/B/BSOpenVR.h
+++ b/include/RE/B/BSOpenVR.h
@@ -11,7 +11,7 @@ namespace RE
 	class BSOpenVR : public BSVRInterface
 	{
 	public:
-#	if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#	if defined(EXCLUSIVE_SKYRIM_VR)
 		inline static constexpr auto RTTI = RTTI_BSOpenVR;
 #	endif
 

--- a/include/RE/B/BSOpenVRControllerDevice.h
+++ b/include/RE/B/BSOpenVRControllerDevice.h
@@ -9,7 +9,7 @@ namespace RE
 	class BSOpenVRControllerDevice : public BSTrackedControllerDevice
 	{
 	public:
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 		inline static constexpr auto RTTI = RTTI_BSOpenVRControllerDevice;
 #endif
 
@@ -40,7 +40,7 @@ namespace RE
 		void               Reset() override;                                                           // 08
 
 	private:
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 		std::uint64_t unk80[0x16];  // 080
 		std::uint32_t unk130;       // 130
 		std::uint32_t unk134;       // 134
@@ -52,7 +52,7 @@ namespace RE
 		std::uint32_t unk14C;       // 14C
 #endif
 	};
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BSOpenVRControllerDevice) == 0x150);
 #endif
 }

--- a/include/RE/B/BSOrderedNode.h
+++ b/include/RE/B/BSOrderedNode.h
@@ -31,7 +31,7 @@ namespace RE
 		bool          RegisterStreamables(NiStream& a_stream) override;   // 1A
 		void          SaveBinary(NiStream& a_stream) override;            // 1B
 		bool          IsEqual(NiObject* a_object) override;               // 1C
-#if !defined(ENABLE_SKYRIM_VR) || (!defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_VR))
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		// The following are virtual functions past the point where VR compatibility breaks.
 		void UpdateDownwardPass(NiUpdateData& a_data, std::uint32_t a_arg2) override;          // 2C
 		void UpdateSelectedDownwardPass(NiUpdateData& a_data, std::uint32_t a_arg2) override;  // 2D
@@ -53,9 +53,9 @@ namespace RE
 		RUNTIME_DATA_CONTENT  // 128, 150
 #endif
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BSOrderedNode) == 0x140);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BSOrderedNode) == 0x168);
 #endif
 }

--- a/include/RE/B/BSPCGamepadDeviceHandler.h
+++ b/include/RE/B/BSPCGamepadDeviceHandler.h
@@ -50,9 +50,7 @@ namespace RE
 		friend class BSInputDeviceFactory;
 		BSPCGamepadDeviceHandler();
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(BSPCGamepadDeviceHandler) == 0x10);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#ifndef SKYRIM_CROSS_VR
 	static_assert(sizeof(BSPCGamepadDeviceHandler) == 0x10);
 #else
 	static_assert(sizeof(BSPCGamepadDeviceHandler) == 0x8);

--- a/include/RE/B/BSTrackedControllerDevice.h
+++ b/include/RE/B/BSTrackedControllerDevice.h
@@ -17,7 +17,7 @@ namespace RE
 	class BSTrackedControllerDevice : public BSInputDevice
 	{
 	public:
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 		inline static constexpr auto RTTI = RTTI_BSTrackedControllerDevice;
 #endif
 

--- a/include/RE/B/BSTriShape.h
+++ b/include/RE/B/BSTriShape.h
@@ -48,9 +48,9 @@ namespace RE
 		RUNTIME_DATA_CONTENT  // 158, 1A0
 #endif
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BSTriShape) == 0x160);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BSTriShape) == 0x1A8);
 #endif
 }

--- a/include/RE/B/BarterMenu.h
+++ b/include/RE/B/BarterMenu.h
@@ -68,12 +68,12 @@ namespace RE
 		RUNTIME_DATA_CONTENT  // 30, 40
 #endif
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(BarterMenu) == 0xB8);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+	static_assert(sizeof(BarterMenu) == 0xA8);
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BarterMenu) == 0xB8);
 #else
-	static_assert(sizeof(BarterMenu) == 0x40);
+	static_assert(sizeof(BarterMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/B/BleedoutCameraState.h
+++ b/include/RE/B/BleedoutCameraState.h
@@ -37,9 +37,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BleedoutCameraState) == 0x138);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BleedoutCameraState) == 0x150);
 #else
 	static_assert(sizeof(BleedoutCameraState) == 0x138);

--- a/include/RE/B/BookMenu.h
+++ b/include/RE/B/BookMenu.h
@@ -110,14 +110,12 @@ namespace RE
 		RUNTIME_DATA_CONTENT  // 50, 60
 #endif
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	if defined(ENABLE_SKYRIM_AE)
-	static_assert(sizeof(BookMenu) == 0xA8);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(BookMenu) == 0x98);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BookMenu) == 0xA8);
+#else
+	static_assert(sizeof(BookMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/B/ButtonEvent.h
+++ b/include/RE/B/ButtonEvent.h
@@ -9,7 +9,7 @@
 namespace RE
 {
 	class ButtonEvent :
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 		public VRWandEvent
 #else
 		public IDEvent
@@ -86,9 +86,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(ButtonEvent) == 0x30);
-#elif !defined(ENABLE_SKYRIM_SE) && !defined(ENABLE_SKYRIM_AE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(ButtonEvent) == 0x38);
 #else
 	static_assert(sizeof(ButtonEvent) == 0x28);

--- a/include/RE/C/CalibrationOptionMenu.h
+++ b/include/RE/C/CalibrationOptionMenu.h
@@ -25,6 +25,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
+#if defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(CalibrationOptionMenu) == 0x58);
-
+#else
+	static_assert(sizeof(CalibrationOptionMenu) == 0x48);
+#endif
 }

--- a/include/RE/C/Character.h
+++ b/include/RE/C/Character.h
@@ -60,5 +60,7 @@ namespace RE
 	};
 #ifndef ENABLE_SKYRIM_AE
 	static_assert(sizeof(Character) == 0x2B0);
+#else
+	static_assert(sizeof(Character) == 0x78);
 #endif
 }

--- a/include/RE/C/CombatController.h
+++ b/include/RE/C/CombatController.h
@@ -99,7 +99,7 @@ namespace RE
 		AITimer                        unk44;                 // 44
 		float                          lowMovementDelta;      // 4C
 		BSTArray<CombatAimController*> aimControllers;        // 50
-#if defined(ENABLE_SKYRIM_AE) && !(defined(ENABLE_SKYRIM_SE) || defined(ENABLE_SKYRIM_VR))
+#if defined(EXCLUSIVE_SKYRIM_AE)
 		AE_RUNTIME_DATA_CONTENT;
 #endif
 		RUNTIME_DATA_CONTENT;
@@ -107,7 +107,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if defined(ENABLE_SKYRIM_AE) && !(defined(ENABLE_SKYRIM_SE) || defined(ENABLE_SKYRIM_VR))
+#if defined(EXCLUSIVE_SKYRIM_AE)
 	static_assert(sizeof(CombatController) == 0xE0);
 #else
 	static_assert(sizeof(CombatController) == 0xD8);

--- a/include/RE/C/ConsoleNativeUIMenu.h
+++ b/include/RE/C/ConsoleNativeUIMenu.h
@@ -47,14 +47,13 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
+
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+	static_assert(sizeof(ConsoleNativeUIMenu) == 0x38);
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(ConsoleNativeUIMenu) == 0x48);
 #else
-	static_assert(sizeof(ConsoleNativeUIMenu) == 0x38);
-#endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
-	static_assert(sizeof(ConsoleNativeUIMenu) == 0x48);
+	static_assert(sizeof(ConsoleNativeUIMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/C/ContainerMenu.h
+++ b/include/RE/C/ContainerMenu.h
@@ -84,12 +84,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(ContainerMenu) == 0xD0);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+	static_assert(sizeof(ContainerMenu) == 0xC0);
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(ContainerMenu) == 0xD0);
 #else
-	static_assert(sizeof(ContainerMenu) == 0x40);
+	static_assert(sizeof(ContainerMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/C/ControlMap.h
+++ b/include/RE/C/ControlMap.h
@@ -123,16 +123,16 @@ namespace RE
 		//members
 
 		// members
-		InputContext* controlMap[InputContextID::kTotal];        // 060
-#if !defined(ENABLE_SKYRIM_VR)                                   //flat
-#	if !defined(ENABLE_SKYRIM_AE) && defined(ENABLE_SKYRIM_SE)  // SSE
-		RUNTIME_DATA_CONTENT;                                    // 0E8
-#	else                                                        // AE
+		InputContext* controlMap[InputContextID::kTotal];  // 060
+#if defined(EXCLUSIVE_SKYRIM_FLAT)                         // FLAT
+#	if defined(EXCLUSIVE_SKYRIM_SE)                       // SSE
+		RUNTIME_DATA_CONTENT;                              // 0E8
+#	else                                                  // AE
 		RUNTIME_DATA_CONTENT;  // 0F8
 #	endif
-#elif !defined(ENABLE_SKYRIM_AE) && defined(ENABLE_SKYRIM_SE)  // VR
+#elif defined(EXCLUSIVE_SKYRIM_VR)  // VR
 		RUNTIME_DATA_CONTENT;  // 108
-#else                                                          // ALL
+#else                               // ALL
 		// controlMap can be accessed up to kTotal, kAETotal, or kVRTotal based on runtime
 #endif
 
@@ -156,14 +156,16 @@ namespace RE
 			return REL::RelocateMember<RUNTIME_DATA>(this, 0xE8, 0x108);
 		}
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	if !defined(ENABLE_SKYRIM_AE)
-	static_assert(sizeof(ControlMap) == 0x130);
-#	elif !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+#	if defined(EXCLUSIVE_SKYRIM_SE)
 	static_assert(sizeof(ControlMap) == 0x128);
+#	else
+	static_assert(sizeof(ControlMap) == 0x130);
 #	endif
-#elif !defined(ENABLE_SKYRIM_SE) && !defined(ENABLE_SKYRIM_AE)
-	//static_assert(sizeof(ControlMap) == 0x148);  // VS seems to choke even though this should be right
+#elif defined(EXCLUSIVE_SKYRIM_VR)
+	static_assert(sizeof(ControlMap) == 0x128);
+#else
+	static_assert(sizeof(ControlMap) == 0xE8);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/C/CraftingMenu.h
+++ b/include/RE/C/CraftingMenu.h
@@ -56,15 +56,11 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(CraftingMenu) == 0x48);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(CraftingMenu) == 0x38);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(CraftingMenu) == 0x58);
 #else
-	static_assert(sizeof(CraftingMenu) == 0x50);
+	static_assert(sizeof(CraftingMenu) == 0x40);
 #endif
 }

--- a/include/RE/C/CreationClubMenu.h
+++ b/include/RE/C/CreationClubMenu.h
@@ -101,14 +101,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE();
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(CreationClubMenu) == 0x98);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(CreationClubMenu) == 0x88);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(CreationClubMenu) == 0x98);
+#else
+	static_assert(sizeof(CreationClubMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/C/CreditsMenu.h
+++ b/include/RE/C/CreditsMenu.h
@@ -43,13 +43,11 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(CreditsMenu) == 0x50);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(CreditsMenu) == 0x40);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
-static_assert(sizeof(CreditsMenu) == 0x50);
+#elif defined(EXCLUSIVE_SKYRIM_VR)
+	static_assert(sizeof(CreditsMenu) == 0x50);
+#else
+	static_assert(sizeof(CreditsMenu) == 0x30);
 #endif
 }

--- a/include/RE/C/CrosshairPickData.h
+++ b/include/RE/C/CrosshairPickData.h
@@ -32,7 +32,7 @@ namespace RE
 		}
 
 		// members
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		std::uint32_t                    pad00;           // 00
 		ObjectRefHandle                  target;          // 04
 		ObjectRefHandle                  targetActor;     // 08
@@ -65,7 +65,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(CrosshairPickData) == 0x38);
 #else
 	static_assert(sizeof(CrosshairPickData) == 0x88);

--- a/include/RE/C/CursorMenu.h
+++ b/include/RE/C/CursorMenu.h
@@ -45,13 +45,11 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(CursorMenu) == 0x50);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(CursorMenu) == 0x40);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
-static_assert(sizeof(CursorMenu) == 0x50);
+#elif defined(EXCLUSIVE_SKYRIM_VR)
+	static_assert(sizeof(CursorMenu) == 0x50);
+#else
+	static_assert(sizeof(CursorMenu) == 0x30);
 #endif
 }

--- a/include/RE/D/DialogueMenu.h
+++ b/include/RE/D/DialogueMenu.h
@@ -13,10 +13,10 @@ namespace RE
 	// flags = kUpdateUsesCursor | kDontHideCursorWhenTopmost
 	// context = kMenuMode
 	class DialogueMenu :
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		public WorldSpaceMenu,                   // 00
 		public BSTEventSink<MenuOpenCloseEvent>  // 88
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		public IMenu,                            // 00
 		public BSTEventSink<MenuOpenCloseEvent>  // 30
 #else
@@ -89,14 +89,16 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(DialogueMenu) == 0x78);
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+#	if defined(ENABLE_SKYRIM_AE) || defined(ENABLE_SKYRIM_SE)
+	static_assert(sizeof(DialogueMenu) == 0x68);
 #	else
 	static_assert(sizeof(DialogueMenu) == 0x50);
 #	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(DialogueMenu) == 0x60);
+#else
+	static_assert(sizeof(DialogueMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/F/FaderMenu.h
+++ b/include/RE/F/FaderMenu.h
@@ -38,14 +38,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(FaderMenu) == 0x50);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(FaderMenu) == 0x40);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
-static_assert(sizeof(FaderMenu) == 0x50);
+#elif defined(EXCLUSIVE_SKYRIM_VR)
+	static_assert(sizeof(FaderMenu) == 0x50);
+#else
+	static_assert(sizeof(FaderMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/F/FastTravelConfirmCallback.h
+++ b/include/RE/F/FastTravelConfirmCallback.h
@@ -30,8 +30,7 @@ namespace RE
 		MapMenu*     mapMenu;     // 10
 		std::int32_t cursorPosX;  // 18
 		std::int32_t cursorPosY;  // 1C
-#if !defined(ENABLE_SKYRIM_VR)
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 		RUNTIME_DATA_CONTENT;
 #endif
 		[[nodiscard]] inline RUNTIME_DATA& GetRuntimeData() noexcept
@@ -47,12 +46,10 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-static_assert(sizeof(FastTravelConfirmCallback) == 0x20);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
-static_assert(sizeof(FastTravelConfirmCallback) == 0x30);
+#if defined(EXCLUSIVE_SKYRIM_VR)
+	static_assert(sizeof(FastTravelConfirmCallback) == 0x30);
 #else
-static_assert(sizeof(FastTravelConfirmCallback) == 0x20);
+	static_assert(sizeof(FastTravelConfirmCallback) == 0x20);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/F/FavoritesMenu.h
+++ b/include/RE/F/FavoritesMenu.h
@@ -86,14 +86,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(FavoritesMenu) == 0x88);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(FavoritesMenu) == 0x78);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
-static_assert(sizeof(FavoritesMenu) == 0x88);
+#elif defined(EXCLUSIVE_SKYRIM_VR)
+	static_assert(sizeof(FavoritesMenu) == 0x88);
+#else
+	static_assert(sizeof(FavoritesMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/F/FirstPersonState.h
+++ b/include/RE/F/FirstPersonState.h
@@ -53,9 +53,8 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(FirstPersonState) == 0x90);
-#elif !defined(SKYRIM_AE) && !defined(SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
+	static_assert(sizeof(FirstPersonState) == 0xA8);
 #else
 	static_assert(sizeof(FirstPersonState) == 0x90);
 #endif

--- a/include/RE/F/FreeCameraState.h
+++ b/include/RE/F/FreeCameraState.h
@@ -40,8 +40,8 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+#	if defined(ENABLE_SKYRIM_AE) || defined(ENABLE_SKYRIM_SE)
 	static_assert(sizeof(FreeCameraState) == 0x50);
 #	else
 	static_assert(sizeof(FreeCameraState) == 0x48);

--- a/include/RE/G/GiftMenu.h
+++ b/include/RE/G/GiftMenu.h
@@ -61,12 +61,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(GiftMenu) == 0x90);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+	static_assert(sizeof(GiftMenu) == 0x80);
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(GiftMenu) == 0x90);
 #else
-	static_assert(sizeof(GiftMenu) == 0x40);
+	static_assert(sizeof(GiftMenu) == 0x30);
 #endif
 
 };

--- a/include/RE/H/HUDMenu.h
+++ b/include/RE/H/HUDMenu.h
@@ -19,7 +19,7 @@ namespace RE
 	// flags = kAlwaysOpen | kRequiresUpdate | kAllowSaving | kCustomRendering | kAssignCursorToRenderer
 	// context = kNone
 	class HUDMenu :
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 		public WorldSpaceMenu,                       // 00
 		public BSTEventSink<UserEventEnabledEvent>,  // 58
 		public BSTEventSink<BSRemoteGamepadEvent>    // 60
@@ -125,7 +125,7 @@ namespace RE
 
 		// members
 #ifndef SKYRIM_CROSS_VR
-#	if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#	if defined(EXCLUSIVE_SKYRIM_VR)
 		std::uint64_t pad68;  // 68
 #	endif
 		RUNTIME_DATA_CONTENT;  // 40, 70
@@ -134,13 +134,11 @@ namespace RE
 		KEEP_FOR_RE()
 	};
 #ifndef ENABLE_SKYRIM_VR
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(HUDMenu) == 0xA8);
-#	else
 	static_assert(sizeof(HUDMenu) == 0x98);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(HUDMenu) == 0xC8);
+#else
+	static_assert(sizeof(HUDMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/H/HeldStateHandler.h
+++ b/include/RE/H/HeldStateHandler.h
@@ -24,9 +24,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(HeldStateHandler) == 0x18);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(HeldStateHandler) == 0x30);
 #else
 	static_assert(sizeof(HeldStateHandler) == 0x18);

--- a/include/RE/H/HorseCameraState.h
+++ b/include/RE/H/HorseCameraState.h
@@ -34,9 +34,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(HorseCameraState) == 0xF8);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(HorseCameraState) == 0x110);
 #else
 	static_assert(sizeof(HorseCameraState) == 0xF8);

--- a/include/RE/I/IMenu.h
+++ b/include/RE/I/IMenu.h
@@ -116,6 +116,20 @@ namespace RE
 		[[nodiscard]] constexpr bool UsesMenuContext() const noexcept { return menuFlags.all(Flag::kUsesMenuContext); }
 		[[nodiscard]] constexpr bool UsesMovementToDirection() const noexcept { return menuFlags.all(Flag::kUsesMovementToDirection); }
 
+		struct VR_RUNTIME_DATA
+		{
+#define VR_RUNTIME_DATA_CONTENT                                                   \
+	stl::enumeration<UI_MENU_Unk09, std::uint32_t> unk30{ UI_MENU_Unk09::kNone }; \
+	std::byte                                      unk34{ 1 };                    \
+	BSFixedString                                  menuName{ "N/A" };  // 38
+            VR_RUNTIME_DATA_CONTENT
+		};
+
+		[[nodiscard]] inline VR_RUNTIME_DATA& GetVRRuntimeData() noexcept
+		{
+			return REL::RelocateMember<VR_RUNTIME_DATA>(this, 0x0, 0x0);
+		}
+
 		// members
 		GPtr<GFxMovieView>                             uiMovie{ nullptr };              // 10
 		std::int8_t                                    depthPriority{ 3 };              // 18
@@ -125,17 +139,16 @@ namespace RE
 		stl::enumeration<Context, std::uint32_t>       inputContext{ Context::kNone };  // 20
 		std::uint32_t                                  pad24{ 0 };                      // 24
 		GPtr<FxDelegate>                               fxDelegate{ nullptr };           // 28
-		stl::enumeration<UI_MENU_Unk09, std::uint32_t> unk30{ UI_MENU_Unk09::kNone };
-		std::byte                                      unk34{ 1 };
-		BSFixedString                                  menuName{ "N/A" };  // 38
+#if defined(EXCLUSIVE_SKYRIM_VR)
+		VR_RUNTIME_DATA_CONTENT
+#endif
 	private:
 		KEEP_FOR_RE();
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(IMenu) == 0x40);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(IMenu) == 0x40);
 #else
-	static_assert(sizeof(IMenu) == 0x40);
+	static_assert(sizeof(IMenu) == 0x30);
 #endif
 }
+#undef VR_RUNTIME_DATA_CONTENT

--- a/include/RE/I/IVirtualMachine.h
+++ b/include/RE/I/IVirtualMachine.h
@@ -92,11 +92,11 @@ namespace RE
 			virtual bool BindNativeMethod(IFunction* a_fn) = 0;                                                                                                     // 18
 			virtual void SetCallableFromTasklets1(const char* a_className, const char* a_stateName, const char* a_fnName, bool a_callable) = 0;                     // 19
 			virtual void SetCallableFromTasklets2(const char* a_className, const char* a_fnName, bool a_callable) = 0;                                              // 1A
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 			virtual void New_1B(void) = 0;
 #endif
 			SKYRIM_REL_VR_VIRTUAL void ForEachBoundObject(VMHandle a_handle, IForEachScriptObjectFunctor* a_functor);  // 1B, 1C
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 			virtual void New_1D(void) = 0;
 #endif
 			SKYRIM_REL_VR_VIRTUAL bool                       FindBoundObject(VMHandle a_handle, const char* a_className, BSTSmartPointer<Object>& a_result) const;                                                                                   // 1C

--- a/include/RE/I/ImageSpaceManager.h
+++ b/include/RE/I/ImageSpaceManager.h
@@ -321,17 +321,17 @@ namespace RE
 		std::int32_t                         unk40;       /* 040 */
 		NiPointer<BSTriShape>                unk48;       /* 048 */
 		NiPointer<BSTriShape>                unk50;       /* 050 */
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		RUNTIME_DATA_CONTENT
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		VR_RUNTIME_DATA_CONTENT
 #endif
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(ImageSpaceManager) == 0x220);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(ImageSpaceManager) == 0x248);
 #else
 	static_assert(sizeof(ImageSpaceManager) == 0x58);

--- a/include/RE/I/InterfaceStrings.h
+++ b/include/RE/I/InterfaceStrings.h
@@ -197,26 +197,26 @@ namespace RE
 		BSFixedString tutorialMenu;            // 180 - "Tutorial Menu"
 		BSFixedString creditsMenu;             // 188 - "Credits Menu"
 		BSFixedString modManagerMenu;          // 190 - "Mod Manager Menu"
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 #	ifndef ENABLE_SKYRIM_AE
 		RUNTIME_DATA_CONTENT;
 #	else
 		AE_RUNTIME_DATA_CONTENT;
 #	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		VR_RUNTIME_DATA_CONTENT;
 #else
 #endif
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 #	ifndef ENABLE_SKYRIM_AE
 	static_assert(sizeof(InterfaceStrings) == 0x260);
 #	else
 	static_assert(sizeof(InterfaceStrings) == 0x278);
 #	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(InterfaceStrings) == 0x290);
 #else
 	static_assert(sizeof(InterfaceStrings) == 0x198);

--- a/include/RE/I/InventoryMenu.h
+++ b/include/RE/I/InventoryMenu.h
@@ -66,14 +66,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(InventoryMenu) == 0x98);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(InventoryMenu) == 0x88);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(InventoryMenu) == 0x98);
+#else
+	static_assert(sizeof(InventoryMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/J/JournalMenu.h
+++ b/include/RE/J/JournalMenu.h
@@ -97,14 +97,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(JournalMenu) == 0xF8);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(JournalMenu) == 0xE8);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(JournalMenu) == 0xF8);
+#else
+	static_assert(sizeof(JournalMenu) == 0x40);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/J/JumpHandler.h
+++ b/include/RE/J/JumpHandler.h
@@ -18,9 +18,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(JumpHandler) == 0x10);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(JumpHandler) == 0x28);
 #else
 	static_assert(sizeof(JumpHandler) == 0x10);

--- a/include/RE/K/KinectMenu.h
+++ b/include/RE/K/KinectMenu.h
@@ -60,13 +60,11 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(KinectMenu) == 0x60);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(KinectMenu) == 0x50);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(KinectMenu) == 0x60);
+#else
+	static_assert(sizeof(KinectMenu) == 0x30);
 #endif
 }

--- a/include/RE/L/LevelUpMenu.h
+++ b/include/RE/L/LevelUpMenu.h
@@ -48,14 +48,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(LevelUpMenu) == 0x48);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(LevelUpMenu) == 0x38);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(LevelUpMenu) == 0x48);
+#else
+	static_assert(sizeof(LevelUpMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/L/LoadWaitSpinner.h
+++ b/include/RE/L/LoadWaitSpinner.h
@@ -104,13 +104,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(LoadWaitSpinner) == 0x78);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(LoadWaitSpinner) == 0x68);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(LoadWaitSpinner) == 0x78);
 #endif
 }

--- a/include/RE/L/LoadingMenu.h
+++ b/include/RE/L/LoadingMenu.h
@@ -60,14 +60,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(LoadingMenu) == 0x90);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(LoadingMenu) == 0x80);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(LoadingMenu) == 0x90);
+#else
+	static_assert(sizeof(LoadingMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/L/LocalMapMenu.h
+++ b/include/RE/L/LocalMapMenu.h
@@ -53,7 +53,7 @@ namespace RE
 			Data             unk301F8;        // 301F8
 			std::uint64_t    unk30240;        // 30240
 			std::uint64_t    unk30248;        // 30248
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 			std::uint64_t                  unk30250;  // 30250
 			std::uint64_t                  unk30258;  // 30258
 			LocalMapCamera                 camera;    // 30260
@@ -61,7 +61,7 @@ namespace RE
 			ImageSpaceShaderParam          unk302D0;  // 302D0
 			std::uint64_t                  unk30350;  // 30350
 			NiPointer<NiNode>              unk30358;  // 30358
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 			std::uint64_t                  padVR1;    // 30250
 			std::uint64_t                  padVR2;    // 30258
 			std::uint64_t                  unk30260;  // 30260
@@ -85,9 +85,9 @@ namespace RE
 			std::uint8_t  unk30260[0x100];  // 30260
 #endif
 		};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		static_assert(sizeof(LocalMapCullingProcess) == 0x30360);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		static_assert(sizeof(LocalMapCullingProcess) == 0x303D8);
 #endif
 
@@ -139,16 +139,16 @@ namespace RE
 		float                  unk0003C;             // 0003C
 		LocalMapCullingProcess localCullingProcess;  // 00040
 		RUNTIME_DATA           runtimeData;          // 303A0, 30418
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 		std::uint32_t unk30478;  // 30478
 		std::uint32_t pad3047C;  // 3047C
 #endif
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(LocalMapMenu) == 0x30400);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(LocalMapMenu) == 0x30480);
+#else
+	static_assert(sizeof(LocalMapMenu) == 0x30400);
 #endif
 }

--- a/include/RE/L/LockpickingMenu.h
+++ b/include/RE/L/LockpickingMenu.h
@@ -128,10 +128,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+	static_assert(sizeof(LockpickingMenu) == 0x110);
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(LockpickingMenu) == 0x120);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
-	static_assert(sizeof(LockpickingMenu) == 0x120);
+#else
+	static_assert(sizeof(LockpickingMenu) == 0x40);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/L/LookHandler.h
+++ b/include/RE/L/LookHandler.h
@@ -19,9 +19,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(LookHandler) == 0x10);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(LookHandler) == 0x28);
 #else
 	static_assert(sizeof(LookHandler) == 0x10);

--- a/include/RE/L/LooseFileStream.h
+++ b/include/RE/L/LooseFileStream.h
@@ -44,8 +44,6 @@ namespace RE
 			LooseFileStream* Ctor(const BSFixedString& a_prefix, const BSFixedString& a_dirName, const BSFixedString& a_fileName, std::uint32_t a_fileSize, bool a_readOnly, Location* a_location);
 #endif
 		};
-#if !defined(ENABLE_SKYRIM_VR)
 		static_assert(sizeof(LooseFileStream) == 0x50);
-#endif
 	}
 }

--- a/include/RE/M/MagicMenu.h
+++ b/include/RE/M/MagicMenu.h
@@ -58,14 +58,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(MagicMenu) == 0x78);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(MagicMenu) == 0x68);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(MagicMenu) == 0x78);
+#else
+	static_assert(sizeof(MagicMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/M/Main.h
+++ b/include/RE/M/Main.h
@@ -51,7 +51,7 @@ namespace RE
 	static_assert(sizeof(BSSaveDataSystemUtilityImage) == 0x18);
 
 	class Main :
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		public BSTEventSink<PositionPlayerEvent>,  // 00
 		public BSTEventSink<BSGamerProfileEvent>   // 08
 #else
@@ -66,7 +66,7 @@ namespace RE
 		// override (BSTEventSink<PositionPlayerEvent>)
 		BSEventNotifyControl ProcessEvent(const PositionPlayerEvent* a_event, BSTEventSource<PositionPlayerEvent>* a_eventSource) override;  // 01 - { return BSEventNotifyControl::kContinue; }
 
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		// override (BSTEventSink<BSGamerProfileEvent>)
 		BSEventNotifyControl ProcessEvent(const BSGamerProfileEvent* a_event, BSTEventSource<BSGamerProfileEvent>* a_eventSource) override;  // 01
 #endif
@@ -105,7 +105,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(Main) == 0x270);
 #else
 	static_assert(sizeof(Main) == 0x268);

--- a/include/RE/M/MainMenu.h
+++ b/include/RE/M/MainMenu.h
@@ -129,12 +129,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE();
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(MainMenu) == 0x70);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+	static_assert(sizeof(MainMenu) == 0x60);
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(MainMenu) == 0x70);
 #else
-	static_assert(sizeof(MainMenu) == 0x40);
+	static_assert(sizeof(MainMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/M/MapMenu.h
+++ b/include/RE/M/MapMenu.h
@@ -26,7 +26,7 @@ namespace RE
 	// flags = kPausesGame | kUsesCursor | kRendersOffscreenTargets | kCustomRendering
 	// context = kMap
 	class MapMenu :
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 		public WorldSpaceMenu,                    // 00000
 		public BSTEventSink<MenuOpenCloseEvent>,  // 00058
 		public IMapCameraCallbacks                // 00060
@@ -92,9 +92,9 @@ namespace RE
 
 			RUNTIME_DATA_CONTENT
 		};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		static_assert(sizeof(RUNTIME_DATA) == 0x30420);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		static_assert(sizeof(RUNTIME_DATA) == 0x304A0);
 #else
 		static_assert(sizeof(RUNTIME_DATA) == 0x30420);
@@ -116,9 +116,9 @@ namespace RE
 	LocalMapMenu                        localMapMenu;    /* 000B0*/
             VR_RUNTIME_DATA_CONTENT;
 		};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		static_assert(sizeof(VR_RUNTIME_DATA) == 0x30450);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		static_assert(sizeof(VR_RUNTIME_DATA) == 0x304D0);
 #else
 		static_assert(sizeof(VR_RUNTIME_DATA) == 0x30450);
@@ -295,26 +295,22 @@ namespace RE
 			}
 		}
 		// members
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		VR_RUNTIME_DATA_CONTENT;   // 40, 60
 		VR_RUNTIME_DATA2_CONTENT;  // 30460, 30530
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		RUNTIME_DATA_CONTENT;   // 40, 60
 		RUNTIME_DATA2_CONTENT;  // 30460, 30530
 #endif
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(MapMenu) == 0x30560);
-#	else
-	static_assert(sizeof(MapMenu) == 0x30598);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+	static_assert(sizeof(MapMenu) == 0x30550);
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(MapMenu) == 0x30640);
 #else
-	static_assert(sizeof(MapMenu) == 0x40);
+	static_assert(sizeof(MapMenu) == 0x30);
 #endif
 }
 

--- a/include/RE/M/MenuControls.h
+++ b/include/RE/M/MenuControls.h
@@ -101,7 +101,7 @@ namespace RE
 		FavoritesHandler*           favoritesHandler;      // 70
 		ScreenshotHandler*          screenshotHandler;     // 78
 #ifndef ENABLE_SKYRIM_VR
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		std::uint64_t occlusionCullingToggleHandler;  // 80
 #endif
 #ifndef SKYRIM_CROSS_VR
@@ -115,7 +115,7 @@ namespace RE
 #ifndef ENABLE_SKYRIM_VR
 	static_assert(sizeof(MenuControls) == 0x88);
 	static_assert(offsetof(MenuControls, remapMode) == 0x82);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(offsetof(MenuControls, remapMode) == 0x8A);
 	static_assert(sizeof(MenuControls) == 0x90);
 #else

--- a/include/RE/M/MenuCursor.h
+++ b/include/RE/M/MenuCursor.h
@@ -41,7 +41,7 @@ namespace RE
 		std::uint8_t  pad01;  // 01
 		std::uint16_t pad02;  // 02
 #ifndef ENABLE_SKYRIM_VR
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		float unkVR04;
 #else
 #endif
@@ -50,9 +50,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(MenuCursor) == 0x30);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(MenuCursor) == 0x34);
 #else
 	static_assert(sizeof(MenuCursor) == 0x30);

--- a/include/RE/M/MessageBoxMenu.h
+++ b/include/RE/M/MessageBoxMenu.h
@@ -48,14 +48,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(MessageBoxMenu) == 0x48);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(MessageBoxMenu) == 0x38);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(MessageBoxMenu) == 0x48);
+#else
+	static_assert(sizeof(MessageBoxMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/M/MistMenu.h
+++ b/include/RE/M/MistMenu.h
@@ -141,14 +141,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(MistMenu) == 0x150);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(MistMenu) == 0x140);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(MistMenu) == 0x150);
+#else
+	static_assert(sizeof(MistMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/M/ModManagerMenu.h
+++ b/include/RE/M/ModManagerMenu.h
@@ -86,14 +86,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(ModManagerMenu) == 0x68);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(ModManagerMenu) == 0x58);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(ModManagerMenu) == 0x68);
+#else
+	static_assert(sizeof(ModManagerMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/M/MovementControllerAI.h
+++ b/include/RE/M/MovementControllerAI.h
@@ -60,7 +60,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(MovementControllerAI) == 0x120);
 #endif
 }

--- a/include/RE/M/MovementControllerNPC.h
+++ b/include/RE/M/MovementControllerNPC.h
@@ -60,7 +60,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(MovementControllerNPC) == 0x1D0);
 #endif
 }

--- a/include/RE/M/MovementHandler.h
+++ b/include/RE/M/MovementHandler.h
@@ -18,9 +18,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(MovementHandler) == 0x10);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(MovementHandler) == 0x28);
 #endif
 }

--- a/include/RE/N/NavMeshInfoMap.h
+++ b/include/RE/N/NavMeshInfoMap.h
@@ -59,7 +59,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(NavMeshInfoMap) == 0xF0);
 #endif
 }

--- a/include/RE/N/NiAVObject.h
+++ b/include/RE/N/NiAVObject.h
@@ -103,7 +103,7 @@ namespace RE
 
 		// add
 		virtual void UpdateControllers(NiUpdateData& a_data);  // 25
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 		virtual void ApplyLocalTransformToWorld();
 #endif
 		SKYRIM_REL_VR_VIRTUAL void        PerformOp(PerformOpFunc& a_func);                                                                   // 26
@@ -168,7 +168,7 @@ namespace RE
 		NiTransform                  world;            // 07C
 		NiTransform                  previousWorld;    // 0B0
 		NiBound                      worldBound;       // 0E4
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		stl::enumeration<Flag, std::uint32_t> flags;                    // 0F4
 		TESObjectREFR*                        userData;                 // 0F8
 		float                                 fadeAmount;               // 100
@@ -181,7 +181,7 @@ namespace RE
 		KEEP_FOR_RE()
 	};
 	static_assert(sizeof(NiAVObject) == 0x110);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		float                                 unkF4;                    // 0F4
 		float                                 unkF8;                    // 0F8
 		float                                 unkFC;                    // 0FC

--- a/include/RE/N/NiBillboardNode.h
+++ b/include/RE/N/NiBillboardNode.h
@@ -54,9 +54,9 @@ namespace RE
 		// members
 		std::uint16_t userFlags;  // 128
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(NiBillboardNode) == 0x130);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(NiBillboardNode) == 0x158);
 #else
 	static_assert(sizeof(NiBillboardNode) == 0x118);

--- a/include/RE/N/NiCamera.h
+++ b/include/RE/N/NiCamera.h
@@ -16,12 +16,12 @@ namespace RE
 
 		struct RUNTIME_DATA
 		{
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 #	define RUNTIME_DATA_CONTENT float worldToCam[4][4]; /* 0 */
 			RUNTIME_DATA_CONTENT
 		};
 		static_assert(sizeof(RUNTIME_DATA) == 0x40);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 #	define RUNTIME_DATA_CONTENT                   \
 		float           worldToCam[4][4]; /* 0 */  \
 		NiFrustum*      viewFrustumPtr;   /* 40 */ \
@@ -62,7 +62,7 @@ namespace RE
 		bool          RegisterStreamables(NiStream& a_stream) override;   // 1A
 		void          SaveBinary(NiStream& a_stream) override;            // 1B - { return; }
 		bool          IsEqual(NiObject* a_object) override;               // 1C
-#if !defined(ENABLE_SKYRIM_VR) || (!defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_VR))
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		// The following are virtual functions past the point where VR compatibility breaks.
 		void UpdateWorldBound() override;                     // 2F - { return; }
 		void UpdateWorldData(NiUpdateData* a_data) override;  // 30
@@ -103,9 +103,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE();
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(NiCamera) == 0x188);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(NiCamera) == 0x208);
 #endif
 }

--- a/include/RE/N/NiDirectionalLight.h
+++ b/include/RE/N/NiDirectionalLight.h
@@ -51,9 +51,9 @@ namespace RE
 		RUNTIME_DATA_CONTENT  // 140, 168
 #endif
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(NiDirectionalLight) == 0x158);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(NiDirectionalLight) == 0x180);
 #endif
 }

--- a/include/RE/N/NiGeometry.h
+++ b/include/RE/N/NiGeometry.h
@@ -46,7 +46,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(NiGeometry) == 0x160);
 #else
 	static_assert(sizeof(NiGeometry) == 0x138);

--- a/include/RE/N/NiLight.h
+++ b/include/RE/N/NiLight.h
@@ -50,9 +50,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(NiLight) == 0x140);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(NiLight) == 0x168);
 #endif
 }

--- a/include/RE/N/NiNode.h
+++ b/include/RE/N/NiNode.h
@@ -82,9 +82,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(NiNode) == 0x128);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(NiNode) == 0x150);
 #endif
 }

--- a/include/RE/N/NiPSysData.h
+++ b/include/RE/N/NiPSysData.h
@@ -70,9 +70,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(NiPSysData) == 0xA8);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(NiPSysData) == 0xA8);
 #else
 	static_assert(sizeof(NiPSysData) == 0x10);

--- a/include/RE/N/NiParticleSystem.h
+++ b/include/RE/N/NiParticleSystem.h
@@ -75,9 +75,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(NiParticleSystem) == 0x198);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(NiParticleSystem) == 0x1E0);
 #else
 	static_assert(sizeof(NiParticleSystem) == 0x110);

--- a/include/RE/N/NiParticles.h
+++ b/include/RE/N/NiParticles.h
@@ -50,9 +50,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(NiParticles) == 0x168);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(NiParticles) == 0x1B0);
 #else
 	static_assert(sizeof(NiParticles) == 0x110);

--- a/include/RE/N/NiParticlesData.h
+++ b/include/RE/N/NiParticlesData.h
@@ -76,9 +76,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(NiParticlesData) == 0x90);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(NiParticlesData) == 0x90);
 #else
 	static_assert(sizeof(NiParticlesData) == 0x10);

--- a/include/RE/N/NiPointLight.h
+++ b/include/RE/N/NiPointLight.h
@@ -71,9 +71,9 @@ namespace RE
 		}
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(NiPointLight) == 0x150);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(NiPointLight) == 0x178);
 #endif
 }

--- a/include/RE/N/NiSkinInstance.h
+++ b/include/RE/N/NiSkinInstance.h
@@ -48,7 +48,7 @@ namespace RE
 		void*                      boneMatrices;                  // 48
 		void*                      prevBoneMatrices;              // 50
 		void*                      skinToWorldWorldToSkinMatrix;  // 58
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		REX::W32::CRITICAL_SECTION lock;  // 60
 	private:
 		KEEP_FOR_RE()

--- a/include/RE/Offsets.h
+++ b/include/RE/Offsets.h
@@ -207,7 +207,7 @@ namespace RE::Offset
 		constexpr auto Singleton = RELOCATION_ID(514622, 400782);
 	}
 
-#if !defined(ENABLE_SKYRIM_SE) && !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_AE)
 	namespace GASActionBufferData
 	{
 		constexpr auto Vtbl = RELOCATION_ID(0, 242366);
@@ -239,7 +239,7 @@ namespace RE::Offset
 		constexpr auto InvokeNoReturn = RELOCATION_ID(80547, 82665);
 	}
 
-#if !defined(ENABLE_SKYRIM_SE) && !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_AE)
 	namespace GFxPlaceObject2
 	{
 		constexpr auto Vtbl = RELOCATION_ID(0, 242592);

--- a/include/RE/P/PlayerCamera.h
+++ b/include/RE/P/PlayerCamera.h
@@ -164,10 +164,10 @@ namespace RE
 		std::uint8_t  pad039;        // 039
 		std::uint16_t pad03A;        // 03A
 		ActorHandle   cameraTarget;  // 03C
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		RUNTIME_DATA_CONTENT;
 		RUNTIME_DATA2_CONTENT;
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		VR_RUNTIME_DATA_CONTENT;
 		RUNTIME_DATA2_CONTENT;
 #endif
@@ -177,9 +177,9 @@ namespace RE
 		bool QCameraEquals(CameraState a_cameraState) const;
 		KEEP_FOR_RE();
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(PlayerCamera) == 0x168);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(PlayerCamera) == 0x180);
 #endif
 }

--- a/include/RE/P/PlayerCharacter.h
+++ b/include/RE/P/PlayerCharacter.h
@@ -54,7 +54,7 @@ namespace RE
 	struct PositionPlayerEvent;
 	struct TESQuestStageItem;
 	struct TESTrackedStatsEvent;
-#ifdef ENABLE_SKYRIM_VR
+#ifdef EXCLUSIVE_SKYRIM_VR
 	struct VRDeviceConnectionChange;
 	struct VROverlayChange;
 	struct VRResetHMDHeight;
@@ -278,7 +278,7 @@ namespace RE
 		public BSTEventSink<MenuModeChangeEvent>,    // SE,VR 2B8, AE 2C0
 		public BSTEventSink<UserEventEnabledEvent>,  // SE,VR 2C0, AE 2C8
 		public BSTEventSink<TESTrackedStatsEvent>    // SE,VR 2C8, AE 2D0
-#ifdef ENABLE_SKYRIM_VR
+#ifdef EXCLUSIVE_SKYRIM_VR
 		,
 		public BSTEventSink<VROverlayChange>,           // 2D0
 		public BSTEventSink<VRDeviceConnectionChange>,  // 2D8
@@ -391,29 +391,29 @@ namespace RE
 			bool dragonRideTargetLocked: 1;         // 5:2
 			bool everModded: 1;                     // 5:3
 			bool servingJailTime: 1;                // 5:4 - Briefly set
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 			bool          pad5_5: 3;  // 5:5
 			std::uint16_t pad6;       // 6
 #else
-			bool unk5_5: 1;                                                                // 5:5
-			bool unk5_6: 1;                                                                // 5:6
-			bool unk5_7: 1;                                                                // 5:7
-			bool unk6_0: 1;                                                                // 6:0
-			bool unk6_1: 1;                                                                // 6:1
-			bool unk6_2: 1;                                                                // 6:2
-			bool unk6_3: 1;                                                                // 6:3
-			bool unk6_4: 1;                                                                // 6:4
-			bool unk6_5: 1;                                                                // 6:5
-			bool unk6_6: 1;                                                                // 6:6
-			bool unk6_7: 1;                                                                // 6:7
-			bool unk7_0: 1;                                                                // 7:0
-			bool unk7_1: 1;                                                                // 7:1
-			bool unk7_2: 1;                                                                // 7:2
-			bool unk7_3: 1;                                                                // 7:3
-			bool unk7_4: 1;                                                                // 7:4
-			bool unk7_5: 1;                                                                // 7:5
-			bool unk7_6: 1;                                                                // 7:6
-			bool unk7_7: 1;                                                                // 7:7
+			bool unk5_5: 1;  // 5:5
+			bool unk5_6: 1;  // 5:6
+			bool unk5_7: 1;  // 5:7
+			bool unk6_0: 1;  // 6:0
+			bool unk6_1: 1;  // 6:1
+			bool unk6_2: 1;  // 6:2
+			bool unk6_3: 1;  // 6:3
+			bool unk6_4: 1;  // 6:4
+			bool unk6_5: 1;  // 6:5
+			bool unk6_6: 1;  // 6:6
+			bool unk6_7: 1;  // 6:7
+			bool unk7_0: 1;  // 7:0
+			bool unk7_1: 1;  // 7:1
+			bool unk7_2: 1;  // 7:2
+			bool unk7_3: 1;  // 7:3
+			bool unk7_4: 1;  // 7:4
+			bool unk7_5: 1;  // 7:5
+			bool unk7_6: 1;  // 7:6
+			bool unk7_7: 1;  // 7:7
 #endif
 		};
 		static_assert(sizeof(PlayerFlags) == 0x8);
@@ -683,9 +683,9 @@ namespace RE
 		~PlayerCharacter() override;  // 000
 
 		// override
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		void RemoveWeapon(BIPED_OBJECT equipIndex) override;  // 82
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		void AttachWeapon(RE::TESObjectWEAP* a_weapon, bool attachToShieldHand) override;  // 82
 		void RemoveWeapon(BIPED_OBJECT equipIndex) override;                               // 83
 #else
@@ -1148,25 +1148,25 @@ namespace RE
 		}
 
 		// members
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		PLAYER_RUNTIME_DATA_CONTENT
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		VR_PLAYER_RUNTIME_DATA_CONTENT
-#elif (!defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)) || (!defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_VR))
 #endif
 
 	private:
 		bool CenterOnCell_Impl(const char* a_cellName, RE::TESObjectCELL* a_cell);
 	};
-#if !defined(ENABLE_SKYRIM_VR) && defined(ENABLE_SKYRIM_SE) && !defined(ENABLE_SKYRIM_AE)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+#	if defined(EXCLUSIVE_SKYRIM_SE)
 	static_assert(sizeof(PlayerCharacter) == 0xBE0);
-#elif !defined(ENABLE_SKYRIM_VR) && !defined(ENABLE_SKYRIM_SE) && defined(ENABLE_SKYRIM_AE)
+#	else
 	static_assert(sizeof(PlayerCharacter) == 0x9A8);
-#elif defined(ENABLE_SKYRIM_VR) && !defined(ENABLE_SKYRIM_SE) && !defined(ENABLE_SKYRIM_AE)
+#	endif
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(PlayerCharacter) == 0x12F0);
-#elif !defined(ENABLE_SKYRIM_VR)
 #else
-	static_assert(sizeof(PlayerCharacter) == 0x1B8);
+	static_assert(sizeof(PlayerCharacter) == 0x1A0);
 #endif
 }
 #undef PLAYER_RUNTIME_DATA_CONTENT

--- a/include/RE/P/PlayerCharacter.h
+++ b/include/RE/P/PlayerCharacter.h
@@ -270,17 +270,19 @@ namespace RE
 	static_assert(sizeof(PlayerActionObject) == 0xC);
 
 	class PlayerCharacter :
-#ifndef ENABLE_SKYRIM_AE
 		public Character,                            // 000
-		public BSTEventSource<BGSActorCellEvent>,    // 2D0
-		public BSTEventSource<BGSActorDeathEvent>,   // 328
-		public BSTEventSource<PositionPlayerEvent>,  // 380
-		public BSTEventSink<MenuOpenCloseEvent>,     // 2B0
-		public BSTEventSink<MenuModeChangeEvent>,    // 2B8
-		public BSTEventSink<UserEventEnabledEvent>,  // 2C0
-		public BSTEventSink<TESTrackedStatsEvent>    // 2C8
-#else
-		public Character                                                                   // 000
+		public BSTEventSource<BGSActorCellEvent>,    // SE 2D0, AE 2D8, VR 2E8
+		public BSTEventSource<BGSActorDeathEvent>,   // SE 328, AE 330, VR 340
+		public BSTEventSource<PositionPlayerEvent>,  // SE 380, AE 388, VR 398
+		public BSTEventSink<MenuOpenCloseEvent>,     // SE,VR 2B0, AE 2B8
+		public BSTEventSink<MenuModeChangeEvent>,    // SE,VR 2B8, AE 2C0
+		public BSTEventSink<UserEventEnabledEvent>,  // SE,VR 2C0, AE 2C8
+		public BSTEventSink<TESTrackedStatsEvent>    // SE,VR 2C8, AE 2D0
+#ifdef ENABLE_SKYRIM_VR
+		,
+		public BSTEventSink<VROverlayChange>,           // 2D0
+		public BSTEventSink<VRDeviceConnectionChange>,  // 2D8
+		public BSTEventSink<VRResetHMDHeight>           // 2E0
 #endif
 	{
 	public:
@@ -1156,12 +1158,15 @@ namespace RE
 	private:
 		bool CenterOnCell_Impl(const char* a_cellName, RE::TESObjectCELL* a_cell);
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(PlayerCharacter) == 0x880);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
-	static_assert(sizeof(PlayerCharacter) == 0x12D8);
+#if !defined(ENABLE_SKYRIM_VR) && defined(ENABLE_SKYRIM_SE) && !defined(ENABLE_SKYRIM_AE)
+	static_assert(sizeof(PlayerCharacter) == 0xBE0);
+#elif !defined(ENABLE_SKYRIM_VR) && !defined(ENABLE_SKYRIM_SE) && defined(ENABLE_SKYRIM_AE)
+	static_assert(sizeof(PlayerCharacter) == 0x9A8);
+#elif defined(ENABLE_SKYRIM_VR) && !defined(ENABLE_SKYRIM_SE) && !defined(ENABLE_SKYRIM_AE)
+	static_assert(sizeof(PlayerCharacter) == 0x12F0);
+#elif !defined(ENABLE_SKYRIM_VR)
 #else
-	static_assert(sizeof(PlayerCharacter) == 0x78);
+	static_assert(sizeof(PlayerCharacter) == 0x1B8);
 #endif
 }
 #undef PLAYER_RUNTIME_DATA_CONTENT

--- a/include/RE/P/PlayerInputHandler.h
+++ b/include/RE/P/PlayerInputHandler.h
@@ -34,7 +34,7 @@ namespace RE
 		std::uint8_t  pad09{ 0 };                 // 09
 		std::uint16_t pad0A{ 0 };                 // 0A
 		std::uint32_t pad0C{ 0 };                 // 0C
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 		std::uint64_t unk10;  // 10
 		BSFixedString unk18;  // 18
 		std::uint64_t unk20;
@@ -42,9 +42,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(PlayerInputHandler) == 0x10);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(PlayerInputHandler) == 0x28);
 #else
 	static_assert(sizeof(PlayerInputHandler) == 0x10);

--- a/include/RE/R/RaceSexMenu.h
+++ b/include/RE/R/RaceSexMenu.h
@@ -90,15 +90,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(RaceSexMenu) == 0x1B8);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(RaceSexMenu) == 0x1A8);
-	char (*__kaboom)[sizeof(RaceSexMenu)] = 1;
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(RaceSexMenu) == 0x1B8);
+#else
+	static_assert(sizeof(RaceSexMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/R/ReadyWeaponHandler.h
+++ b/include/RE/R/ReadyWeaponHandler.h
@@ -18,9 +18,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(ReadyWeaponHandler) == 0x10);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(ReadyWeaponHandler) == 0x28);
 #endif
 }

--- a/include/RE/R/Renderer.h
+++ b/include/RE/R/Renderer.h
@@ -245,10 +245,10 @@ namespace RE
 			std::uint64_t unk000;      // 0000
 			bool          drawStereo;  // 0008
 #if !defined(ENABLE_SKYRIM_VR)
+			RUNTIME_DATA_CONTENT;  // 0010
 #elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
-			std::uint64_t unk010;  // 0010
+			RUNTIME_DATA_CONTENT;  // VR 18
 #endif
-			RUNTIME_DATA_CONTENT;  // 0010, VR 18
 
 		private:
 			void Begin(std::uint32_t windowID);
@@ -259,9 +259,9 @@ namespace RE
 #if !defined(ENABLE_SKYRIM_VR)
 		static_assert(sizeof(Renderer) == 0x21C0);
 #elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
-		static_assert(sizeof(Renderer) == 0x1fc0);
+		static_assert(sizeof(Renderer) == 0x1FB0);
 #else
-		static_assert(sizeof(Renderer) == 0x1fb0);
+		static_assert(sizeof(Renderer) == 0x10);
 #endif
 	}
 }

--- a/include/RE/R/Renderer.h
+++ b/include/RE/R/Renderer.h
@@ -51,10 +51,10 @@ namespace RE
 		struct DepthStencilRuntimeData
 		{
 		public:
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 #	define DEPTHSTENCIL_RUNTIME_DATA_CONTENT \
 		DepthStencilData depthStencils[RENDER_TARGET_DEPTHSTENCIL::kTOTAL]; /* 1FB8, VR 21D0, AE1130 0x2018*/
-//#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+//#elif defined(EXCLUSIVE_SKYRIM_VR)
 #else
 #	define DEPTHSTENCIL_RUNTIME_DATA_CONTENT \
 		DepthStencilData depthStencils[RENDER_TARGET_DEPTHSTENCIL::kVRTOTAL]; /* 1FB8, VR 21D0, AE1130 0x2018*/
@@ -66,7 +66,7 @@ namespace RE
 		{
 		public:
 			// members
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 #	define RUNTIME_DATA_CONTENT                                                                             \
 		std::uint32_t                      uiAdapter;                              /* 0018 */                \
 		REX::W32::DXGI_RATIONAL            desiredRefreshRate;                     /* 001C - refreshRate? */ \
@@ -111,11 +111,11 @@ namespace RE
 #endif
 			RUNTIME_DATA_CONTENT;
 		};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		static_assert(sizeof(RendererData) == 0x21B8);
 		static_assert(offsetof(RendererData, context) == 0x40);
 		static_assert(offsetof(RendererData, renderTargets) == 0xa48);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		static_assert(sizeof(RendererData) == 0x1fa8);
 		static_assert(offsetof(RendererData, context) == 0x40);
 		static_assert(offsetof(RendererData, renderTargets) == 0xa48);
@@ -244,9 +244,9 @@ namespace RE
 			// members
 			std::uint64_t unk000;      // 0000
 			bool          drawStereo;  // 0008
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 			RUNTIME_DATA_CONTENT;  // 0010
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 			RUNTIME_DATA_CONTENT;  // VR 18
 #endif
 
@@ -256,9 +256,9 @@ namespace RE
 			void End();
 			void Shutdown();
 		};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		static_assert(sizeof(Renderer) == 0x21C0);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		static_assert(sizeof(Renderer) == 0x1FB0);
 #else
 		static_assert(sizeof(Renderer) == 0x10);

--- a/include/RE/R/RunHandler.h
+++ b/include/RE/R/RunHandler.h
@@ -17,9 +17,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(RunHandler) == 0x18);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(RunHandler) == 0x30);
 #endif
 }

--- a/include/RE/S/SafeZoneMenu.h
+++ b/include/RE/S/SafeZoneMenu.h
@@ -17,13 +17,11 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(SafeZoneMenu) == 0x40);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(SafeZoneMenu) == 0x30);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(SafeZoneMenu) == 0x40);
+#else
+	static_assert(sizeof(RaceSexMenu) == 0x30);
 #endif
 }

--- a/include/RE/S/ScriptEventSourceHolder.h
+++ b/include/RE/S/ScriptEventSourceHolder.h
@@ -114,7 +114,7 @@ namespace RE
 		public BSTEventSource<TESUniqueIDChangeEvent>,           // 10D8
 		public BSTEventSource<TESWaitStartEvent>,                // 1130 - ?
 		public BSTEventSource<TESWaitStopEvent>,                 // 1188 - ?
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		public BSTEventSource<TESSwitchRaceCompleteEvent>,  // 11E0
 		public BSTEventSource<TESFastTravelEndEvent>        // 1238
 #else
@@ -170,9 +170,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(ScriptEventSourceHolder) == 0x1290);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(ScriptEventSourceHolder) == 0x1238);
 #endif
 }

--- a/include/RE/S/ShaderAccumulator.h
+++ b/include/RE/S/ShaderAccumulator.h
@@ -56,14 +56,14 @@ namespace RE
 			bool firstPerson;      // 128
 			char _pad0[0x3];       // 129
 			bool drawDecals;       // 130
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 			RUNTIME_DATA_CONTENT;  // 130
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 			std::uint64_t unk000[(0x158 - 0x130) >> 3];  // 130
 			RUNTIME_DATA_CONTENT;                        // 158
 #endif
 		};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		static_assert(sizeof(BSShaderAccumulator) == 0x180);
 		static_assert(offsetof(BSShaderAccumulator, batchRenderer) == 0x130);
 		static_assert(offsetof(BSShaderAccumulator, currentPass) == 0x138);
@@ -72,7 +72,7 @@ namespace RE
 		static_assert(offsetof(BSShaderAccumulator, activeShadowSceneNode) == 0x148);
 		static_assert(offsetof(BSShaderAccumulator, renderMode) == 0x150);
 		static_assert(offsetof(BSShaderAccumulator, eyePosition) == 0x16C);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		static_assert(offsetof(BSShaderAccumulator, batchRenderer) == 0x158);
 		static_assert(offsetof(BSShaderAccumulator, currentPass) == 0x160);
 		static_assert(offsetof(BSShaderAccumulator, currentBucket) == 0x164);

--- a/include/RE/S/ShadowSceneNode.h
+++ b/include/RE/S/ShadowSceneNode.h
@@ -99,7 +99,7 @@ namespace RE
 
 		// override (NiNode)
 		const NiRTTI* GetRTTI() const override;  // 02
-#if !defined(ENABLE_SKYRIM_VR) || (!defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_VR))
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		// The following are virtual functions past the point where VR compatibility breaks.
 		void OnVisible(NiCullingProcess& a_process) override;  // 34
 #endif
@@ -135,9 +135,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(ShadowSceneNode) == 0x308);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(ShadowSceneNode) == 0x330);
 #endif
 }

--- a/include/RE/S/ShadowState.h
+++ b/include/RE/S/ShadowState.h
@@ -232,24 +232,13 @@ namespace RE
 	ID3D11Buffer*                           PSConstantBuffers[12];                                       /* VR 8F0 only */
                 VR_RUNTIME_DATA_CONTENT;
 			};
-
-			struct RUNTIME_DATA
-			{
-#if !defined(ENABLE_SKYRIM_VR)
-#	define RUNTIME_DATA_CONTENT \
-		FLAT_RUNTIME_DATA_CONTENT;
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
-#	define RUNTIME_DATA_CONTENT \
-		VR_RUNTIME_DATA_CONTENT;
-#else
-#	define RUNTIME_DATA_CONTENT ;
-#endif
-				RUNTIME_DATA_CONTENT;
-			};
-
+			
 			// members
-
-			RUNTIME_DATA_CONTENT;  // 0
+#ifndef ENABLE_SKYRIM_VR
+			FLAT_RUNTIME_DATA_CONTENT;  // 0
+#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+			VR_RUNTIME_DATA_CONTENT;  // 0
+#endif
 
 			[[nodiscard]] inline FLAT_RUNTIME_DATA& GetRuntimeData() noexcept
 			{
@@ -430,6 +419,5 @@ namespace RE
 #endif
 	}
 }
-#undef RUNTIME_DATA_CONTENT
 #undef FLAT_RUNTIME_DATA_CONTENT
 #undef VR_RUNTIME_DATA_CONTENT

--- a/include/RE/S/ShadowState.h
+++ b/include/RE/S/ShadowState.h
@@ -236,7 +236,7 @@ namespace RE
 			// members
 #ifndef ENABLE_SKYRIM_VR
 			FLAT_RUNTIME_DATA_CONTENT;  // 0
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 			VR_RUNTIME_DATA_CONTENT;  // 0
 #endif
 
@@ -351,7 +351,7 @@ namespace RE
 				*reinterpret_cast<ValueType*>((reinterpret_cast<float*>(data.currentPixelShader->constantBuffers[static_cast<size_t>(level)].data) + offset)) = value;
 			}
 		};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		static_assert(sizeof(RendererShadowState) == 0x5e0);
 		static_assert(offsetof(RendererShadowState, renderTargets) == 0x18);
 		static_assert(offsetof(RendererShadowState, depthStencil) == 0x38);
@@ -381,7 +381,7 @@ namespace RE
 		static_assert(offsetof(RendererShadowState, posAdjust) == 0x35c);
 		static_assert(offsetof(RendererShadowState, previousPosAdjust) == 0x368);
 		static_assert(offsetof(RendererShadowState, cameraData) == 0x380);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		static_assert(sizeof(RendererShadowState) == 0x950);
 		static_assert(offsetof(RendererShadowState, OMUAVModifiedBits) == 0x18);
 		static_assert(offsetof(RendererShadowState, renderTargets) == 0x20);

--- a/include/RE/S/ShoutHandler.h
+++ b/include/RE/S/ShoutHandler.h
@@ -21,9 +21,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(ShoutHandler) == 0x20);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(ShoutHandler) == 0x38);
 #endif
 }

--- a/include/RE/S/SkyrimVM.h
+++ b/include/RE/S/SkyrimVM.h
@@ -136,7 +136,7 @@ namespace RE
 		public BSTEventSink<TESUniqueIDChangeEvent>,           // 0170
 		public BSTEventSink<TESSwitchRaceCompleteEvent>,       // 0178
 		public BSTEventSink<TESPlayerBowShotEvent>,            // 0180
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		public BSTEventSink<TESFastTravelEndEvent>,  // 0188
 		public BSTEventSink<PositionPlayerEvent>,    // 0190
 		public BSTEventSink<BSScript::StatsEvent>,   // 0198
@@ -346,9 +346,9 @@ namespace RE
 		BSTArray<BSTSmartPointer<UpdateDataEvent>> queuedOnUpdateEvents;       // 0720
 		BSTArray<BSTSmartPointer<UpdateDataEvent>> queuedOnUpdateGameEvents;   // 0738
 		std::uint32_t                              unk0750;                    // 0750
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		RUNTIME_DATA_CONTENT;
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		VR_RUNTIME_DATA_CONTENT;
 #elif defined(SKYRIM_CROSS_VR)
 #else
@@ -358,14 +358,13 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 #ifdef ENABLE_SKYRIM_AE
 	static_assert(sizeof(SkyrimVM) == 0x760);
 	#else
-	static_assert(sizeof(SkyrimVM) == 0x8978);
-	char (*__kaboom)[sizeof(SkyrimVM)] = 1;
+	static_assert(sizeof(SkyrimVM) == 0x760);
 #	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(SkyrimVM) == 0x780);
 #else
 	static_assert(sizeof(SkyrimVM) == 0x758);

--- a/include/RE/S/SleepWaitMenu.h
+++ b/include/RE/S/SleepWaitMenu.h
@@ -60,14 +60,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(SleepWaitMenu) == 0x68);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(SleepWaitMenu) == 0x58);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(SleepWaitMenu) == 0x68);
+#else
+	static_assert(sizeof(SleepWaitMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/S/SneakHandler.h
+++ b/include/RE/S/SneakHandler.h
@@ -17,9 +17,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(SneakHandler) == 0x10);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(SneakHandler) == 0x28);
 #endif
 }

--- a/include/RE/S/SprintHandler.h
+++ b/include/RE/S/SprintHandler.h
@@ -17,9 +17,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(SprintHandler) == 0x18);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(SprintHandler) == 0x30);
 #endif
 }

--- a/include/RE/S/State.h
+++ b/include/RE/S/State.h
@@ -53,7 +53,7 @@ namespace RE
 		NiPoint3 posAdjust;                                             /* 20 */                                                               \
 		NiPoint3 currentPosAdjust;                                      /* 38 */                                                               \
 		NiPoint3 previousPosAdjust;                                     /* 50 */                                                               \
-		#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)  // VR
+		#elif defined(EXCLUSIVE_SKYRIM_VR)  // VR
 #	define CAMERASTATE_RUNTIME_DATA_CONTENT                                                                         \
 		BSTArray<ViewData> camViewData;       /* 08 VR is BSTArray, Each array has 2 elements (one for each eye?) */ \
 		BSTArray<NiPoint3> posAdjust;         /* 20 */                                                               \
@@ -87,7 +87,7 @@ namespace RE
 		};
 #if !defined(ENABLE_SKYRIM_VR)  // Non-VR
 		static_assert(sizeof(CameraStateData) == 0x68);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)  // VR
+#elif defined(EXCLUSIVE_SKYRIM_VR)  // VR
 		static_assert(sizeof(CameraStateData) == 0x8);
 #else
 		static_assert(sizeof(CameraStateData) == 0x8);
@@ -97,7 +97,7 @@ namespace RE
 		public:
 			struct RUNTIME_DATA
 			{
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)  // VR
+#if defined(EXCLUSIVE_SKYRIM_VR)  // VR
 #	define RUNTIME_DATA_CONTENT                                                                                               \
 		uint32_t                   firstCameraStateIndex;                /*	058 VR   only ?*/                                  \
 		NiPointer<NiSourceTexture> defaultTextureBlack;                  /* SE 058, AE,VR 060 - "BSShader_DefHeightMap"*/      \
@@ -150,7 +150,7 @@ namespace RE
 			};
 #if !defined(ENABLE_SKYRIM_VR)  // Non-VR
 			static_assert(offsetof(RUNTIME_DATA, dynamicResolutionWidthRatio) == 0xA4);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)  // VR
+#elif defined(EXCLUSIVE_SKYRIM_VR)  // VR
 			static_assert(offsetof(RUNTIME_DATA, dynamicResolutionWidthRatio) == 0xAC);
 #else
 			static_assert(offsetof(RUNTIME_DATA, dynamicResolutionWidthRatio) == 0xA4);
@@ -224,7 +224,7 @@ namespace RE
 			RUNTIME_DATA_CONTENT;  // 058, AE,VR 060
 #endif
 		};
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_VR)  // SE
+#if defined(EXCLUSIVE_SKYRIM_SE)  // SE
 		static_assert(sizeof(State) == 0x118);
 		static_assert(offsetof(State, screenWidth) == 0x24);
 		static_assert(offsetof(State, frameBufferViewport) == 0x2C);
@@ -234,7 +234,7 @@ namespace RE
 		static_assert(offsetof(State, defaultTextureWhite) == 0x60);
 		static_assert(offsetof(State, cameraDataCacheA) == 0xa0);
 		static_assert(offsetof(State, dynamicResolutionWidthRatio) == 0x0fc);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)  // VR
+#elif defined(EXCLUSIVE_SKYRIM_VR)  // VR
 		static_assert(sizeof(State) == 0x120);
 		static_assert(offsetof(State, screenWidth) == 0x24);
 		static_assert(offsetof(State, frameBufferViewport) == 0x2C);

--- a/include/RE/S/State.h
+++ b/include/RE/S/State.h
@@ -220,32 +220,36 @@ namespace RE
 			bool                       compiledShaderThisFrame;            // 053
 			bool                       useEarlyZ;                          // 054
 			bool                       unk055;                             // 055
-			RUNTIME_DATA_CONTENT;                                          // 058, AE,VR 060
+#ifndef ENABLE_SKYRIM_AE
+			RUNTIME_DATA_CONTENT;  // 058, AE,VR 060
+#endif
 		};
-#if !defined(ENABLE_SKYRIM_VR)  // Non-VR
+#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_VR)  // SE
+		static_assert(sizeof(State) == 0x118);
 		static_assert(offsetof(State, screenWidth) == 0x24);
 		static_assert(offsetof(State, frameBufferViewport) == 0x2C);
 		static_assert(offsetof(State, letterbox) == 0x51);
+		static_assert(offsetof(State, useEarlyZ) == 0x54);
 		static_assert(offsetof(State, defaultTextureBlack) == 0x58);
 		static_assert(offsetof(State, defaultTextureWhite) == 0x60);
 		static_assert(offsetof(State, cameraDataCacheA) == 0xa0);
 		static_assert(offsetof(State, dynamicResolutionWidthRatio) == 0x0fc);
 #elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)  // VR
+		static_assert(sizeof(State) == 0x120);
 		static_assert(offsetof(State, screenWidth) == 0x24);
 		static_assert(offsetof(State, frameBufferViewport) == 0x2C);
 		static_assert(offsetof(State, letterbox) == 0x51);
+		static_assert(offsetof(State, useEarlyZ) == 0x54);
 		static_assert(offsetof(State, defaultTextureBlack) == 0x60);
 		static_assert(offsetof(State, defaultTextureWhite) == 0x68);
 		static_assert(offsetof(State, cameraDataCacheA) == 0xa8);
 		static_assert(offsetof(State, dynamicResolutionWidthRatio) == 0x104);
 #else
+		static_assert(sizeof(State) == 0x58);
 		static_assert(offsetof(State, screenWidth) == 0x24);
 		static_assert(offsetof(State, frameBufferViewport) == 0x2C);
 		static_assert(offsetof(State, letterbox) == 0x51);
-		static_assert(offsetof(State, defaultTextureBlack) == 0x58);
-		static_assert(offsetof(State, defaultTextureWhite) == 0x60);
-		static_assert(offsetof(State, cameraDataCacheA) == 0xa0);
-		static_assert(offsetof(State, dynamicResolutionWidthRatio) == 0x0fc);
+		static_assert(offsetof(State, useEarlyZ) == 0x54);
 #endif
 	}
 }

--- a/include/RE/S/StatsMenu.h
+++ b/include/RE/S/StatsMenu.h
@@ -183,14 +183,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(StatsMenu) == 0x338);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(StatsMenu) == 0x328);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(StatsMenu) == 0x338);
+#else
+	static_assert(sizeof(StatsMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/T/TES.h
+++ b/include/RE/T/TES.h
@@ -96,6 +96,7 @@ namespace RE
 	std::uint64_t unk138;          /* 138 */
 			RUNTIME_DATA_CONTENT
 		};
+		static_assert(sizeof(RUNTIME_DATA) == 0x18);
 
 		// 1130 and later
 		struct AE_RUNTIME_DATA
@@ -109,6 +110,7 @@ namespace RE
 	std::uint64_t unk140;          /* 140 - actual offset change is somewhere near showLandBorder */
 			AE_RUNTIME_DATA_CONTENT
 		};
+		static_assert(sizeof(AE_RUNTIME_DATA) == 0x20);
 
 		struct RUNTIME_DATA2
 		{
@@ -160,6 +162,7 @@ namespace RE
 	std::uint64_t                                   unk2B0;     /* 2B0 */
             RUNTIME_DATA2_CONTENT
 		};
+		static_assert(sizeof(RUNTIME_DATA2) == 0x178);
 
 		[[nodiscard]] inline RUNTIME_DATA* GetRuntimeData() noexcept
 		{
@@ -230,20 +233,22 @@ namespace RE
 		BSSimpleList<NiPointer<ImageSpaceModifierInstance>> activeImageSpaceModifiers;  // 108
 		std::uint64_t                                       unk118;                     // 118
 		std::uint64_t                                       unk120;                     // 120
-#if defined(ENABLE_SKYRIM_AE) && !(defined(ENABLE_SKYRIM_SE) || defined(ENABLE_SKYRIM_VR))
-		AE_RUNTIME_DATA_CONTENT;
-#else
-		RUNTIME_DATA_CONTENT;
+#ifndef ENABLE_SKYRIM_AE
+		RUNTIME_DATA_CONTENT;   // 128
+		RUNTIME_DATA2_CONTENT;  // 140
+#elif !defined(ENABLE_SKYRIM_VR) && !defined(ENABLE_SKYRIM_SE)
+		AE_RUNTIME_DATA_CONTENT;  // 128
+		RUNTIME_DATA2_CONTENT;    // 148
 #endif
-		RUNTIME_DATA2_CONTENT;
-
 	private:
 		KEEP_FOR_RE()
 	};
-#if defined(ENABLE_SKYRIM_AE) && !(defined(ENABLE_SKYRIM_SE) || defined(ENABLE_SKYRIM_VR))
+#ifndef ENABLE_SKYRIM_AE
+	static_assert(sizeof(TES) == 0x2B8);
+#elif !defined(ENABLE_SKYRIM_VR) && !defined(ENABLE_SKYRIM_SE)
 	static_assert(sizeof(TES) == 0x2C0);
 #else
-	static_assert(sizeof(TES) == 0x2B8);
+	static_assert(sizeof(TES) == 0x128);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/T/TESAmmo.h
+++ b/include/RE/T/TESAmmo.h
@@ -41,21 +41,20 @@ namespace RE
 		public TESModelTextureSwap,  // 040
 		public TESIcon,              // 078
 		public BGSMessageIcon,       // 088
-#if !defined(ENABLE_SKYRIM_VR)
-		public TESValueForm,               // 0A0
+		public TESValueForm         // 0A0
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+		,
 		public TESWeightForm,              // 0B0
 		public BGSDestructibleObjectForm,  // 0C0
 		public BGSPickupPutdownSounds,     // 0D0
 		public TESDescription,             // 0E8
 		public BGSKeywordForm              // 0F8
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
-		public TESValueForm,               // 0A0
+#elif defined(EXCLUSIVE_SKYRIM_VR)
+		,
 		public BGSDestructibleObjectForm,  // 0B0
 		public BGSPickupPutdownSounds,     // 0C0
 		public TESDescription,             // 0D8
 		public BGSKeywordForm              // 0E8
-#else
-		public TESValueForm  // 0A0
 #endif
 	{
 	public:
@@ -95,7 +94,7 @@ namespace RE
 		NiAVObject* Clone3D(TESObjectREFR* a_ref, bool a_arg3) override;                 // 40
 		void        HandleRemoveItemFromContainer(TESObjectREFR* a_container) override;  // 4E
 
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		// override (BGSKeywordForm)
 		[[nodiscard]] BGSKeyword* GetDefaultKeyword() const override;  // 05
 #endif
@@ -154,17 +153,17 @@ namespace RE
 		}
 
 		// members
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		RUNTIME_DATA_CONTENT;  // 110
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		RUNTIME_DATA_CONTENT;  // VR 100
 #endif
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(TESAmmo) == 0x128);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(TESAmmo) == 0x118);
 #endif
 }

--- a/include/RE/T/TESAmmo.h
+++ b/include/RE/T/TESAmmo.h
@@ -154,7 +154,11 @@ namespace RE
 		}
 
 		// members
-		RUNTIME_DATA_CONTENT;  // 110, 100
+#if !defined(ENABLE_SKYRIM_VR)
+		RUNTIME_DATA_CONTENT;  // 110
+#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+		RUNTIME_DATA_CONTENT;  // VR 100
+#endif
 	private:
 		KEEP_FOR_RE()
 	};

--- a/include/RE/T/TESDataHandler.h
+++ b/include/RE/T/TESDataHandler.h
@@ -188,7 +188,7 @@ namespace RE
 		std::uint32_t                     padD54;                                         // D54
 		TESFile*                          activeFile;                                     // D58
 		BSSimpleList<TESFile*>            files;                                          // D60
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 		TESFileCollection compiledFileCollection;  // D70
 		RUNTIME_DATA_CONTENT
 		std::uint8_t          unkDAA;             // DAA
@@ -196,7 +196,7 @@ namespace RE
 		std::uint32_t         padDAC;             // DAC
 		TESRegionDataManager* regionDataManager;  // DB0
 		InventoryChanges*     merchantInventory;  // DB8
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		std::uint32_t loadedModCount;    // D70 this should be avoided if SkyrimVRESL is available
 		std::uint32_t pad14;             // D74
 		TESFile*      loadedMods[0xFF];  // D78 this should be avoided if SkyrimVRESL is available

--- a/include/RE/T/TESObjectCONT.h
+++ b/include/RE/T/TESObjectCONT.h
@@ -81,7 +81,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(offsetof(TESObjectCONT, data) == 0xB9);
 	static_assert(sizeof(TESObjectCONT) == 0xD0);
 #endif

--- a/include/RE/T/TESObjectREFR.h
+++ b/include/RE/T/TESObjectREFR.h
@@ -477,6 +477,7 @@ namespace RE
 
 			RUNTIME_DATA_CONTENT
 		};
+		static_assert(sizeof(REFERENCE_RUNTIME_DATA) == 0x10);
 
 		[[nodiscard]] inline REFERENCE_RUNTIME_DATA& GetReferenceRuntimeData() noexcept
 		{
@@ -507,6 +508,8 @@ namespace RE
 	};
 #ifndef ENABLE_SKYRIM_AE
 	static_assert(sizeof(TESObjectREFR) == 0x98);
+#else
+	static_assert(sizeof(TESObjectREFR) == 0x78);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/T/TESObjectREFR.h
+++ b/include/RE/T/TESObjectREFR.h
@@ -313,12 +313,12 @@ namespace RE
 		[[nodiscard]] virtual const BSTSmartPointer<BipedAnim>& GetBiped2() const;                                                                                                                                                                                           // 7F
 		[[nodiscard]] virtual const BSTSmartPointer<BipedAnim>& GetCurrentBiped() const;                                                                                                                                                                                     // 80 - { return GetBiped2(); }
 		virtual void                                            SetBiped(const BSTSmartPointer<BipedAnim>& a_biped);                                                                                                                                                         // 81 - { return; }																																																																			 // Virtual functions defined in TESObjectREFR after the vtable structure becomes different in VR.
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 		SKYRIM_REL_VR_VIRTUAL void AttachWeapon(RE::TESObjectWEAP* a_weapon, bool attachToShieldHand);  // 82 - Virtual in VR, non-virtual in SE/AE. Shield hand may be just left hand?
 #endif
 		SKYRIM_REL_VR_VIRTUAL void RemoveWeapon(BIPED_OBJECT equipIndex);  // 82 - { return; }
 		SKYRIM_REL_VR_VIRTUAL void Unk_83(void);                           // 83 - { return; }
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 		virtual void Unk_84(void);
 #endif
 		SKYRIM_REL_VR_VIRTUAL void                         SetObjectReference(TESBoundObject* a_object);                                         // 84 - sets flag 24 if the object has destructibles

--- a/include/RE/T/TeleportHandler.h
+++ b/include/RE/T/TeleportHandler.h
@@ -30,8 +30,7 @@ namespace RE
 	};
 #	if !defined(ENABLE_SKYRIM_VR)
 	static_assert(sizeof(TeleportHandler) == 0x58);
-	char (*__kaboom)[sizeof(TeleportHandler)] = 1;
-#	elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#	elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(TeleportHandler) == 0x70);
 #	else
 	static_assert(sizeof(TeleportHandler) == 0x58);

--- a/include/RE/T/ThirdPersonState.h
+++ b/include/RE/T/ThirdPersonState.h
@@ -77,9 +77,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-	static_assert(sizeof(ThirdPersonState) == 0xE8);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(ThirdPersonState) == 0x100);
 #else
 	static_assert(sizeof(ThirdPersonState) == 0xE8);

--- a/include/RE/T/TitleSequenceMenu.h
+++ b/include/RE/T/TitleSequenceMenu.h
@@ -20,13 +20,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
+#if defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(TitleSequenceMenu) == 0x40);
-#	else
+#else
 	static_assert(sizeof(TitleSequenceMenu) == 0x30);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
-	static_assert(sizeof(TitleSequenceMenu) == 0x40);
 #endif
 }

--- a/include/RE/T/TogglePOVHandler.h
+++ b/include/RE/T/TogglePOVHandler.h
@@ -23,9 +23,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(TogglePOVHandler) == 0x20);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(TogglePOVHandler) == 0x38);
 #endif
 }

--- a/include/RE/T/ToggleRunHandler.h
+++ b/include/RE/T/ToggleRunHandler.h
@@ -17,9 +17,9 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(ToggleRunHandler) == 0x10);
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(ToggleRunHandler) == 0x28);
 #endif
 }

--- a/include/RE/T/TrainingMenu.h
+++ b/include/RE/T/TrainingMenu.h
@@ -81,14 +81,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(TrainingMenu) == 0x100);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(TrainingMenu) == 0x0F0);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(TrainingMenu) == 0x100);
+#else
+	static_assert(sizeof(TrainingMenu) == 0x30);
 #endif
 }
 

--- a/include/RE/T/TutorialMenu.h
+++ b/include/RE/T/TutorialMenu.h
@@ -44,13 +44,11 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(TutorialMenu) == 0x58);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(TutorialMenu) == 0x48);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(TutorialMenu) == 0x58);
+#else
+	static_assert(sizeof(TutorialMenu) == 0x30);
 #endif
 }

--- a/include/RE/T/TweenMenu.h
+++ b/include/RE/T/TweenMenu.h
@@ -63,14 +63,12 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
-#	ifdef ENABLE_SKYRIM_AE
-	static_assert(sizeof(TweenMenu) == 0x60);
-#	else
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(TweenMenu) == 0x50);
-#	endif
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(TweenMenu) == 0x60);
+#else
+	static_assert(sizeof(TweenMenu) == 0x30);
 #endif
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/U/UI.h
+++ b/include/RE/U/UI.h
@@ -149,7 +149,7 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
 	static_assert(sizeof(UI) == 0x1C8);
 #else
 	static_assert(sizeof(UI) == 0x1D0);

--- a/include/RE/U/UIBlurManager.h
+++ b/include/RE/U/UIBlurManager.h
@@ -32,7 +32,5 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_VR)
 	static_assert(sizeof(UIBlurManager) == 0x20);
-#endif
 }

--- a/include/RE/V/VirtualMachine.h
+++ b/include/RE/V/VirtualMachine.h
@@ -98,13 +98,13 @@ namespace RE
 				void SetCallableFromTasklets1(const char* a_className, const char* a_stateName, const char* a_fnName, bool a_callable) override;                     // 19
 				void SetCallableFromTasklets2(const char* a_className, const char* a_fnName, bool a_callable) override;                                              // 1A - { SetCallableFromTasklets1(a_className, 0, a_fnName, a_callable); }
 				// This is where the vtable differs between AE/SE and VR.
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 				void New_1B(void) override;
 #endif
 #ifndef SKYRIM_CROSS_VR
 				void ForEachBoundObject(VMHandle a_handle, IForEachScriptObjectFunctor* a_functor) override;  // 1B, 1C
 #endif
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 				void New_1D(void) override;
 #endif
 #ifndef SKYRIM_CROSS_VR
@@ -242,9 +242,7 @@ namespace RE
 			private:
 				KEEP_FOR_RE()
 			};
-#if !defined(ENABLE_SKYRIM_VR)
-			//static_assert(sizeof(VirtualMachine) == 0x9518);
-#endif
+			static_assert(sizeof(VirtualMachine) == 0x9518);
 		}
 	}
 }

--- a/include/RE/W/WSActivateRollover.h
+++ b/include/RE/W/WSActivateRollover.h
@@ -30,10 +30,10 @@ namespace RE
 	};
 #	if !defined(ENABLE_SKYRIM_VR)
 	static_assert(sizeof(WSActivateRollover) == 0x68);
-#	elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#	elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(WSActivateRollover) == 0x70);
 #	else
-	static_assert(sizeof(WSActivateRollover) == 0x68);
+	static_assert(sizeof(WSActivateRollover) == 0x58);
 #	endif
 }
 

--- a/include/RE/W/WorldSpaceMenu.h
+++ b/include/RE/W/WorldSpaceMenu.h
@@ -33,7 +33,7 @@ namespace RE
 #endif
 	{
 	public:
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_VR)
 		inline static constexpr auto RTTI = RTTI_WorldSpaceMenu;
 #endif
 		WorldSpaceMenu(bool a_registerHudModeChangeEvent, bool a_matchAsTopMenu, bool a_queueUpdateFixup);
@@ -79,7 +79,11 @@ namespace RE
 	private:
 		KEEP_FOR_RE()
 	};
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+	static_assert(sizeof(WorldSpaceMenu) == 0x48);
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(WorldSpaceMenu) == 0x58);
+#else
+	static_assert(sizeof(WorldSpaceMenu) == 0x40);
 #endif
 }

--- a/include/REL/Common.h
+++ b/include/REL/Common.h
@@ -1,5 +1,35 @@
 #pragma once
 
+#if !defined(ENABLE_SKYRIM_VR) && !defined(ENABLE_SKYRIM_SE) && defined(ENABLE_SKYRIM_AE)
+/**
+ * Defined to indicate that this build only supports AE
+ */
+#define EXCLUSIVE_SKYRIM_AE
+/**
+ * Defined to indicate that this build only supports AE and SE
+ */
+#define EXCLUSIVE_SKYRIM_FLAT
+#elif !defined(ENABLE_SKYRIM_VR) && defined(ENABLE_SKYRIM_SE) && !defined(ENABLE_SKYRIM_AE)
+/**
+ * Defined to indicate that this build only supports SE
+ */
+#define EXCLUSIVE_SKYRIM_SE
+/**
+ * Defined to indicate that this build only supports AE and SE
+ */
+#define EXCLUSIVE_SKYRIM_FLAT
+#elif defined(ENABLE_SKYRIM_VR) && !defined(ENABLE_SKYRIM_SE) && !defined(ENABLE_SKYRIM_AE)
+/**
+ * Defined to indicate that this build only supports VR
+ */
+#define EXCLUSIVE_SKYRIM_VR
+#elif !defined(ENABLE_SKYRIM_VR) && (defined(ENABLE_SKYRIM_SE) || defined(ENABLE_SKYRIM_AE))
+/**
+ * Defined to indicate that this build only supports AE and SE
+ */
+#define EXCLUSIVE_SKYRIM_FLAT
+#endif
+
 #if defined(ENABLE_SKYRIM_VR) && (defined(ENABLE_SKYRIM_AE) || defined(ENABLE_SKYRIM_SE))
 /**
  * Defined to indicate that this build supports both VR and non-VR runtimes.

--- a/include/REL/Module.h
+++ b/include/REL/Module.h
@@ -256,7 +256,7 @@ namespace REL
 		{
 #ifndef ENABLE_SKYRIM_VR
 			return false;
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 			return true;
 #else
 			return GetRuntime() == Runtime::VR;

--- a/include/REL/Relocation.h
+++ b/include/REL/Relocation.h
@@ -469,11 +469,11 @@ namespace REL
 		[[maybe_unused]] T a_ae,
 		[[maybe_unused]] T a_vr) noexcept
 	{
-#if !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_VR)
+#if defined(EXCLUSIVE_SKYRIM_SE)
 		return a_se;
 #elif !defined(ENABLE_SKYRIM_SE) && !defined(ENABLE_SKYRIM_VR)
 		return a_ae;
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 		return a_vr;
 #else
 		switch (Module::get().GetRuntime()) {
@@ -575,7 +575,7 @@ namespace REL
 #ifndef ENABLE_SKYRIM_VR
 												a_seAndAEVtableOffset) +
 			a_seAndAEVtableIndex
-#elif !defined(ENABLE_SKYRIM_AE) && !defined(ENABLE_SKYRIM_SE)
+#elif defined(EXCLUSIVE_SKYRIM_VR)
 												a_vrVtableOffset) +
 			a_vrVtableIndex
 #else

--- a/src/RE/I/IMenu.cpp
+++ b/src/RE/I/IMenu.cpp
@@ -94,7 +94,7 @@ namespace RE
 #ifdef ENABLE_SKYRIM_VR
 	void IMenu::Unk_09(UI_MENU_Unk09 a_unk)
 	{
-		unk30 = a_unk;
+		GetVRRuntimeData().unk30 = a_unk;
 	}
 
 	void IMenu::Unk_0A()

--- a/src/RE/N/NiAVObject.cpp
+++ b/src/RE/N/NiAVObject.cpp
@@ -236,14 +236,14 @@ namespace RE
 		auto                                gState = BSGraphics::State::GetSingleton();
 		BSTSmartPointer<BSEffectShaderData> newShaderData(new BSEffectShaderData());
 		newShaderData->fillColor = a_color;
-		newShaderData->baseTexture = gState->defaultTextureWhite;
+		newShaderData->baseTexture = gState->GetRuntimeData().defaultTextureWhite;
 
 		BSVisit::TraverseScenegraphGeometries(this, [&](BSGeometry* a_geometry) -> BSVisit::BSVisitControl {
 			auto effect = a_geometry->GetGeometryRuntimeData().properties[BSGeometry::States::kEffect];
 			auto shaderProp = netimmerse_cast<BSShaderProperty*>(effect.get());
 			if (shaderProp && shaderProp->AcceptsEffectData()) {
 				auto shaderData = shaderProp->effectData;
-				if (!shaderData || shaderData->baseTexture == gState->defaultTextureWhite) {
+				if (!shaderData || shaderData->baseTexture == gState->GetRuntimeData().defaultTextureWhite) {
 					shaderProp->SetEffectShaderData(newShaderData);
 				}
 			}

--- a/src/RE/P/Projectile.cpp
+++ b/src/RE/P/Projectile.cpp
@@ -222,7 +222,7 @@ namespace RE
 	}
 
 	Projectile::LaunchData::LaunchData(Actor* a_shooter, const NiPoint3& a_origin, const ProjectileRot& a_angles, TESAmmo* a_ammo, TESObjectWEAP* a_weap) :
-		LaunchData(a_ammo->data.projectile, a_shooter, a_origin, a_angles)
+		LaunchData(a_ammo->GetRuntimeData().data.projectile, a_shooter, a_origin, a_angles)
 	{
 		weaponSource = a_weap;
 		ammoSource = a_ammo;

--- a/src/RE/T/TES.cpp
+++ b/src/RE/T/TES.cpp
@@ -38,10 +38,12 @@ namespace RE
 				} while (x < gridLength);
 			}
 		}
-		if (const auto skyCell = worldSpace ? worldSpace->GetSkyCell() : nullptr; skyCell) {
-			skyCell->ForEachReference([&](TESObjectREFR* a_ref) {
-				return a_callback(a_ref);
-			});
+		if (const auto ws = GetRuntimeData2().worldSpace) {
+			if (const auto skyCell = ws ? ws->GetSkyCell() : nullptr; skyCell) {
+				skyCell->ForEachReference([&](TESObjectREFR* a_ref) {
+					return a_callback(a_ref);
+				});
+			}
 		}
 	}
 
@@ -81,11 +83,12 @@ namespace RE
 					} while (x < gridLength);
 				}
 			}
-
-			if (const auto skyCell = worldSpace ? worldSpace->GetSkyCell() : nullptr; skyCell) {
-				skyCell->ForEachReferenceInRange(originPos, a_radius, [&](TESObjectREFR* a_ref) {
-					return a_callback(a_ref);
-				});
+			if (const auto ws = GetRuntimeData2().worldSpace) {
+				if (const auto skyCell = ws ? ws->GetSkyCell() : nullptr; skyCell) {
+					skyCell->ForEachReferenceInRange(originPos, a_radius, [&](TESObjectREFR* a_ref) {
+						return a_callback(a_ref);
+					});
+				}
 			}
 		} else {
 			ForEachReference([&](TESObjectREFR* a_ref) {

--- a/src/RE/T/TESAmmo.cpp
+++ b/src/RE/T/TESAmmo.cpp
@@ -4,11 +4,11 @@ namespace RE
 {
 	bool TESAmmo::IgnoresNormalWeaponResistance()
 	{
-		return data.flags.all(AMMO_DATA::Flag::kIgnoresNormalWeaponResistance);
+		return GetRuntimeData().data.flags.all(AMMO_DATA::Flag::kIgnoresNormalWeaponResistance);
 	}
 
 	bool TESAmmo::IsBolt()
 	{
-		return data.flags.none(AMMO_DATA::Flag::kNonBolt);
+		return GetRuntimeData().data.flags.none(AMMO_DATA::Flag::kNonBolt);
 	}
 }

--- a/src/RE/W/WorldSpaceMenu.cpp
+++ b/src/RE/W/WorldSpaceMenu.cpp
@@ -16,7 +16,7 @@ namespace RE
 			menuNode.reset();
 		}
 
-		menuName.~BSFixedString();
+		GetVRRuntimeData().menuName.~BSFixedString();
 		fxDelegate.reset();
 		uiMovie.reset();
 	}
@@ -79,12 +79,12 @@ namespace RE
 			RE::IMenu* topMenu = 0;
 			UI::GetSingleton()->GetTopMostMenu(&topMenu, 15);
 			if (topMenu &&
-				topMenu->menuName == InterfaceStrings::GetSingleton()->hudMenu &&
+				topMenu->GetVRRuntimeData().menuName == InterfaceStrings::GetSingleton()->hudMenu &&
 				a_message->menu == InterfaceStrings::GetSingleton()->topMenu) {
 				isTopMenu = true;
 			}
 		}
-		return isTopMenu || a_message->menu == menuName;
+		return isTopMenu || a_message->menu == GetVRRuntimeData().menuName;
 	}
 }
 #endif


### PR DESCRIPTION
Fixes:
- [Add some runtime protection and fix some possible crashes](https://github.com/alandtse/CommonLibVR/commit/ede74e6983f216c8f6dc1f0627e1f0a265707734)
  - This will fix being able to access `Renderer, State, Tes` data directly without using `GetRuntimeData*` when using ALL mode
- [Fix PlayerCharacter inheritence and sizes](https://github.com/alandtse/CommonLibVR/commit/317bd7405208bd6ec801b9e9e2eead8349081a49)
  - Fix inheritence to match commonlibsse and ida classinformer structures
  
Refactors:
- [Cleanup defines and sizes for NG](https://github.com/alandtse/CommonLibVR/commit/3c061d1586636d4082cd7ea7bc8a52e1f9b11360)
  - Added new defines `EXCLUSIVE_SKYRIM_AE, EXCLUSIVE_SKYRIM_SE, EXCLUSIVE_SKYRIM_VR,EXCLUSIVE_SKYRIM_FLAT` to simplify defines. A lot easier to see why data is not showing up when running specific build.
  - This was verified with running `build-debug-msvc-vcpkg-all, build-debug-msvc-vcpkg-vr, build-debug-msvc-vcpkg-ae, build-debug-msvc-vcpkg-se, build-debug-msvc-vcpkg-flatrim` cmake presets (pretty sure some of these didn't build before my changes as well
  - Added `GetVRRuntimeData` for VR specific data in IMenu (NG have wrong sizes for Flatrim now and can access undefined vr data)

I have a clean commit history so this PR can be merged without squash to seperate the logic