### PR TITLE
test: add consumer integration tests

### DIFF
--- a/.github/workflows/test-consumer.yml
+++ b/.github/workflows/test-consumer.yml
@@ -1,0 +1,52 @@
+name: Consumer Integration Test
+
+on:
+  push:
+    branches: [ ng ]
+  pull_request:
+    branches: [ ng ]
+
+jobs:
+  test-as-dependency:
+    name: Test CommonLib as Dependency
+    runs-on: windows-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+      
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgJsonGlob: '**/vcpkg.json'
+      
+      - name: Install vcpkg dependencies
+        run: |
+          $env:VCPKG_ROOT = "${{ github.workspace }}/vcpkg"
+          & "$env:VCPKG_ROOT/vcpkg" install --triplet=x64-windows
+      
+      - name: Configure Consumer Test
+        working-directory: test_consumer
+        run: |
+          cmake -B build -S . `
+            -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" `
+            -DVCPKG_INSTALLED_DIR="${{ github.workspace }}/vcpkg_installed" `
+            -DENABLE_SKYRIM_SE=ON `
+            -DENABLE_SKYRIM_AE=ON `
+            -DENABLE_SKYRIM_VR=ON
+      
+      - name: Build Consumer Test
+        working-directory: test_consumer
+        run: cmake --build build --config Release
+      
+      - name: Run Consumer Test
+        working-directory: test_consumer
+        run: |
+          Write-Host "Running consumer integration test..."
+          .\build\Release\ConsumerTest.exe
+          Write-Host "`n✓ Test passed: CommonLib headers compiled successfully when used as dependency"

--- a/cmake/testlist.cmake
+++ b/cmake/testlist.cmake
@@ -3,6 +3,7 @@ set(TESTS
     tests/RE/A/ActorValues.test.cpp
     tests/RE/F/FormTypes.test.cpp
     tests/REL/Relocation.test.cpp
+    tests/REL/StaticAssertSize.test.cpp
     tests/SKSE/Interfaces.test.cpp
     tests/SKSE/Trampoline.test.cpp
 )

--- a/test_consumer/CMakeLists.txt
+++ b/test_consumer/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.21)
+
+project(
+	CommonLibSSEConsumerTest
+	LANGUAGES CXX
+	VERSION 1.0.0
+)
+
+# This test project validates that CommonLib works correctly when used as a dependency
+# It specifically tests that STATIC_ASSERT_SIZE macros compile when consuming CommonLib
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Add CommonLib as a subdirectory dependency (simulates real-world usage)
+set(BUILD_TESTS OFF CACHE BOOL "Disable CommonLib tests in consumer" FORCE)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/.. CommonLibSSE EXCLUDE_FROM_ALL)
+
+# Create a simple test executable that uses CommonLib headers
+add_executable(
+	ConsumerTest
+	test.cpp
+)
+
+target_link_libraries(
+	ConsumerTest
+	PRIVATE
+	CommonLibSSE::CommonLibSSE
+)
+
+# Use CommonLib's precompiled header (critical for RTTI macros, stl namespace, etc.)
+target_precompile_headers(
+	ConsumerTest
+	PRIVATE
+		<SKSE/SKSE.h>
+		<RE/Skyrim.h>
+)
+
+# Enable testing
+enable_testing()
+add_test(
+	NAME ConsumerCompileTest
+	COMMAND ConsumerTest
+)

--- a/test_consumer/README.md
+++ b/test_consumer/README.md
@@ -1,0 +1,46 @@
+# Consumer Integration Test
+
+This directory contains an integration test that validates CommonLib works correctly when consumed as a CMake subdirectory dependency.
+
+## Purpose
+
+This test specifically validates that **CommonLib's internal STATIC_ASSERT_SIZE macros** compile correctly when the library is used as a dependency via `add_subdirectory()`.
+
+## The Problem This Test Catches
+
+Without the `/Zc:preprocessor` compiler flag, CommonLib's variadic macro dispatcher for `STATIC_ASSERT_SIZE` fails to expand correctly. This causes compilation errors like:
+
+```text
+error C2338: static_assert failed: 'STATIC_ASSERT_SIZE requires at least 2 arguments: ClassName and Size'
+```
+
+**The key issue**: CommonLib builds fine in isolation, but when consumed as a dependency, its own headers fail to compile due to the preprocessor issue.
+
+## How It Works
+
+1. The test includes CommonLib headers that contain `STATIC_ASSERT_SIZE` calls (PlayerCharacter, Actor, RaceSexMenu, etc.)
+2. Uses CommonLib's precompiled header to get necessary definitions (RTTI macros, `stl::` namespace, etc.)
+3. If `/Zc:preprocessor` is missing, these CommonLib headers fail to compile
+4. If the build succeeds, it proves the preprocessor fix is working
+
+## Running the Test
+
+**Note:** This test requires vcpkg dependencies since it builds CommonLib from source. Make sure vcpkg is set up correctly.
+
+```bash
+# With vcpkg toolchain file
+cmake -B build -S . \
+  -DCMAKE_TOOLCHAIN_FILE=/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake \
+  -DENABLE_SKYRIM_SE=ON \
+  -DENABLE_SKYRIM_AE=ON \
+  -DENABLE_SKYRIM_VR=ON
+
+cmake --build build --config Release
+./build/Release/ConsumerTest.exe
+```
+
+## Relationship to Other Tests
+
+- `tests/` - Unit tests that test CommonLib functionality
+- `test_package/` - Tests CommonLib as a Conan package (via `find_package`)
+- `test_consumer/` - Tests CommonLib as a subdirectory dependency (via `add_subdirectory`)

--- a/test_consumer/test.cpp
+++ b/test_consumer/test.cpp
@@ -1,0 +1,54 @@
+#include <iostream>
+
+// Include CommonLib headers that contain STATIC_ASSERT_SIZE calls
+// The key test is that these headers compile without errors when CommonLib is consumed as a dependency
+#include "RE/R/RaceSexMenu.h"
+#include "RE/P/PlayerCharacter.h"
+#include "RE/M/MapMenu.h"
+#include "RE/A/Actor.h"
+#include "RE/N/NiNode.h"
+#include "RE/T/TESObjectREFR.h"
+
+// This test validates that CommonLib's internal STATIC_ASSERT_SIZE macros compile correctly
+// when the library is used as a dependency (via add_subdirectory).
+//
+// THE ACTUAL ISSUE:
+// When Community Shaders (or any consumer) added CommonLib via add_subdirectory(), the build
+// failed with errors like:
+//   "error C2338: STATIC_ASSERT_SIZE requires at least 2 arguments: ClassName and Size"
+//   "error C2065: 'RTTI_PlayerCharacter': undeclared identifier"
+//   "error C2653: 'stl': is not a class or namespace name"
+//
+// These errors were in CommonLib's OWN headers (PlayerCharacter.h, Actor.h, RaceSexMenu.h, etc.),
+// NOT in the consumer's code. The consumer wasn't using STATIC_ASSERT_SIZE at all!
+//
+// Without /Zc:preprocessor, the variadic macro dispatcher in REL/Common.h doesn't work
+// with MSVC's traditional preprocessor, causing all STATIC_ASSERT_SIZE calls to fail.
+//
+// IMPORTANT: Consumer code must use CommonLib's PCH (SKSE/SKSE.h and RE/Skyrim.h) to get
+// the necessary RTTI macros, namespace definitions, and literal operators.
+
+int main()
+{
+	std::cout << "CommonLib consumer integration test\n";
+	std::cout << "====================================\n\n";
+	
+	std::cout << "Testing that CommonLib headers compile when used as a dependency...\n";
+	std::cout << "All headers included successfully!\n\n";
+	
+	// These are CommonLib's classes - the static_asserts are in CommonLib's headers
+	// If /Zc:preprocessor was missing, the #include statements above would have failed to compile
+	std::cout << "CommonLib class sizes (validated by STATIC_ASSERT_SIZE in headers):\n";
+	std::cout << "  PlayerCharacter: " << sizeof(RE::PlayerCharacter) << " bytes\n";
+	std::cout << "  Actor: " << sizeof(RE::Actor) << " bytes\n";
+	std::cout << "  RaceSexMenu: " << sizeof(RE::RaceSexMenu) << " bytes\n";
+	std::cout << "  MapMenu: " << sizeof(RE::MapMenu) << " bytes\n";
+	std::cout << "  NiNode: " << sizeof(RE::NiNode) << " bytes\n";
+	std::cout << "  TESObjectREFR: " << sizeof(RE::TESObjectREFR) << " bytes\n";
+	
+	std::cout << "\n✓ Test PASSED: CommonLib's STATIC_ASSERT_SIZE macros compiled successfully\n";
+	std::cout << "✓ /Zc:preprocessor flag is working correctly\n";
+	std::cout << "✓ Consumer code doesn't need to know about STATIC_ASSERT_SIZE macro\n";
+	
+	return 0;
+}

--- a/tests/REL/StaticAssertSize.test.cpp
+++ b/tests/REL/StaticAssertSize.test.cpp
@@ -1,0 +1,106 @@
+#include "catch2/catch_all.hpp"
+
+#include "REL/Relocation.h"
+
+// Test that STATIC_ASSERT_SIZE macro compiles correctly with various argument counts
+// This validates that /Zc:preprocessor is enabled and the variadic macro dispatcher works
+
+namespace
+{
+	// Test class with known size
+	struct TestClass1
+	{
+		std::uint64_t a;
+		std::uint32_t b;
+	};
+
+	// 2 args: ClassName, Size (same for all runtimes)
+	STATIC_ASSERT_SIZE(TestClass1, 0x10);
+
+	struct TestClass2
+	{
+		std::uint64_t a;
+		std::uint32_t b;
+		std::uint32_t c;
+	};
+
+	// 3 args: ClassName, FlatSize, VRSize
+	STATIC_ASSERT_SIZE(TestClass2, 0x10, 0x10);
+
+	struct TestClass3
+	{
+		std::uint64_t a;
+		std::uint64_t b;
+	};
+
+	// 4 args: ClassName, SESize, AESize, VRSize
+	STATIC_ASSERT_SIZE(TestClass3, 0x10, 0x10, 0x10);
+
+	struct TestClass4
+	{
+		std::uint64_t a;
+		std::uint64_t b;
+		std::uint32_t c;
+	};
+
+	// 5 args: ClassName, SESize, AESize, VRSize, AllSize
+	STATIC_ASSERT_SIZE(TestClass4, 0x18, 0x18, 0x18, 0x18);
+
+	struct TestClass5
+	{
+		std::uint64_t a;
+		std::uint64_t b;
+		std::uint64_t c;
+	};
+
+	// 6 args: ClassName, SESize, AESize, VRSize, AllSize, FlatSize
+	STATIC_ASSERT_SIZE(TestClass5, 0x18, 0x18, 0x18, 0x18, 0x18);
+}
+
+TEST_CASE("STATIC_ASSERT_SIZE/VariadicMacroDispatch")
+{
+	SECTION("2 arguments compile")
+	{
+		// If this test compiles, the 2-arg variant works
+		CHECK(sizeof(TestClass1) == 0x10);
+	}
+
+	SECTION("3 arguments compile")
+	{
+		// If this test compiles, the 3-arg variant works
+		CHECK(sizeof(TestClass2) == 0x10);
+	}
+
+	SECTION("4 arguments compile")
+	{
+		// If this test compiles, the 4-arg variant works
+		CHECK(sizeof(TestClass3) == 0x10);
+	}
+
+	SECTION("5 arguments compile")
+	{
+		// If this test compiles, the 5-arg variant works
+		CHECK(sizeof(TestClass4) == 0x18);
+	}
+
+	SECTION("6 arguments compile")
+	{
+		// If this test compiles, the 6-arg variant works
+		CHECK(sizeof(TestClass5) == 0x18);
+	}
+}
+
+TEST_CASE("STATIC_ASSERT_SIZE/PreprocessorConformance")
+{
+	// This test validates that /Zc:preprocessor is enabled
+	// Without it, the variadic macro dispatcher fails and all STATIC_ASSERT_SIZE
+	// calls incorrectly route to _STATIC_ASSERT_SIZE_1, causing compile errors
+
+	SECTION("Macro expands correctly")
+	{
+		// The fact that this file compiles proves the preprocessor is working
+		// If /Zc:preprocessor is missing, compilation fails with:
+		// "STATIC_ASSERT_SIZE requires at least 2 arguments: ClassName and Size"
+		CHECK(true);
+	}
+}


### PR DESCRIPTION
Add comprehensive testing to catch preprocessor-related compilation failures when CommonLib is consumed as a dependency:

1. **Unit Test (tests/REL/StaticAssertSize.test.cpp)**:
   - Tests all STATIC_ASSERT_SIZE variants (2-6 arguments)
   - Validates variadic macro dispatcher works correctly
   - Ensures /Zc:preprocessor flag is effective
   - Compile-time validation catches macro expansion failures

2. **Consumer Integration Test (test_consumer/)**:
   - Simulates real-world usage as a CMake subdirectory dependency
   - Simply includes CommonLib headers (PlayerCharacter.h, Actor.h, etc.)
   - If /Zc:preprocessor is missing, CommonLib's OWN headers fail to compile
   - The consumer doesn't use STATIC_ASSERT_SIZE - it just includes headers
   - Separate from test_package (which tests Conan find_package usage)

3. **CI/CD Workflow (test-consumer.yml)**:
   - Automated testing on ng branch push/PR only
   - Builds consumer test and validates headers compile
   - Prevents regressions in dependency integration

The original issue: When Community Shaders consumed CommonLib via add_subdirectory(), the build failed with errors in CommonLib's OWN headers, NOT in consumer code. Without /Zc:preprocessor, the variadic macro dispatcher doesn't work with MSVC's traditional preprocessor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added consumer integration tests to verify the library can be consumed by a downstream project and to print runtime sizing diagnostics.
  * Added unit tests validating STATIC_ASSERT_SIZE macro behavior and preprocessor conformance.
* **CI**
  * Added a Windows end-to-end CI job to build and run the consumer integration test in Release.
* **Documentation**
  * Added README documenting the consumer integration test setup and usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->