### PR TITLE
fix: fix check for successful ID mapping

### DIFF
--- a/include/REL/ID.h
+++ b/include/REL/ID.h
@@ -140,7 +140,7 @@ namespace REL
 				[](auto&& a_lhs, auto&& a_rhs) {
 					return a_lhs.id < a_rhs.id;
 				});
-			if (it == _id2offset.end()) {
+			if (it->id != a_id) {
 				stl::report_and_fail(
 					std::format(
 						"Failed to find the id within the address library: {}\n"

--- a/include/REL/ID.h
+++ b/include/REL/ID.h
@@ -144,8 +144,8 @@ namespace REL
 				stl::report_and_fail(
 					std::format(
 						"Failed to find the id within the address library: {}\n"
-						"This means this script extender plugin is incompatible with the address "
-						"library for this version of the game, and thus does not support it."sv,
+						"This means that this script extender plugin needs a newer version of the "
+						"library than you currently have."sv,
 						a_id));
 			}
 


### PR DESCRIPTION
Should we consider changing the verbiage of the error message up to avoid users thinking the plugin doesn't actually support VR, since it is more likely that they just need to update their Address Library install if they are seeing this message?