### PR TITLE
fix: remove const from EMPTY by Nukem

### DIFF
--- a/include/RE/B/BSString.h
+++ b/include/RE/B/BSString.h
@@ -266,7 +266,7 @@ namespace RE
 			return true;
 		}
 
-		static constexpr value_type EMPTY[]{ 0 };
+		static inline value_type EMPTY[]{ 0 };
 
 		// members
 		pointer       _data{ nullptr };  // ?? (00)


### PR DESCRIPTION
When L191 data() is used, it tries to convert `const char*` to `char*` and gives compile error. Solution A, is to return `const_cast<pointer>(EMPTY)` instead of EMPTY, to remove const. Solution B, is to remove const from EMPTY on its init. I pick B.