### PR TITLE
fix: add missing ExtraLevCreaModifier destructor implementation

### DIFF
--- a/include/RE/E/ExtraLevCreaModifier.h
+++ b/include/RE/E/ExtraLevCreaModifier.h
@@ -23,7 +23,7 @@ namespace RE
 
 		ExtraLevCreaModifier();
 		explicit ExtraLevCreaModifier(LEV_CREA_MODIFIER a_modifier);
-		~ExtraLevCreaModifier() override;  // 00
+		~ExtraLevCreaModifier() override = default;  // 00
 
 		// override (BSExtraData)
 		ExtraDataType GetType() const override;                             // 01 - { return kLevCreaModifier; }


### PR DESCRIPTION
The ExtraLevCreaModifier destructor was declared but never defined, causing linker errors when the class is instantiated in ExtraDataList::SetLevCreaModifier.

Since the class has only trivial members, use = default to let the compiler generate the optimal destructor. This matches the pattern used by other BSExtraData-derived classes like ExtraEncounterZone and ExtraUniqueID.

Closes #109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->