### PR TITLE
fix: clang-cl warnings

### DIFF
--- a/include/RE/B/BGSSaveLoadManager.h
+++ b/include/RE/B/BGSSaveLoadManager.h
@@ -174,7 +174,7 @@ namespace RE
 
 		[[nodiscard]] inline const AE_RUNTIME_DATA& GetAERuntimeData() const noexcept
 		{
-			return this->GetAERuntimeData();
+			return *const_cast<BGSSaveLoadManager*>(this)->GetAERuntimeData();
 		}
 
 		// members
@@ -263,3 +263,6 @@ namespace RE
 	static_assert(sizeof(BGSSaveLoadManager) == 0x2B0);
 #endif
 }
+
+#undef RUNTIME_DATA_CONTENT
+#undef AE_RUNTIME_DATA_CONTENT

--- a/include/RE/B/BGSShaderParticleGeometryData.h
+++ b/include/RE/B/BGSShaderParticleGeometryData.h
@@ -118,3 +118,6 @@ namespace RE
 	static_assert(sizeof(BGSShaderParticleGeometryData) == 0x20);
 #endif
 }
+
+#undef RUNTIME_DATA_CONTENT
+#undef RUNTIME_DATA_CONTENT_VR

--- a/include/RE/B/BSTPointerAndFlags.h
+++ b/include/RE/B/BSTPointerAndFlags.h
@@ -44,7 +44,7 @@ namespace RE
 				clear_flags();
 				a_rhs.clear_flags();
 				_storage.address = a_rhs._storage.address;
-				a_rhs.storage.address = 0;
+				a_rhs._storage.address = 0;
 			}
 			return *this;
 		}

--- a/include/RE/C/CalibrationOptionMenu.h
+++ b/include/RE/C/CalibrationOptionMenu.h
@@ -12,6 +12,8 @@ namespace RE
 	public:
 		inline static constexpr auto RTTI = RTTI_CalibrationOptionMenu;
 
+		using MenuEventHandler::operator delete;
+
 		// override (IMenu)
 		void               Accept(CallbackProcessor* a_processor) override;  // 01
 		UI_MESSAGE_RESULTS ProcessMessage(UIMessage& a_message) override;    // 04

--- a/include/RE/C/CombatController.h
+++ b/include/RE/C/CombatController.h
@@ -70,7 +70,7 @@ namespace RE
 
 		[[nodiscard]] inline const AE_RUNTIME_DATA& GetAERuntimeData() const noexcept
 		{
-			return this->GetAERuntimeData();
+			return *const_cast<CombatController*>(this)->GetAERuntimeData();
 		}
 
 		[[nodiscard]] bool IsFleeing() const
@@ -113,3 +113,6 @@ namespace RE
 	static_assert(sizeof(CombatController) == 0xD8);
 #endif
 }
+
+#undef RUNTIME_DATA_CONTENT
+#undef AE_RUNTIME_DATA_CONTENT

--- a/include/RE/G/GHashSetBase.h
+++ b/include/RE/G/GHashSetBase.h
@@ -211,7 +211,7 @@ namespace RE
 			Clear();
 			if (a_src.IsEmpty() == false) {
 				SetCapacity(a_memAddr, a_src.GetSize());
-				for (const_iterator it = a_src.Begin(); it != a_src.End(); ++it) {
+				for (const_iterator it = a_src.begin(); it != a_src.end(); ++it) {
 					Add(a_memAddr, *it);
 				}
 			}

--- a/include/RE/T/TES.h
+++ b/include/RE/T/TES.h
@@ -202,7 +202,7 @@ namespace RE
 
 		[[nodiscard]] inline const AE_RUNTIME_DATA& GetAERuntimeData() const noexcept
 		{
-			return this->GetAERuntimeData();
+			return *const_cast<TES*>(this)->GetAERuntimeData();
 		}
 
 		[[nodiscard]] inline RUNTIME_DATA2& GetRuntimeData2() noexcept

--- a/src/RE/B/BSOpenVR.cpp
+++ b/src/RE/B/BSOpenVR.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "RE/B/BSOpenVR.h"
 
 namespace RE

--- a/src/RE/I/InventoryChanges.cpp
+++ b/src/RE/I/InventoryChanges.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "RE/I/InventoryChanges.h"
 #include "RE/A/Actor.h"
 #include "RE/F/FormTraits.h"


### PR DESCRIPTION
fixes multiple errors and warnings caught by clang-cl
# Errors
- `GHashSetBase` using methods with incorrect casing
- `BSTPointerAndFlags` using incorrect member
# Warnings
- `CalibrationOptionMenu` inherits multiple class with same operator delete overload (ambiguous overload)
- multiple reuses of `GetRuntimeData` functions where the const overload is not explicit (the compiler may cause infinite recursion)
- multiple `RUNTIME_DATA_CONTENT` macros without `#undef` that conflicts with downstream headers
- multiple `#pragma once` in non-header files
# Ignored Warnings (not fixed in this PR)
- multiple "first argument in call to 'memcpy' is a pointer to non-trivially copyable type 'value_type'"
- definition of implicit copy constructor for 'GHashNode<RE::GString, RE::FxDelegate::CallbackDefn, RE::FxDelegate::CallbackHashFunctor>' is deprecated because it has a user-provided copy assignment operator