### PR TITLE
fix: fix exclusive build for FLAT or VR

### DIFF
--- a/include/RE/S/ShadowState.h
+++ b/include/RE/S/ShadowState.h
@@ -266,13 +266,10 @@ namespace RE
 				return g_RendererShadowState;
 			}
 
-#define GET_RUNTIME_MEMBER(a_value) \
-	auto& a_value = !REL::Module::IsVR() ? GetRuntimeData().a_value : GetVRRuntimeData().a_value;
-
 			void SetPSTexture(size_t textureIndex, BSGraphics::Texture* newTexture)
 			{
-				GET_RUNTIME_MEMBER(PSTexture)
-				GET_RUNTIME_MEMBER(PSResourceModifiedBits)
+				GET_CROSSVR_RUNTIME_MEMBER(PSTexture)
+				GET_CROSSVR_RUNTIME_MEMBER(PSResourceModifiedBits)
 				ID3D11ShaderResourceView* resourceView = newTexture ? newTexture->resourceView : nullptr;
 				if (PSTexture[textureIndex] != resourceView) {
 					PSTexture[textureIndex] = resourceView;
@@ -282,8 +279,8 @@ namespace RE
 
 			void SetPSTexture(size_t textureIndex, const BSGraphics::RenderTargetData& newTexture)
 			{
-				GET_RUNTIME_MEMBER(PSTexture)
-				GET_RUNTIME_MEMBER(PSResourceModifiedBits)
+				GET_CROSSVR_RUNTIME_MEMBER(PSTexture)
+				GET_CROSSVR_RUNTIME_MEMBER(PSResourceModifiedBits)
 				ID3D11ShaderResourceView* resourceView = newTexture.SRV;
 				if (PSTexture[textureIndex] != resourceView) {
 					PSTexture[textureIndex] = resourceView;
@@ -293,8 +290,8 @@ namespace RE
 
 			void SetPSTextureAddressMode(size_t textureIndex, TextureAddressMode newAddressMode)
 			{
-				GET_RUNTIME_MEMBER(PSTextureAddressMode)
-				GET_RUNTIME_MEMBER(PSSamplerModifiedBits)
+				GET_CROSSVR_RUNTIME_MEMBER(PSTextureAddressMode)
+				GET_CROSSVR_RUNTIME_MEMBER(PSSamplerModifiedBits)
 				if (PSTextureAddressMode[textureIndex] != newAddressMode) {
 					PSTextureAddressMode[textureIndex] = newAddressMode;
 					PSSamplerModifiedBits |= (1 << textureIndex);
@@ -303,8 +300,8 @@ namespace RE
 
 			void SetPSTextureFilterMode(size_t textureIndex, TextureFilterMode newFilterMode)
 			{
-				GET_RUNTIME_MEMBER(PSTextureFilterMode)
-				GET_RUNTIME_MEMBER(PSSamplerModifiedBits)
+				GET_CROSSVR_RUNTIME_MEMBER(PSTextureFilterMode)
+				GET_CROSSVR_RUNTIME_MEMBER(PSSamplerModifiedBits)
 				if (PSTextureFilterMode[textureIndex] != newFilterMode) {
 					PSTextureFilterMode[textureIndex] = newFilterMode;
 					PSSamplerModifiedBits |= (1 << textureIndex);
@@ -313,8 +310,8 @@ namespace RE
 
 			void SetVertexShader(VertexShader* shader)
 			{
-				GET_RUNTIME_MEMBER(stateUpdateFlags)
-				GET_RUNTIME_MEMBER(currentVertexShader)
+				GET_CROSSVR_RUNTIME_MEMBER(stateUpdateFlags)
+				GET_CROSSVR_RUNTIME_MEMBER(currentVertexShader)
 				stateUpdateFlags |= ShaderFlags::DIRTY_VERTEX_DESC;
 				currentVertexShader = shader;
 				if (shader != nullptr) {
@@ -324,7 +321,7 @@ namespace RE
 
 			void SetPixelShader(PixelShader* shader)
 			{
-				GET_RUNTIME_MEMBER(currentPixelShader)
+				GET_CROSSVR_RUNTIME_MEMBER(currentPixelShader)
 				currentPixelShader = shader;
 				if (shader != nullptr) {
 					Renderer::GetSingleton()->GetRuntimeData().context->PSSetShader(shader->shader, nullptr, 0);
@@ -333,20 +330,20 @@ namespace RE
 
 			ConstantGroup& GetVSConstantGroup(ConstantGroupLevel level)
 			{
-				GET_RUNTIME_MEMBER(currentVertexShader)
+				GET_CROSSVR_RUNTIME_MEMBER(currentVertexShader)
 				return currentVertexShader->constantBuffers[static_cast<size_t>(level)];
 			}
 
 			ConstantGroup& GetPSConstantGroup(ConstantGroupLevel level)
 			{
-				GET_RUNTIME_MEMBER(currentPixelShader)
+				GET_CROSSVR_RUNTIME_MEMBER(currentPixelShader)
 				return currentPixelShader->constantBuffers[static_cast<size_t>(level)];
 			}
 
 			template <typename ValueType>
 			void SetVSConstant(const ValueType& value, ConstantGroupLevel level, size_t index)
 			{
-				GET_RUNTIME_MEMBER(currentVertexShader)
+				GET_CROSSVR_RUNTIME_MEMBER(currentVertexShader)
 				const int8_t offset = currentVertexShader->constantTable[index];
 				*reinterpret_cast<ValueType*>((reinterpret_cast<float*>(currentVertexShader->constantBuffers[static_cast<size_t>(level)].data) + offset)) = value;
 			}
@@ -354,7 +351,7 @@ namespace RE
 			template <typename ValueType>
 			void SetPSConstant(const ValueType& value, ConstantGroupLevel level, size_t index)
 			{
-				GET_RUNTIME_MEMBER(currentPixelShader)
+				GET_CROSSVR_RUNTIME_MEMBER(currentPixelShader)
 				const int8_t offset = currentPixelShader->constantTable[index];
 				*reinterpret_cast<ValueType*>((reinterpret_cast<float*>(currentPixelShader->constantBuffers[static_cast<size_t>(level)].data) + offset)) = value;
 			}

--- a/include/REL/Common.h
+++ b/include/REL/Common.h
@@ -37,6 +37,41 @@
 #define SKYRIM_CROSS_VR
 #endif
 
+/**
+ * Macros used for utils in CLIB-NG using GetRuntimeData | GetVRRuntimeData
+ */
+#if defined(EXCLUSIVE_SKYRIM_VR)
+#	define GET_CROSSVR_RUNTIME_MEMBER(a_value)
+#	define GET_CROSSVR_INSTANCE_MEMBER(a_value, a_source)
+#elif defined(EXCLUSIVE_SKYRIM_FLAT)
+#	define GET_CROSSVR_RUNTIME_MEMBER(a_value)
+#	define GET_CROSSVR_INSTANCE_MEMBER(a_value, a_source)
+#else
+/**
+ @def GET_CROSSVR_RUNTIME_MEMBER
+ @brief Set variable in current namespace based on instance member from GetRuntimeData or GetVRRuntimeData.
+  
+ @warning The class must have both a GetRuntimeData() and GetVRRuntimeData() function.
+  
+ @param a_value The instance member value to access (e.g., renderTargets).
+ @result The a_value will be set as a variable in the current namespace. (e.g., auto& renderTargets = GetVRRuntimeData().renderTargets; for vr)
+ */
+#	define GET_CROSSVR_RUNTIME_MEMBER(a_value) \
+	auto& a_value = !REL::Module::IsVR() ? GetRuntimeData().a_value : GetVRRuntimeData().a_value;
+/**
+ @def GET_CROSSVR_INSTANCE_MEMBER
+ @brief Set variable in current namespace based on instance member from GetRuntimeData or GetVRRuntimeData.
+  
+ @warning The class must have both a GetRuntimeData() and GetVRRuntimeData() function.
+  
+ @param a_value The instance member value to access (e.g., renderTargets).
+ @param a_source The instance of the class (e.g., state).
+ @result The a_value will be set as a variable in the current namespace. (e.g., auto& renderTargets = state->GetVRRuntimeData().renderTargets; for vr)
+ */
+#	define GET_CROSSVR_INSTANCE_MEMBER(a_value, a_source) \
+	auto& a_value = !REL::Module::IsVR() ? a_source->GetRuntimeData().a_value : a_source->GetVRRuntimeData().a_value;
+#endif
+
 #if !defined(ENABLE_SKYRIM_AE) || (!defined(ENABLE_SKYRIM_SE) && !defined(ENABLE_SKYRIM_VR))
 /**
  * A macro which defines a modifier for expressions that vary by Skyrim Address Library IDs.


### PR DESCRIPTION
Fixes build for exclusive FLAT or VR by moving the macro to `REL/Common.h` and adding empty defines for those cases.