### PR TITLE
fix: move utils to correct place

### DIFF
--- a/include/RE/B/BSLightingShaderProperty.h
+++ b/include/RE/B/BSLightingShaderProperty.h
@@ -6,6 +6,9 @@
 
 namespace RE
 {
+	class BSShader;
+	class BSLight;
+
 	class BSLightingShaderProperty : public BSShaderProperty
 	{
 	public:
@@ -15,8 +18,14 @@ namespace RE
 
 		struct Data
 		{
-			std::uint64_t unk00;  // 00
-			std::uint64_t unk08;  // 08
+			void          Clear();
+			BSRenderPass* EmplacePass(BSShader* a_shader, BSShaderProperty* a_property, BSGeometry* a_geometry,
+				uint32_t a_technique, uint8_t a_numLights = 0, BSLight* a_light0 = nullptr, BSLight* a_light1 = nullptr,
+				BSLight* a_light2 = nullptr, BSLight* a_light3 = nullptr);
+
+			// members
+			RE::BSRenderPass* head;   // 00
+			std::uint64_t     unk08;  // 08
 		};
 		static_assert(sizeof(Data) == 0x10);
 

--- a/include/RE/B/BSRenderPass.h
+++ b/include/RE/B/BSRenderPass.h
@@ -17,6 +17,13 @@ namespace RE
 		};
 		static_assert(sizeof(LODMode) == 0x1);
 
+		void ClearRenderPass()
+		{
+			using func_t = decltype(&BSRenderPass::ClearRenderPass);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(100718, 107498) };
+			func(this);
+		}
+
 		// members
 		BSShader*         shader;            // 00
 		BSShaderProperty* shaderProperty;    // 08

--- a/include/RE/B/BSShader.h
+++ b/include/RE/B/BSShader.h
@@ -14,6 +14,9 @@ namespace RE
 {
 	class BSRenderPass;
 	class BSShaderMaterial;
+	class BSShaderProperty;
+	class BSGeometry;
+	class BSLight;
 
 	namespace BSGraphics
 	{
@@ -128,6 +131,13 @@ namespace RE
 		virtual void RestoreGeometry(BSRenderPass* a_currentPass, std::uint32_t a_renderFlags) = 0;              // 07
 		virtual void GetTechniqueName(std::uint32_t a_techniqueID, char* a_buffer, std::uint32_t a_bufferSize);  // 08
 		virtual void ReloadShaders(bool a_clear);                                                                // 09
+
+		RE::BSRenderPass* MakeRenderPass(BSShaderProperty* property, BSGeometry* geometry, uint32_t technique, uint8_t numLights, BSLight** lights)
+		{
+			using func_t = decltype(&BSShader::MakeRenderPass);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(100717, 107497) };
+			return func(this, property, geometry, technique, numLights, lights);
+		}
 
 		// members
 		stl::enumeration<Type, std::int32_t>                       shaderType;     // 20

--- a/include/RE/B/BSShaderProperty.h
+++ b/include/RE/B/BSShaderProperty.h
@@ -12,8 +12,6 @@ namespace RE
 	class BSShaderMaterial;
 	class BSShaderPropertyLightData;
 	class NiSourceTexture;
-	class BSShader;
-	class BSLight;
 
 	class BSShaderProperty : public NiShadeProperty
 	{
@@ -39,13 +37,6 @@ namespace RE
 
 		struct RenderPassArray
 		{
-			BSRenderPass* MakeRenderPass(BSShader* a_shader, BSShaderProperty* a_property, BSGeometry* a_geometry, uint32_t a_technique, uint8_t a_numLights, BSLight** a_lights);
-			void          ClearRenderPass(BSRenderPass* a_pass);
-			void          Clear();
-			BSRenderPass* EmplacePass(BSShader* a_shader, BSShaderProperty* a_property, BSGeometry* a_geometry,
-				uint32_t a_technique, uint8_t a_numLights = 0, BSLight* a_light0 = nullptr, BSLight* a_light1 = nullptr,
-				BSLight* a_light2 = nullptr, BSLight* a_light3 = nullptr);
-
 			BSRenderPass* head;  // 00
 		};
 		static_assert(sizeof(RenderPassArray) == 0x8);

--- a/src/RE/B/BSLightingShaderProperty.cpp
+++ b/src/RE/B/BSLightingShaderProperty.cpp
@@ -1,5 +1,8 @@
 #include "RE/B/BSLightingShaderProperty.h"
 
+#include "RE/B/BSRenderPass.h"
+#include "RE/B/BSShader.h"
+
 namespace RE
 {
 	void BSLightingShaderProperty::CopyMembers(BSLightingShaderProperty* a_other)
@@ -27,4 +30,36 @@ namespace RE
 		func(this, a_unk1);
 	}
 #endif
+
+	void BSLightingShaderProperty::Data::Clear()
+	{
+		while (head != nullptr) {
+			BSRenderPass* next = head->next;
+			head->ClearRenderPass();
+			head = next;
+		}
+		head = nullptr;
+	}
+
+	BSRenderPass* BSLightingShaderProperty::Data::EmplacePass(BSShader* a_shader, BSShaderProperty* a_property, BSGeometry* a_geometry,
+		uint32_t a_technique, uint8_t a_numLights, BSLight* a_light0, BSLight* a_light1, BSLight* a_light2, BSLight* a_light3)
+	{
+		BSLight* lights[4]{
+			a_light0,
+			a_light1,
+			a_light2,
+			a_light3
+		};
+		auto* newPass = a_shader->MakeRenderPass(a_property, a_geometry, a_technique, a_numLights, lights);
+		if (head != nullptr) {
+			RE::BSRenderPass* lastPass = head;
+			while (lastPass->next != nullptr) {
+				lastPass = lastPass->next;
+			}
+			lastPass->next = newPass;
+		} else {
+			head = newPass;
+		}
+		return newPass;
+	}
 }

--- a/src/RE/B/BSShaderProperty.cpp
+++ b/src/RE/B/BSShaderProperty.cpp
@@ -1,7 +1,5 @@
 #include "RE/B/BSShaderProperty.h"
 
-#include "RE/B/BSRenderPass.h"
-
 namespace RE
 {
 #ifdef ENABLE_SKYRIM_VR
@@ -45,51 +43,5 @@ namespace RE
 		auto vtable = REL::Relocation<void***>(BSShaderProperty::VTABLE[0]);
 		auto baseMethod = reinterpret_cast<void (*)(BSShaderProperty*, NiStream&)>((vtable.get()[0x18]));
 		return baseMethod(this, stream);
-	}
-
-	BSRenderPass* BSShaderProperty::RenderPassArray::MakeRenderPass(BSShader* a_shader, BSShaderProperty* a_property, BSGeometry* a_geometry, uint32_t a_technique, uint8_t a_numLights, BSLight** a_lights)
-	{
-		using func_t = decltype(&BSShaderProperty::RenderPassArray::MakeRenderPass);
-		static REL::Relocation<func_t> func{ RELOCATION_ID(100717, 107497) };
-		return func(this, a_shader, a_property, a_geometry, a_technique, a_numLights, a_lights);
-	}
-
-	void BSShaderProperty::RenderPassArray::ClearRenderPass(BSRenderPass* a_pass)
-	{
-		using func_t = decltype(&RenderPassArray::ClearRenderPass);
-		static REL::Relocation<func_t> func{ RELOCATION_ID(100718, 107498) };
-		func(this, a_pass);
-	}
-
-	void BSShaderProperty::RenderPassArray::Clear()
-	{
-		while (head != nullptr) {
-			BSRenderPass* next = head->next;
-			ClearRenderPass(head);
-			head = next;
-		}
-		head = nullptr;
-	}
-
-	BSRenderPass* BSShaderProperty::RenderPassArray::EmplacePass(BSShader* a_shader, BSShaderProperty* a_property, BSGeometry* a_geometry,
-		uint32_t a_technique, uint8_t a_numLights, BSLight* a_light0, BSLight* a_light1, BSLight* a_light2, BSLight* a_light3)
-	{
-		BSLight* lights[4]{
-			a_light0,
-			a_light1,
-			a_light2,
-			a_light3
-		};
-		auto* newPass = MakeRenderPass(a_shader, a_property, a_geometry, a_technique, a_numLights, lights);
-		if (head != nullptr) {
-			RE::BSRenderPass* lastPass = head;
-			while (lastPass->next != nullptr) {
-				lastPass = lastPass->next;
-			}
-			lastPass->next = newPass;
-		} else {
-			head = newPass;
-		}
-		return newPass;
 	}
 }


### PR DESCRIPTION
This is a cherry pick from https://github.com/powerof3/CommonLibSSE/commit/813dd0ac817bc16d83b9116dbb83f30a0ad0597b

Need this change for community shaders to run https://github.com/doodlum/skyrim-community-shaders/pull/385