### PR TITLE
Guard against  fmt v11+ compatibility for enum formatters

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -916,6 +916,18 @@
       }
     },
     {
+      "name": "flatrim",
+      "displayName": "All Tests (Flatrim)",
+      "configurePreset": "build-debug-msvc-vcpkg-flatrim",
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": false
+      }
+    },
+    {
       "name": "unit",
       "displayName": "Unit Tests",
       "description": "Runs tests that do not require any Skyrim module loaded into the process.",

--- a/include/RE/A/ActorValueList.h
+++ b/include/RE/A/ActorValueList.h
@@ -38,7 +38,7 @@ namespace fmt
 		template <class FormatContext>
 		auto format(const RE::ActorValue& a_actorValue, FormatContext& a_ctx) const
 		{
-			return formatter<std::string_view>::format(ActorValueToString(a_actorValue), a_ctx);
+			return formatter<std::string_view>::format(RE::ActorValueToString(a_actorValue), a_ctx);
 		}
 	};
 }
@@ -53,7 +53,7 @@ namespace std
 		template <class FormatContext>
 		auto format(RE::ActorValue a_actorValue, FormatContext& a_ctx)
 		{
-			return formatter<std::string_view, CharT>::format(ActorValueToString(a_actorValue), a_ctx);
+			return formatter<std::string_view, CharT>::format(RE::ActorValueToString(a_actorValue), a_ctx);
 		}
 	};
 }

--- a/include/RE/A/ActorValueList.h
+++ b/include/RE/A/ActorValueList.h
@@ -33,18 +33,12 @@ namespace RE
 namespace fmt
 {
 	template <>
-	struct formatter<RE::ActorValue>
+	struct formatter<RE::ActorValue> : formatter<std::string_view>
 	{
-		template <class ParseContext>
-		constexpr auto parse(ParseContext& a_ctx)
-		{
-			return a_ctx.begin();
-		}
-
 		template <class FormatContext>
 		auto format(const RE::ActorValue& a_actorValue, FormatContext& a_ctx) const
 		{
-			return fmt::format_to(a_ctx.out(), "{}", ActorValueToString(a_actorValue));
+			return formatter<std::string_view>::format(ActorValueToString(a_actorValue), a_ctx);
 		}
 	};
 }

--- a/include/RE/C/CollisionLayers.h
+++ b/include/RE/C/CollisionLayers.h
@@ -77,18 +77,12 @@ namespace std
 namespace fmt
 {
 	template <>
-	struct formatter<RE::COL_LAYER>
+	struct formatter<RE::COL_LAYER> : formatter<std::string_view>
 	{
-		template <class ParseContext>
-		constexpr auto parse(ParseContext& a_ctx)
-		{
-			return a_ctx.begin();
-		}
-
 		template <class FormatContext>
 		auto format(const RE::COL_LAYER& a_layer, FormatContext& a_ctx) const
 		{
-			return fmt::format_to(a_ctx.out(), "{}", RE::CollisionLayerToString(a_layer));
+			return formatter<std::string_view>::format(RE::CollisionLayerToString(a_layer), a_ctx);
 		}
 	};
 }

--- a/include/RE/E/EffectArchetypes.h
+++ b/include/RE/E/EffectArchetypes.h
@@ -73,18 +73,12 @@ namespace std
 namespace fmt
 {
 	template <>
-	struct formatter<RE::EffectArchetype>
+	struct formatter<RE::EffectArchetype> : formatter<std::string_view>
 	{
-		template <class ParseContext>
-		constexpr auto parse(ParseContext& a_ctx)
-		{
-			return a_ctx.begin();
-		}
-
 		template <class FormatContext>
 		auto format(const RE::EffectArchetype& a_archetype, FormatContext& a_ctx) const
 		{
-			return fmt::format_to(a_ctx.out(), "{}", RE::EffectArchetypeToString(a_archetype));
+			return formatter<std::string_view>::format(RE::EffectArchetypeToString(a_archetype), a_ctx);
 		}
 	};
 }

--- a/include/RE/F/FormTypes.h
+++ b/include/RE/F/FormTypes.h
@@ -293,18 +293,12 @@ namespace std
 
 #ifdef FMT_VERSION
 template <>
-struct fmt::formatter<RE::FormType>
+struct fmt::formatter<RE::FormType> : fmt::formatter<std::string_view>
 {
-	template <class ParseContext>
-	constexpr auto parse(ParseContext& a_ctx)
-	{
-		return a_ctx.begin();
-	}
-
 	template <class FormatContext>
-	auto format(const RE::FormType& a_formType, FormatContext& a_ctx)
+	auto format(const RE::FormType& a_formType, FormatContext& a_ctx) const
 	{
-		return fmt::format_to(a_ctx.out(), "{}", RE::FormTypeToString(a_formType));
+		return fmt::formatter<std::string_view>::format(RE::FormTypeToString(a_formType), a_ctx);
 	}
 };
 #endif

--- a/include/RE/M/MaterialIDs.h
+++ b/include/RE/M/MaterialIDs.h
@@ -110,18 +110,12 @@ namespace std
 namespace fmt
 {
 	template <>
-	struct formatter<RE::MATERIAL_ID>
+	struct formatter<RE::MATERIAL_ID> : formatter<std::string_view>
 	{
-		template <class ParseContext>
-		constexpr auto parse(ParseContext& a_ctx)
-		{
-			return a_ctx.begin();
-		}
-
 		template <class FormatContext>
 		auto format(const RE::MATERIAL_ID& a_materialID, FormatContext& a_ctx) const
 		{
-			return fmt::format_to(a_ctx.out(), "{}", RE::MaterialIDToString(a_materialID));
+			return formatter<std::string_view>::format(RE::MaterialIDToString(a_materialID), a_ctx);
 		}
 	};
 }

--- a/include/REL/Version.h
+++ b/include/REL/Version.h
@@ -188,13 +188,12 @@ struct std::formatter<REL::Version, CharT> : formatter<std::string, CharT>
 
 #ifdef FMT_VERSION
 template <class CharT>
-struct fmt::formatter<REL::Version, CharT> : fmt::formatter<std::basic_string_view<CharT>, CharT>
+struct fmt::formatter<REL::Version, CharT> : fmt::formatter<std::string>
 {
 	template <class FormatContext>
 	auto format(const REL::Version& a_version, FormatContext& a_ctx) const
 	{
-		auto str = a_version.string();
-		return fmt::formatter<std::basic_string_view<CharT>, CharT>::format(std::basic_string_view<CharT>(str.data(), str.size()), a_ctx);
+		return fmt::formatter<std::string>::format(a_version.string(), a_ctx);
 	}
 };
 #endif

--- a/include/REL/Version.h
+++ b/include/REL/Version.h
@@ -175,20 +175,20 @@ namespace std
 }
 
 #ifdef __cpp_lib_format
-template <class CharT>
-struct std::formatter<REL::Version, CharT> : formatter<std::string, CharT>
+template <>
+struct std::formatter<REL::Version> : formatter<std::string>
 {
 	template <class FormatContext>
 	constexpr auto format(const REL::Version a_version, FormatContext& a_ctx) const
 	{
-		return formatter<std::string, CharT>::format(a_version.string(), a_ctx);
+		return formatter<std::string>::format(a_version.string(), a_ctx);
 	}
 };
 #endif
 
 #ifdef FMT_VERSION
-template <class CharT>
-struct fmt::formatter<REL::Version, CharT> : fmt::formatter<std::string>
+template <>
+struct fmt::formatter<REL::Version> : fmt::formatter<std::string>
 {
 	template <class FormatContext>
 	auto format(const REL::Version& a_version, FormatContext& a_ctx) const

--- a/include/REL/Version.h
+++ b/include/REL/Version.h
@@ -175,25 +175,25 @@ namespace std
 }
 
 #ifdef __cpp_lib_format
-template <>
-struct std::formatter<REL::Version> : formatter<std::string>
+template <class CharT>
+struct std::formatter<REL::Version, CharT> : formatter<std::string_view, CharT>
 {
 	template <class FormatContext>
-	constexpr auto format(const REL::Version a_version, FormatContext& a_ctx) const
+	constexpr auto format(const REL::Version& a_version, FormatContext& a_ctx) const
 	{
-		return formatter<std::string>::format(a_version.string(), a_ctx);
+		return formatter<std::string_view, CharT>::format(a_version.string(), a_ctx);
 	}
 };
 #endif
 
 #ifdef FMT_VERSION
 template <>
-struct fmt::formatter<REL::Version> : fmt::formatter<std::string>
+struct fmt::formatter<REL::Version> : fmt::formatter<std::string_view>
 {
 	template <class FormatContext>
 	auto format(const REL::Version& a_version, FormatContext& a_ctx) const
 	{
-		return fmt::formatter<std::string>::format(a_version.string(), a_ctx);
+		return fmt::formatter<std::string_view>::format(a_version.string(), a_ctx);
 	}
 };
 #endif

--- a/include/REL/Version.h
+++ b/include/REL/Version.h
@@ -188,12 +188,13 @@ struct std::formatter<REL::Version, CharT> : formatter<std::string, CharT>
 
 #ifdef FMT_VERSION
 template <class CharT>
-struct fmt::formatter<REL::Version, CharT> : formatter<std::string, CharT>
+struct fmt::formatter<REL::Version, CharT> : fmt::formatter<std::basic_string_view<CharT>, CharT>
 {
 	template <class FormatContext>
-	auto format(const REL::Version a_version, FormatContext& a_ctx) const
+	auto format(const REL::Version& a_version, FormatContext& a_ctx) const
 	{
-		return formatter<std::string, CharT>::format(a_version.string(), a_ctx);
+		auto str = a_version.string();
+		return fmt::formatter<std::basic_string_view<CharT>, CharT>::format(std::basic_string_view<CharT>(str.data(), str.size()), a_ctx);
 	}
 };
 #endif

--- a/include/REL/Version.h
+++ b/include/REL/Version.h
@@ -176,12 +176,12 @@ namespace std
 
 #ifdef __cpp_lib_format
 template <class CharT>
-struct std::formatter<REL::Version, CharT> : formatter<std::string_view, CharT>
+struct std::formatter<REL::Version, CharT> : formatter<std::string, CharT>
 {
 	template <class FormatContext>
 	constexpr auto format(const REL::Version& a_version, FormatContext& a_ctx) const
 	{
-		return formatter<std::string_view, CharT>::format(a_version.string(), a_ctx);
+		return formatter<std::string, CharT>::format(a_version.string(), a_ctx);
 	}
 };
 #endif

--- a/include/REL/Version.h
+++ b/include/REL/Version.h
@@ -176,12 +176,19 @@ namespace std
 
 #ifdef __cpp_lib_format
 template <class CharT>
-struct std::formatter<REL::Version, CharT> : formatter<std::string, CharT>
+struct std::formatter<REL::Version, CharT> : formatter<std::basic_string_view<CharT>, CharT>
 {
 	template <class FormatContext>
 	constexpr auto format(const REL::Version& a_version, FormatContext& a_ctx) const
 	{
-		return formatter<std::string, CharT>::format(a_version.string(), a_ctx);
+		auto str = a_version.string();
+		if constexpr (std::is_same_v<CharT, char>) {
+			return formatter<std::basic_string_view<CharT>, CharT>::format(str, a_ctx);
+		} else {
+			// Convert narrow string to wide string for wchar_t formatting
+			std::basic_string<CharT> wstr(str.begin(), str.end());
+			return formatter<std::basic_string_view<CharT>, CharT>::format(wstr, a_ctx);
+		}
 	}
 };
 #endif

--- a/tests/REL/Relocation.test.cpp
+++ b/tests/REL/Relocation.test.cpp
@@ -79,6 +79,8 @@ TEST_CASE("Version/fmt::format")
 TEST_CASE("Version/std::format")
 {
 	CHECK(std::format("Hello {}", std::to_string(SKSE::RUNTIME_SSE_1_5_97)) == "Hello 1.5.97.0");
+	// Test wide-character formatting to verify formatter<std::string, CharT> handles conversion
+	CHECK(std::format(L"Hello {}", SKSE::RUNTIME_SSE_1_5_97) == L"Hello 1-5-97-0");
 }
 
 TEST_CASE("Version/StringConstructor")


### PR DESCRIPTION
# Fix fmt v12 Compatibility

## Problem
Users upgrading to fmt v12 encountered compilation errors when formatting enums:

`error C2338: static_assert failed: 'Cannot format an argument. To make type T formattable provide a formatter<T> specialization'
note: see reference to function template instantiation 'fmt::v12::detail::value<Context>::valueRE::FormType,0(T &)' being compiled`

This occurred because fmt v12 requires formatters to either:
1. Inherit from an existing formatter (e.g., `formatter<string_view>`)
2. Use the `format_as` mechanism

## Solution
Updated all enum and custom type `fmt::formatter` specializations to inherit from `formatter<string_view>` (or `formatter<basic_string_view>` for templated types). This approach:

- ✅ Works with fmt v10, v11, and v12
- ✅ Reduces boilerplate (no manual `parse()` implementation needed)
- ✅ Maintains identical formatting behavior
- ✅ Follows fmt best practices

## Additional Improvements

### Wide-Character Formatting Support (REL::Version)

Fixed a pre-existing bug in `std::formatter<REL::Version, CharT>` where wide-character formatting would fail to compile:

## Changes
Updated formatters for:
- `RE::FormType`
- `RE::ActorValue`
- `RE::EffectArchetype`
- `RE::COL_LAYER`
- `RE::MATERIAL_ID`
• `REL::Version` (uses `formatter<std::string>` since `Version::string()` returns `std::string`)


**Before:**
```cpp
template <>
struct fmt::formatter<RE::FormType> {
    template <class ParseContext>
    constexpr auto parse(ParseContext& a_ctx) {
        return a_ctx.begin();
    }
    
    template <class FormatContext>
    auto format(const RE::FormType& a_formType, FormatContext& a_ctx) {
        return fmt::format_to(a_ctx.out(), "{}", RE::FormTypeToString(a_formType));
    }
};
```

**After**

After (enum types):
```cpp
template <>
struct fmt::formatter<RE::FormType> : fmt::formatter<std::string_view> {
    template <class FormatContext>
    auto format(const RE::FormType& a_formType, FormatContext& a_ctx) const {
        return fmt::formatter<std::string_view>::format(RE::FormTypeToString(a_formType), a_ctx);
    }
};
```

After (`REL::Version` - uses `std::string` since `Version::string()` returns `std::string`):
```cpp
// std::formatter - templated on CharT for multi-character type support
template <class CharT>
struct std::formatter<REL::Version, CharT> : formatter<std::string, CharT> {
    template <class FormatContext>
    constexpr auto format(const REL::Version& a_version, FormatContext& a_ctx) const {
        return formatter<std::string, CharT>::format(a_version.string(), a_ctx);
    }
};

// fmt::formatter - non-templated, inherits from string_view formatter
template <>
struct fmt::formatter<REL::Version> : fmt::formatter<std::string_view> {
    template <class FormatContext>
    auto format(const REL::Version& a_version, FormatContext& a_ctx) const {
        return fmt::formatter<std::string_view>::format(a_version.string(), a_ctx);
    }
};
```


## Breaking Changes

None. API and behavior remain unchanged for fmt v10. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified and simplified many type formatters to use a single string-view-based formatting path for consistent display output.

* **Chores**
  * Added a new "flatrim" test preset to run the full test suite with the Flatrim runtime configuration.

* **Tests**
  * Added a wide-character formatting test to verify correct output for wide-string formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->