### PR TITLE
fix: add getters to BSShadowDirectionalLight

### DIFF
--- a/include/RE/B/BSShadowDirectionalLight.h
+++ b/include/RE/B/BSShadowDirectionalLight.h
@@ -8,6 +8,22 @@ namespace RE
 	{
 	public:
 		inline static constexpr auto RTTI = RTTI_BSShadowDirectionalLight;
+		inline static constexpr auto VTABLE = VTABLE_BSShadowDirectionalLight;
+
+		struct RUNTIME_DATA
+		{
+#define RUNTIME_DATA_CONTENT                                                            \
+	NiPoint3                              lightDirection;             /* 560, VR 5C0 */ \
+	NiPoint3                              previousLightDirection;     /* 56C, VR 5CC */ \
+	NiPointer<NiCamera>                   cullingCamera;              /* 578, VR 5D8 */ \
+	BSTArray<NiPointer<BSCullingProcess>> cullingProcesses;           /* 580, VR 5E0 */ \
+	float                                 startSplitDistances[3];     /* 598, VR 5F8 */ \
+	float                                 endSplitDistances[3];       /* 5A4, VR 604 */ \
+	float                                 lightDirectionUpdateTimer;  /* 5B0, VR 610 */ \
+	bool                                  cameraShifted;              /* 5B4, VR 614 */
+			RUNTIME_DATA_CONTENT
+		};
+		static_assert(sizeof(RUNTIME_DATA) == 0x58);
 
 		~BSShadowDirectionalLight() override;  // 00
 
@@ -22,15 +38,20 @@ namespace RE
 		void Unk_0F() override;                                                                                                // 0F
 		bool SetFrameCamera(const NiCamera& frameCamera) override;                                                             // 10
 
+		[[nodiscard]] inline RUNTIME_DATA& GetShadowDirectionalLightRuntimeData() noexcept
+		{
+			return REL::RelocateMember<RUNTIME_DATA>(this, 0x560, 0x5C0);
+		}
+
+		[[nodiscard]] inline const RUNTIME_DATA& GetShadowDirectionalLightRuntimeData() const noexcept
+		{
+			return REL::RelocateMember<RUNTIME_DATA>(this, 0x560, 0x5C0);
+		}
+
 		// members
-		NiPoint3                              lightDirection;             // 560
-		NiPoint3                              previousLightDirection;     // 56C
-		NiPointer<NiCamera>                   cullingCamera;              // 578
-		BSTArray<NiPointer<BSCullingProcess>> cullingProcesses;           // 580
-		float                                 startSplitDistances[3];     // 598
-		float                                 endSplitDistances[3];       // 5A4
-		float                                 lightDirectionUpdateTimer;  // 5B0
-		bool                                  cameraShifted;              // 5B4
+#ifndef SKYRIM_CROSS_VR
+		RUNTIME_DATA_CONTENT; // 560, VR 5C0
+#endif 
 	private:
 		KEEP_FOR_RE()
 	};
@@ -39,6 +60,7 @@ namespace RE
 #elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(BSShadowDirectionalLight) == 0x618);
 #else
-	static_assert(sizeof(BSShadowDirectionalLight) == 0x1A0);
+	static_assert(sizeof(BSShadowDirectionalLight) == 0x148);
 #endif
 }
+#undef RUNTIME_DATA_CONTENT


### PR DESCRIPTION
Adds getters to allow for fetching from correct offsets on ALL builds.