### PR TITLE
Fix `HUDMenu` name

### DIFF
--- a/include/RE/H/HUDMenu.h
+++ b/include/RE/H/HUDMenu.h
@@ -78,7 +78,7 @@ namespace RE
 	{
 	public:
 		inline static constexpr auto      RTTI = RTTI_HUDMenu;
-		constexpr static std::string_view MENU_NAME = "VR/VR_HMD_info";
+		constexpr static std::string_view MENU_NAME = "HUD Menu";
 
 		~HUDMenu() override;  // 00
 


### PR DESCRIPTION
This is tested in game, the previous `MENU_NAME` does not return `HUDMenu` object.