### PR TITLE
fix(xmake): Add preprocessor flag

### DIFF
--- a/include/RE/N/NiNode.h
+++ b/include/RE/N/NiNode.h
@@ -73,5 +73,5 @@ namespace RE
 	protected:
 		NiNode* Ctor(std::uint16_t a_arrBufLen);
 	};
-	STATIC_ASSERT_SIZE(NiNode, 0x128, 0x150)
+	STATIC_ASSERT_SIZE(NiNode, 0x128, 0x150);
 }

--- a/xmake.lua
+++ b/xmake.lua
@@ -141,7 +141,7 @@ target("commonlibsse-ng")
     set_pcxxheader("include/SKSE/Impl/PCH.h")
 
     -- add flags
-    add_cxxflags("/EHsc", "/permissive-", { public = true })
+    add_cxxflags("/EHsc", "/permissive-", "/Zc:preprocessor", { public = true })
 
     -- add flags (cl)
     add_cxxflags(


### PR DESCRIPTION
cl::/Zc:preprocessor and /Zc:preprocessor are not the same, huh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected syntax in assertion macro.
  * Enhanced C++ compiler preprocessing conformance flags for improved build compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->