### PR TITLE
fix: AE relocation ID for BGSFootstepManager::GetSingleton() was changed

### DIFF
--- a/src/RE/B/BGSFootstepManager.cpp
+++ b/src/RE/B/BGSFootstepManager.cpp
@@ -4,7 +4,7 @@ namespace RE
 {
 	BGSFootstepManager* BGSFootstepManager::GetSingleton()
 	{
-		static REL::Relocation<BGSFootstepManager**> singleton{ RELOCATION_ID(517045, 401262) };
+		static REL::Relocation<BGSFootstepManager**> singleton{ RELOCATION_ID(517045, 403553) };
 		return *singleton;
 	}
 }


### PR DESCRIPTION
Needs to be updated in the ng branch too. Let me know if you prefer another PR for that.