### PR TITLE
fix: BGSDefaultObjectManager::GetObject lookup failure

### DIFF
--- a/src/RE/B/BGSDefaultObjectManager.cpp
+++ b/src/RE/B/BGSDefaultObjectManager.cpp
@@ -25,13 +25,13 @@ namespace RE
 
 	TESForm** BGSDefaultObjectManager::GetObject(DefaultObjectID a_object) noexcept
 	{
-		assert(std::to_underlying(a_object) < Relocate(364, 364, 369));
 		auto idx = MapIndex(std::to_underlying(a_object));
 		if (idx == kInvalid) {
 			return nullptr;
 		}
+		assert(idx < Relocate(364, 364, 369));
 		return (&RelocateMember<bool>(this, 0xB80, 0xBA8))[idx] ?
-		           &RelocateMember<TESForm**>(this, 0x20, 0x20)[idx] :
+		           &(&RelocateMember<TESForm*>(this, 0x20, 0x20))[idx] :
 		           nullptr;
 	}
 


### PR DESCRIPTION
Similar to the objectInit fix in 054cbcd49ae4ffccf2a405313112504f16aa58f5 but for the actual objects array relocation.
Also fixed assertion failure by relocating after the id->idx mapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimization with no user-visible changes or impact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->