### PR TITLE
Revert possible incorrect relocation to test SHSE

### DIFF
--- a/src/RE/T/TESObjectREFR.cpp
+++ b/src/RE/T/TESObjectREFR.cpp
@@ -59,7 +59,7 @@ namespace RE
 	bool TESObjectREFR::ActivateRef(TESObjectREFR* a_activator, uint8_t a_arg2, TESBoundObject* a_object, int32_t a_count, bool a_defaultProcessingOnly)
 	{
 		using func_t = decltype(&TESObjectREFR::ActivateRef);
-		static REL::Relocation<func_t> func{ RELOCATION_ID(19369, 20221) };
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19369, 19796) };
 		return func(this, a_activator, a_arg2, a_object, a_count, a_defaultProcessingOnly);
 	}
 


### PR DESCRIPTION
This relocation for ActivateRef appears to be wrong. I tested with the alandtse version and my autooot mod Smart Harvest SE that calls this **all the time** fails to autoloot.
I tested with this patch and the mod now works again.
My two cents: looks to me like a bad cut-and-paste from the new relocation just below for _AddLock_