### PR TITLE
feat: xmake | support plugin installation and packaging

### DIFF
--- a/xmake-extra.lua
+++ b/xmake-extra.lua
@@ -10,7 +10,7 @@ SKSEPluginInfo(
     .RuntimeCompatibility = ${PLUGIN_RUNTIME_COMPATIBILITY}
 )]]
 
-local PLUGIN_VERSION_FILE = [[
+local PLUGIN_RC_FILE = [[
 #include <winres.h>
 
 1 VERSIONINFO
@@ -68,6 +68,15 @@ rule("commonlibsse-ng.plugin")
 
         target:set("arch", "x64")
         target:set("kind", "shared")
+
+        target:add("installfiles", target:targetfile(), { prefixdir = "SKSE/Plugins" })
+        target:add("installfiles", target:symbolfile(), { prefixdir = "SKSE/Plugins" })
+
+        if os.getenv("XSE_TES5_MODS_PATH") then
+            target:set("installdir", path.join(os.getenv("XSE_TES5_MODS_PATH"), target:name()))
+        elseif os.getenv("XSE_TES5_GAME_PATH") then
+            target:set("installdir", path.join(os.getenv("XSE_TES5_GAME_PATH"), "Data"))
+        end
 
         local conf = target:extraconf("rules", "commonlibsse-ng.plugin")
         local conf_dir = path.join(target:autogendir(), "rules", "commonlibsse-ng", "plugin")
@@ -129,5 +138,54 @@ rule("commonlibsse-ng.plugin")
         end
 
         add_file("plugin.cpp", PLUGIN_FILE)
-        add_file("version.rc", PLUGIN_VERSION_FILE)
+        add_file("version.rc", PLUGIN_RC_FILE)
+    end)
+
+    on_install(function(target)
+        local srcfiles, dstfiles = target:installfiles()
+        if srcfiles and #srcfiles > 0 and dstfiles and #dstfiles > 0 then
+            for idx, srcfile in ipairs(srcfiles) do
+                os.trycp(srcfile, dstfiles[idx])
+            end
+        end
+    end)
+
+    on_package(function(target)
+        import("core.project.config")
+        import("core.project.project")
+        import("utils.archive")
+
+        local archive_name = target:name() .. "-" .. (target:version() or "0.0.0") .. ".zip"
+        print("packing %s .. ", archive_name)
+
+        local root_dir = path.join(os.tmpdir(), "packages", project.name() or "", target:name())
+        os.tryrm(root_dir)
+
+        local srcfiles, dstfiles = target:installfiles(path.join(root_dir, "Data"))
+        if srcfiles and #srcfiles > 0 and dstfiles and #dstfiles > 0 then
+            for idx, srcfile in ipairs(srcfiles) do
+                os.trycp(srcfile, dstfiles[idx])
+            end
+        else
+            return
+        end
+
+        local archive_path = path.join(config.buildir(), "packages", archive_name)
+        local old_dir = os.cd(root_dir)
+        local archive_files = os.files("**")
+        os.cd(old_dir)
+        archive.archive(path.absolute(archive_path), archive_files, { curdir = root_dir })
+    end)
+
+    after_build(function(target)
+        import("core.project.depend")
+        import("core.project.project")
+        import("core.project.task")
+
+        depend.on_changed(function()
+            local srcfiles, dstfiles = target:installfiles()
+            if srcfiles and #srcfiles > 0 and dstfiles and #dstfiles > 0 then 
+                task.run("install")
+            end
+        end, { changed = target:is_rebuilt(), files = { target:targetfile() } })
     end)

--- a/xmake.lua
+++ b/xmake.lua
@@ -12,7 +12,7 @@ set_warnings("allextra")
 set_encodings("utf-8")
 
 -- add rules
-add_rules("mode.debug", "mode.release")
+add_rules("mode.debug", "mode.releasedbg")
 
 -- define options
 option("skyrim_se")
@@ -62,6 +62,9 @@ target("commonlibsse-ng")
     -- set target kind
     set_kind("static")
 
+    -- set build by default
+    set_default(os.scriptdir() == os.projectdir())
+
     -- add packages
     add_packages("directxmath", "directxtk", "spdlog", { public = true })
 
@@ -78,7 +81,7 @@ target("commonlibsse-ng")
     add_options("skyrim_se", "skyrim_ae", "skyrim_vr", "skse_xbyak", "tests", { public = true })
 
     -- add system links
-    add_syslinks("advapi32", "d3d11", "d3dcompiler", "dbghelp", "dxgi", "ole32", "shell32", "user32", "version")
+    add_syslinks("advapi32", "bcrypt", "d3d11", "d3dcompiler", "dbghelp", "dxgi", "ole32", "shell32", "user32", "version")
 
     -- add source files
     add_files("src/**.cpp")
@@ -162,6 +165,9 @@ if has_config("tests") then
     target("commonlibsse-ng-tests")
         -- set target kind
         set_kind("binary")
+
+        -- set build by default
+        set_default(os.scriptdir() == os.projectdir())
 
         -- add dependencies
         add_deps("commonlibsse-ng")


### PR DESCRIPTION
- when you build (or run `xmake install`) it will search for the environment variable `XSE_TES5_MODS_PATH` or `XSE_TES5_GAME_PATH` and copy install files (by default ".dll" and ".pdb") to the root path listed. More files can be added using `add_installfiles`.
  - the install path above can be overwritten using `set_installdir`
- when you run `xmake package` it will package the same files from above into a zip archive named after the target and the version.
- these events can be overwritten on a per-target basis if you wish to make your own install/package logic.

**_other_**
- don't build by default if library is being used as a subproject
- change `release` to `releasedbg`