### PR TITLE
refactor: use hierarchical macros

### DIFF
--- a/include/RE/F/FaderMenu.h
+++ b/include/RE/F/FaderMenu.h
@@ -33,6 +33,16 @@ namespace RE
 		UI_MESSAGE_RESULTS ProcessMessage(UIMessage& a_message) override;                         // 04
 		void               AdvanceMovie(float a_interval, std::uint32_t a_currentTime) override;  // 05
 
+		[[nodiscard]] inline RUNTIME_DATA& GetRuntimeData() noexcept
+		{
+			return REL::RelocateMember<RUNTIME_DATA>(this, 0x30, 0x40);
+		}
+
+		[[nodiscard]] inline const RUNTIME_DATA& GetRuntimeData() const noexcept
+		{
+			return REL::RelocateMember<RUNTIME_DATA>(this, 0x30, 0x40);
+		}
+
 		// members
 #ifndef SKYRIM_CROSS_VR
 		RUNTIME_DATA_CONTENT;  // 30 - smart ptr

--- a/include/RE/L/LocalMapMenu.h
+++ b/include/RE/L/LocalMapMenu.h
@@ -23,21 +23,74 @@ namespace RE
 		struct LocalMapCullingProcess  // actually: LocalMapRenderer
 		{
 		public:
-			struct Data
+			// Common renderer data shared by SE/AE and VR (at different offsets)
+#define RENDERER_DATA_CONTENT                                                              \
+	LocalMapCamera                 camera;                /* 30260 (SE/AE) / 30270 (VR) */ \
+	NiPointer<BSShaderAccumulator> accumulator;           /* 302C8 (SE/AE) / 302D8 (VR) */ \
+	ImageSpaceShaderParam          imageSpaceShaderParam; /* 302D0 (SE/AE) / 302E0 (VR) */ \
+	std::uint32_t                  renderTarget;          /* 30350 (SE/AE) / 30360 (VR) */ \
+	std::uint32_t                  renderMode;            /* 30354 (SE/AE) / 30364 (VR) */ \
+	NiPointer<NiNode>              unk30358;              /* 30358 (SE/AE) / 30368 (VR) */
+
+			// VR-specific additional renderer data
+#define VR_EXTRA_RENDERER_DATA_CONTENT    \
+	BSTArray<void*> unk30370; /* 30370 */ \
+	BSTArray<void*> unk30388; /* 30388 */ \
+	BSTArray<void*> unk303A0; /* 303A0 */ \
+	void*           unk303B8; /* 303B8 */ \
+	NiCamera*       unk303C0; /* 303C0 */ \
+	std::uint32_t   unk303C8; /* 303C8 */ \
+	std::uint32_t   pad303CC; /* 303CC */ \
+	std::uint64_t   unk303D0; /* 303D0 */
+
+			// SE/AE renderer data
+			struct RENDERER_DATA
 			{
-			public:
-				// members
-				NiPointer<BSShaderAccumulator> shaderAccumulator;  // 00
-				void*                          unk08;              // 08 - smart ptr
-				NiPointer<NiCamera>            camera;             // 10
-				std::uint64_t                  unk18;              // 18
-				std::uint64_t                  unk20;              // 20
-				std::uint64_t                  unk28;              // 28
-				std::uint64_t                  unk30;              // 30
-				std::uint64_t                  unk38;              // 38
-				void*                          unk40;              // 40 - smart ptr
+				RENDERER_DATA_CONTENT
 			};
-			static_assert(sizeof(Data) == 0x48);
+
+			// VR renderer data with extra arrays
+			struct VR_RENDERER_DATA
+			{
+				RENDERER_DATA_CONTENT
+				VR_EXTRA_RENDERER_DATA_CONTENT
+			};
+
+			[[nodiscard]] inline RENDERER_DATA* GetRendererData() noexcept
+			{
+				if SKYRIM_REL_VR_CONSTEXPR (!REL::Module::IsVR()) {
+					return &REL::RelocateMember<RENDERER_DATA>(this, 0x30260, 0);
+				} else {
+					return nullptr;
+				}
+			}
+
+			[[nodiscard]] inline const RENDERER_DATA* GetRendererData() const noexcept
+			{
+				if SKYRIM_REL_VR_CONSTEXPR (!REL::Module::IsVR()) {
+					return &REL::RelocateMember<RENDERER_DATA>(this, 0x30260, 0);
+				} else {
+					return nullptr;
+				}
+			}
+
+			[[nodiscard]] inline VR_RENDERER_DATA* GetVRRendererData() noexcept
+			{
+				if SKYRIM_REL_VR_CONSTEXPR (REL::Module::IsVR()) {
+					return &REL::RelocateMember<VR_RENDERER_DATA>(this, 0, 0x30270);
+				} else {
+					return nullptr;
+				}
+			}
+
+			[[nodiscard]] inline const VR_RENDERER_DATA* GetVRRendererData() const noexcept
+			{
+				if SKYRIM_REL_VR_CONSTEXPR (REL::Module::IsVR()) {
+					return &REL::RelocateMember<VR_RENDERER_DATA>(this, 0, 0x30270);
+				} else {
+					return nullptr;
+				}
+			}
 
 			[[nodiscard]] inline LocalMapCamera* GetLocalMapCamera() const noexcept
 			{
@@ -52,38 +105,19 @@ namespace RE
 			// members
 			BSCullingProcess cullingProcess;  // 00000
 			BSCullingJob     cullingJob;      // 301F8
-#if defined(EXCLUSIVE_SKYRIM_FLAT)
-			std::uint64_t                  unk30250;                                    // 30250
-			std::uint64_t                  unk30258;                                    // 30258
-			LocalMapCamera                 camera;                                      // 30260
-			NiPointer<BSShaderAccumulator> accumulator;                                 // 302C8
-			ImageSpaceShaderParam          imageSpaceShaderParamimageSpaceShaderParam;  // 302D0
-			std::uint32_t                  renderTarget;                                // 30350
-			std::uint32_t                  renderMode;                                  // 30354
-			NiPointer<NiNode>              unk30358;                                    // 30358
-#elif defined(EXCLUSIVE_SKYRIM_VR)
-			std::uint64_t                  padVR1;                 // 30250
-			std::uint64_t                  padVR2;                 // 30258
-			std::uint64_t                  unk30260;               // 30260
-			std::uint64_t                  unk30268;               // 30268
-			LocalMapCamera                 camera;                 // 30270
-			NiPointer<BSShaderAccumulator> accumulator;            // 302D8
-			ImageSpaceShaderParam          imageSpaceShaderParam;  // 302E0
-			std::uint32_t                  renderTarget;           // 30360
-			std::uint32_t                  renderMode;             // 30364
-			NiPointer<NiNode>              unk30358;               // 30368
-			BSTArray<void*>                unk30370;               // 30370
-			BSTArray<void*>                unk30388;               // 30388
-			BSTArray<void*>                unk303A0;               // 303A0
-			void*                          unk303B8;               // 303B8
-			NiCamera*                      unk303C0;               // 303C0
-			std::uint32_t                  unk303C8;               // 303C8
-			std::uint32_t                  pad303CC;               // 303CC
-			std::uint64_t                  unk303D0;               // 303D0
-#else
-			std::uint64_t unk30250;         // 30250
-			std::uint64_t unk30258;         // 30258
-			std::uint8_t  unk30260[0x100];  // 30260
+#if !defined(SKYRIM_CROSS_VR)
+#	if defined(EXCLUSIVE_SKYRIM_FLAT)
+			std::uint64_t unk30250;  // 30250
+			std::uint64_t unk30258;  // 30258
+			RENDERER_DATA_CONTENT
+#	elif defined(EXCLUSIVE_SKYRIM_VR)
+			std::uint64_t unk30250;  // 30250
+			std::uint64_t unk30258;  // 30258
+			std::uint64_t unk30260;  // 30260
+			std::uint64_t unk30268;  // 30268
+			RENDERER_DATA_CONTENT
+			VR_EXTRA_RENDERER_DATA_CONTENT
+#	endif
 #endif
 		};
 #if defined(EXCLUSIVE_SKYRIM_FLAT)
@@ -91,7 +125,7 @@ namespace RE
 #elif defined(EXCLUSIVE_SKYRIM_VR)
 		static_assert(sizeof(LocalMapCullingProcess) == 0x303E8);
 #else
-		static_assert(sizeof(LocalMapCullingProcess) == 0x30370);
+		static_assert(sizeof(LocalMapCullingProcess) == 0x301F8);
 #endif
 
 		class InputHandler : public MenuEventHandler
@@ -160,3 +194,6 @@ namespace RE
 	static_assert(sizeof(LocalMapMenu) == 0x30410);
 #endif
 }
+
+#undef RENDERER_DATA_CONTENT
+#undef VR_EXTRA_RENDERER_DATA_CONTENT

--- a/include/RE/L/LocalMapMenu.h
+++ b/include/RE/L/LocalMapMenu.h
@@ -125,7 +125,7 @@ namespace RE
 #elif defined(EXCLUSIVE_SKYRIM_VR)
 		static_assert(sizeof(LocalMapCullingProcess) == 0x303E8);
 #else
-		static_assert(sizeof(LocalMapCullingProcess) == 0x301F8);
+		static_assert(sizeof(LocalMapCullingProcess) == 0x30260);  // Cross-VR: only base members (cullingProcess + cullingJob), use accessors for runtime data
 #endif
 
 		class InputHandler : public MenuEventHandler
@@ -191,7 +191,7 @@ namespace RE
 #elif defined(EXCLUSIVE_SKYRIM_VR)
 	static_assert(sizeof(LocalMapMenu) == 0x30490);
 #else
-	static_assert(sizeof(LocalMapMenu) == 0x30410);
+	static_assert(sizeof(LocalMapMenu) == 0x30300);
 #endif
 }
 

--- a/include/RE/M/MapMenu.h
+++ b/include/RE/M/MapMenu.h
@@ -42,14 +42,31 @@ namespace RE
 		inline static constexpr auto      RTTI = RTTI_MapMenu;
 		constexpr static std::string_view MENU_NAME = "MapMenu";
 
+		// Common handlers shared by SE/AE and VR
+#define COMMON_HANDLERS_CONTENT                           \
+	BSTSmartPointer<MapMoveHandler> moveHandler; /* 00 */ \
+	BSTSmartPointer<MapLookHandler> lookHandler; /* 08 */ \
+	BSTSmartPointer<MapZoomHandler> zoomHandler; /* 10 */
+
+		// VR-specific extra handlers
+#define VR_EXTRA_HANDLERS_CONTENT                                 \
+	BSTSmartPointer<MapClickHandler>    clickHandler;    /* 18 */ \
+	BSTSmartPointer<MapTouchpadHandler> touchpadHandler; /* 20 */ \
+	BSTSmartPointer<void*>              unk00088;        /* 28 */ \
+	BSTSmartPointer<void*>              unk00090;        /* 30 */ \
+	BSTSmartPointer<void*>              unk00098;        /* 38 */ \
+	BSTSmartPointer<void*>              unk000A0;        /* 40 */
+
+		// Common map data shared by SE/AE and VR (at different offsets)
+#define COMMON_MAP_DATA_CONTENT                              \
+	ObjectRefHandle mapMarker;    /* 18 (SE/AE) / A8 (VR) */ \
+	LocalMapMenu    localMapMenu; /* 20 (SE/AE) / B0 (VR) */
+
 		struct RUNTIME_DATA
 		{
-#define RUNTIME_DATA_CONTENT                               \
-	BSTSmartPointer<MapMoveHandler> moveHandler;  /* 00 */ \
-	BSTSmartPointer<MapLookHandler> lookHandler;  /* 08 */ \
-	BSTSmartPointer<MapZoomHandler> zoomHandler;  /* 10 */ \
-	ObjectRefHandle                 mapMarker;    /* 18 */ \
-	LocalMapMenu                    localMapMenu; /* 20 */
+#define RUNTIME_DATA_CONTENT \
+	COMMON_HANDLERS_CONTENT  \
+	COMMON_MAP_DATA_CONTENT
 
 			RUNTIME_DATA_CONTENT
 		};
@@ -63,19 +80,12 @@ namespace RE
 
 		struct VR_RUNTIME_DATA
 		{
-#define VR_RUNTIME_DATA_CONTENT                                      \
-	BSTSmartPointer<MapMoveHandler>     moveHandler;     /* 00060 */ \
-	BSTSmartPointer<MapLookHandler>     lookHandler;     /* 00068*/  \
-	BSTSmartPointer<MapZoomHandler>     zoomHandler;     /* 00070*/  \
-	BSTSmartPointer<MapClickHandler>    clickHandler;    /* 00078*/  \
-	BSTSmartPointer<MapTouchpadHandler> touchpadHandler; /* 00080*/  \
-	BSTSmartPointer<void*>              unk00088;        /* 00088*/  \
-	BSTSmartPointer<void*>              unk00090;        /* 00090*/  \
-	BSTSmartPointer<void*>              unk00098;        /* 00098*/  \
-	BSTSmartPointer<void*>              unk000A0;        /* 000A0*/  \
-	ObjectRefHandle                     mapMarker;       /* 000A8*/  \
-	LocalMapMenu                        localMapMenu;    /* 000B0*/
-            VR_RUNTIME_DATA_CONTENT;
+#define VR_RUNTIME_DATA_CONTENT \
+	COMMON_HANDLERS_CONTENT     \
+	VR_EXTRA_HANDLERS_CONTENT   \
+	COMMON_MAP_DATA_CONTENT
+
+			VR_RUNTIME_DATA_CONTENT;
 		};
 #if defined(EXCLUSIVE_SKYRIM_FLAT)
 		static_assert(sizeof(VR_RUNTIME_DATA) == 0x30460);
@@ -85,52 +95,55 @@ namespace RE
 		static_assert(sizeof(VR_RUNTIME_DATA) == 0x30460);
 #endif
 
-		struct RUNTIME_DATA2
-		{
-#define RUNTIME_DATA2_CONTENT                                                        \
+		// Common map data 2 shared by SE/AE and VR
+#define COMMON_MAP_DATA2_CONTENT                                                     \
 	RefHandle               cameraRootRef;        /* 000 - defaults to player ref */ \
 	NiPoint3                playerMarkerPosition; /* 004 */                          \
 	BSTArray<MapMenuMarker> mapMarkers;           /* 010 */                          \
-	BSTArray<GFxValue>      markerData;           /* 028 */                          \
-	MapCamera               camera;               /* 040 */                          \
-	std::uint64_t           unk30530;             /* 0D0 */                          \
-	TESWorldSpace*          worldSpace;           /* 0D8 */                          \
-	GFxValue                mapMovie;             /* 0E0 */                          \
-	std::int32_t            selectedMarker;       /* 0F8 */                          \
-	NiPoint3                cameraPickOrigin;     /* 0FC */                          \
-	NiPoint3                cameraPickDirection;  /* 108 */                          \
-	BSSoundHandle           unk30574;             /* 114 */                          \
-	std::uint64_t           unk30580;             /* 120 */                          \
-	std::uint32_t           unk30588;             /* 128 */                          \
-	bool                    controlsReady;        /* 12C */                          \
-	std::uint8_t            unk3058D;             /* 12D */                          \
-	std::uint16_t           unk3058E;             /* 12E */                          \
-	std::uint64_t           unk30590;             /* 130 */
-            RUNTIME_DATA2_CONTENT
+	BSTArray<GFxValue>      markerData;           /* 028 */
+
+		struct RUNTIME_DATA2
+		{
+#define RUNTIME_DATA2_CONTENT                     \
+	COMMON_MAP_DATA2_CONTENT                      \
+	MapCamera      camera;              /* 040 */ \
+	std::uint64_t  unk30530;            /* 0D0 */ \
+	TESWorldSpace* worldSpace;          /* 0D8 */ \
+	GFxValue       mapMovie;            /* 0E0 */ \
+	std::int32_t   selectedMarker;      /* 0F8 */ \
+	NiPoint3       cameraPickOrigin;    /* 0FC */ \
+	NiPoint3       cameraPickDirection; /* 108 */ \
+	BSSoundHandle  unk30574;            /* 114 */ \
+	std::uint64_t  unk30580;            /* 120 */ \
+	std::uint32_t  unk30588;            /* 128 */ \
+	bool           controlsReady;       /* 12C */ \
+	std::uint8_t   unk3058D;            /* 12D */ \
+	std::uint16_t  unk3058E;            /* 12E */ \
+	std::uint64_t  unk30590;            /* 130 */
+
+			RUNTIME_DATA2_CONTENT
 		};
 		static_assert(sizeof(RUNTIME_DATA2) == 0x138);
 
 		struct VR_RUNTIME_DATA2
 		{
-#define VR_RUNTIME_DATA2_CONTENT                                                     \
-	RefHandle               cameraRootRef;        /* 000 - defaults to player ref */ \
-	NiPoint3                playerMarkerPosition; /* 004 */                          \
-	BSTArray<MapMenuMarker> mapMarkers;           /* 010 */                          \
-	BSTArray<GFxValue>      markerData;           /* 028 */                          \
-	NiPoint3                unk30570;             /* 040 */                          \
-	std::int32_t            selectedMarker;       /* 30540 */                        \
-	std::uint64_t           unk30580;             /* 30558 */                        \
-	std::uint64_t           unk30588;             /* 30570 */                        \
-	TESWorldSpace*          worldSpace;           /* 0D8 */                          \
-	GFxValue                mapMovie;             /* 0E0 */                          \
-	BSSoundHandle           unk305B0;             /* 114 */                          \
-	std::uint64_t           unk305C0;             /* 120 */                          \
-	std::uint64_t           unk305C8;             /* 128 */                          \
-	std::uint64_t           unk305D0;             /* 128 */                          \
-	std::uint64_t           unk305D8;             /* 128 */                          \
-	std::uint64_t           unk305E0;             /* 128 */                          \
-	std::uint64_t           unk305E8;             /* 130 */
-            VR_RUNTIME_DATA2_CONTENT;
+#define VR_RUNTIME_DATA2_CONTENT             \
+	COMMON_MAP_DATA2_CONTENT                 \
+	NiPoint3       unk30570;       /* 040 */ \
+	std::int32_t   selectedMarker; /* 04C */ \
+	std::uint64_t  unk30580;       /* 050 */ \
+	std::uint64_t  unk30588;       /* 058 */ \
+	TESWorldSpace* worldSpace;     /* 060 */ \
+	GFxValue       mapMovie;       /* 068 */ \
+	BSSoundHandle  unk305B0;       /* 080 */ \
+	std::uint64_t  unk305C0;       /* 088 */ \
+	std::uint64_t  unk305C8;       /* 090 */ \
+	std::uint64_t  unk305D0;       /* 098 */ \
+	std::uint64_t  unk305D8;       /* 0A0 */ \
+	std::uint64_t  unk305E0;       /* 0A8 */ \
+	std::uint64_t  unk305E8;       /* 0B0 */
+
+			VR_RUNTIME_DATA2_CONTENT;
 		};
 		static_assert(sizeof(VR_RUNTIME_DATA2) == 0xC0);
 
@@ -276,6 +289,13 @@ namespace RE
 #endif
 }
 
+// Clean up sub-macros
+#undef COMMON_HANDLERS_CONTENT
+#undef VR_EXTRA_HANDLERS_CONTENT
+#undef COMMON_MAP_DATA_CONTENT
+#undef COMMON_MAP_DATA2_CONTENT
+
+// Clean up main macros
 #undef RUNTIME_DATA_CONTENT
 #undef VR_RUNTIME_DATA_CONTENT
 #undef RUNTIME_DATA2_CONTENT

--- a/include/RE/M/MapMenu.h
+++ b/include/RE/M/MapMenu.h
@@ -75,7 +75,7 @@ namespace RE
 #elif defined(EXCLUSIVE_SKYRIM_VR)
 		static_assert(sizeof(RUNTIME_DATA) == 0x304B0);
 #else
-		static_assert(sizeof(RUNTIME_DATA) == 0x30430);
+		static_assert(sizeof(RUNTIME_DATA) == 0x30320);
 #endif
 
 		struct VR_RUNTIME_DATA
@@ -92,7 +92,7 @@ namespace RE
 #elif defined(EXCLUSIVE_SKYRIM_VR)
 		static_assert(sizeof(VR_RUNTIME_DATA) == 0x304E0);
 #else
-		static_assert(sizeof(VR_RUNTIME_DATA) == 0x30460);
+		static_assert(sizeof(VR_RUNTIME_DATA) == 0x30350);
 #endif
 
 		// Common map data 2 shared by SE/AE and VR

--- a/include/RE/T/TESDataHandler.h
+++ b/include/RE/T/TESDataHandler.h
@@ -76,6 +76,7 @@ namespace RE
 
 		ObjectRefHandle CreateReferenceAtLocation(TESBoundObject* a_base, const NiPoint3& a_location, const NiPoint3& a_rotation, TESObjectCELL* a_targetCell, TESWorldSpace* a_selfWorldSpace, TESObjectREFR* a_alreadyCreatedRef, BGSPrimitive* a_primitive, const ObjectRefHandle& a_linkedRoomRefHandle, bool a_forcePersist, bool a_arg11);
 
+		// Common runtime flags shared by SE/AE and VR (at different offsets)
 		struct RUNTIME_DATA
 		{
 #define RUNTIME_DATA_CONTENT \
@@ -92,6 +93,11 @@ namespace RE
 
 			RUNTIME_DATA_CONTENT
 		};
+
+		// Common trailing members shared by SE/AE and VR (at different offsets)
+#define TRAILING_MEMBERS_CONTENT                                           \
+	TESRegionDataManager* regionDataManager; /* DB0 (SE/AE) / 1580 (VR) */ \
+	InventoryChanges*     merchantInventory; /* DB8 (SE/AE) / 1588 (VR) */
 
 		[[nodiscard]] inline RUNTIME_DATA& GetGeometryRuntimeData() noexcept
 		{
@@ -157,6 +163,16 @@ namespace RE
 			}
 		}
 
+		[[nodiscard]] inline std::uint8_t& GetGameSettingsLoadState() noexcept
+		{
+			return REL::RelocateMember<std::uint8_t>(this, 0xDAA, 0x157A);
+		}
+
+		[[nodiscard]] inline const std::uint8_t& GetGameSettingsLoadState() const noexcept
+		{
+			return REL::RelocateMember<std::uint8_t>(this, 0xDAA, 0x157A);
+		}
+
 		[[nodiscard]] inline TESRegionDataManager* GetRegionDataManager() noexcept
 		{
 			return REL::RelocateMember<TESRegionDataManager*>(this, 0xDB0, 0x1580);
@@ -191,23 +207,23 @@ namespace RE
 		std::uint32_t                     padD54;                                         // D54
 		TESFile*                          activeFile;                                     // D58
 		BSSimpleList<TESFile*>            files;                                          // D60
-#if defined(EXCLUSIVE_SKYRIM_FLAT)
+#if !defined(SKYRIM_CROSS_VR)
+#	if defined(EXCLUSIVE_SKYRIM_FLAT)
 		TESFileCollection compiledFileCollection;  // D70
 		RUNTIME_DATA_CONTENT
-		std::uint8_t          gameSettingsLoadState;  // DAA
-		std::uint8_t          padDAB;                 // DAB
-		std::uint32_t         padDAC;                 // DAC
-		TESRegionDataManager* regionDataManager;      // DB0
-		InventoryChanges*     merchantInventory;      // DB8
-#elif defined(EXCLUSIVE_SKYRIM_VR)
+		std::uint8_t  gameSettingsLoadState;  // DAA
+		std::uint8_t  padDAB;                 // DAB
+		std::uint32_t padDAC;                 // DAC
+		TRAILING_MEMBERS_CONTENT
+#	elif defined(EXCLUSIVE_SKYRIM_VR)
 		std::uint32_t loadedModCount;    // D70 this should be avoided if SkyrimVRESL is available
 		std::uint32_t pad14;             // D74
 		TESFile*      loadedMods[0xFF];  // D78 this should be avoided if SkyrimVRESL is available
 		RUNTIME_DATA_CONTENT
-		std::uint8_t          gameSettingsLoadState;  // 157A
-		std::uint8_t          pad157B[4];             // 157B
-		TESRegionDataManager* regionDataManager;      // 1580
-		InventoryChanges*     merchantInventory;      // 1588
+		std::uint8_t gameSettingsLoadState;  // 157A
+		std::uint8_t pad157B[4];             // 157B
+		TRAILING_MEMBERS_CONTENT
+#	endif
 #endif
 	};
 
@@ -239,4 +255,6 @@ namespace RE
 		return reinterpret_cast<BSTArray<T*>&>(GetFormArray(T::FORMTYPE));
 	}
 }
+
 #undef RUNTIME_DATA_CONTENT
+#undef TRAILING_MEMBERS_CONTENT


### PR DESCRIPTION
Apply a hierarchical macro pattern to improve code organization and maintainability across MapMenu, LocalMapMenu, and TESDataHandler. Introduce sub-macros for shared components and add necessary accessor functions to support multi-runtime builds. Fix missing accessors in FaderMenu discovered during an audit. No API changes introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * Exposed runtime and renderer state for menus and map systems via new public accessors.
  * Reorganized map and local-map runtime structures to separate standard and VR renderer data layouts.
  * Consolidated repeated runtime declarations into reusable blocks to simplify structure composition.
  * Added an accessor to surface game-settings load state for progress visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->