### PR TITLE
fix(VR): GetActiveEffectList shim

### DIFF
--- a/include/RE/A/Actor.h
+++ b/include/RE/A/Actor.h
@@ -366,42 +366,10 @@ namespace RE
 #endif
 
 		// override (MagicTarget)
-#ifndef ENABLE_SKYRIM_AE
-		[[nodiscard]] Actor* GetTargetStatsObject() override;      // 002 - { return this; }
-		[[nodiscard]] bool   MagicTargetIsActor() const override;  // 003 - { return true; }
-		/**
-		 * @brief Get the list of active effects on this actor
-		 * @return Pointer to list of active effects
-		 * 
-		 * @warning Behavior differs between runtimes:
-		 * 
-		 * @note SE/AE: Returns the game's native persistent list stored in actor memory.
-		 *       The list remains valid and can be safely stored or iterated multiple times.
-		 * 
-		 * @note VR (when running on Skyrim VR): Returns a thread-local temporary snapshot.
-		 *       VR has no native GetActiveEffectList() - this is a compatibility shim.
-		 *       The returned pointer is ONLY valid until the next call to this function on the same thread.
-		 *       DO NOT store the pointer. Iterate immediately and discard.
-		 *       For robust VR code, use MagicTarget::VisitActiveEffects() instead.
-		 */
-		[[nodiscard]] BSSimpleList<ActiveEffect*>* GetActiveEffectList() override;  // 007
-#else
-		/**
-		 * @brief Get the list of active effects on this actor
-		 * @return Pointer to list of active effects
-		 * 
-		 * @warning Behavior differs between runtimes:
-		 * 
-		 * @note SE/AE: Returns the game's native persistent list stored in actor memory.
-		 *       The list remains valid and can be safely stored or iterated multiple times.
-		 * 
-		 * @note VR (when running on Skyrim VR): Returns a thread-local temporary snapshot.
-		 *       VR has no native GetActiveEffectList() - this is a compatibility shim.
-		 *       The returned pointer is ONLY valid until the next call to this function on the same thread.
-		 *       DO NOT store the pointer. Iterate immediately and discard.
-		 *       For robust VR code, use MagicTarget::VisitActiveEffects() instead.
-		 */
-		[[nodiscard]] SKYRIM_REL_VR_VIRTUAL BSSimpleList<ActiveEffect*>* GetActiveEffectList();  // 007
+#ifndef ENABLE_SKYRIM_VR
+		[[nodiscard]] Actor*                       GetTargetStatsObject() override;      // 002 - { return this; }
+		[[nodiscard]] bool                         MagicTargetIsActor() const override;  // 003 - { return true; }
+		[[nodiscard]] BSSimpleList<ActiveEffect*>* GetActiveEffectList() override;       // 007
 #endif
 
 		// add

--- a/include/RE/A/Actor.h
+++ b/include/RE/A/Actor.h
@@ -135,7 +135,6 @@ namespace RE
 	NiSmartPointer(Actor);
 
 	class Actor :
-#ifndef ENABLE_SKYRIM_AE
 		public TESObjectREFR,                              // 000
 		public MagicTarget,                                // 098, 0A0
 		public ActorValueOwner,                            // 0B0, 0B8
@@ -143,9 +142,6 @@ namespace RE
 		public BSTEventSink<BSTransformDeltaEvent>,        // 0C8, 0D0
 		public BSTEventSink<bhkCharacterMoveFinishEvent>,  // 0D0, 0D8
 		public IPostAnimationChannelUpdateFunctor          // 0D8, 0E0
-#else
-		public TESObjectREFR  // 000
-#endif
 	{
 	private:
 		using EntryPoint = BGSEntryPointPerkEntry::EntryPoint;
@@ -759,6 +755,6 @@ namespace RE
 		float       CalcEquippedWeight();
 		TESFaction* GetCrimeFactionImpl() const;
 	};
-	STATIC_ASSERT_SIZE(Actor, 0x2B0, 0x78, 0x2B0, 0x78);
+	STATIC_ASSERT_SIZE(Actor, 0x2B0, 0xD0, 0x2B0, 0xC0);
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/C/Character.h
+++ b/include/RE/C/Character.h
@@ -56,5 +56,5 @@ namespace RE
 		virtual void Unk_128(void);  // 128
 		virtual void Unk_129(void);  // 129 - { return 1; }
 	};
-	STATIC_ASSERT_SIZE(Character, 0x2B0, 0x78, 0x2B0, 0x78, 0x78);
+	STATIC_ASSERT_SIZE(Character, 0x2B0, 0xD0, 0x2B0, 0xC0, 0xC0);
 }

--- a/include/RE/M/MagicTarget.h
+++ b/include/RE/M/MagicTarget.h
@@ -154,7 +154,6 @@ namespace RE
 		void                         EffectRemoved(ActiveEffect* a_effect);                                                // 09 - { return; }
 		float                        CheckResistance(MagicItem* a_magicItem, Effect* a_effect, TESBoundObject* a_object);  // 0A - { return 1.0; }
 		bool                         CheckAbsorb(Actor* a_actor, MagicItem* a_magicItem, const Effect* a_effect);          // 0B - { return false; }
-
 #endif
 		bool DispelEffect(MagicItem* a_spell, BSPointerHandle<Actor>& a_caster, ActiveEffect* a_effect = nullptr);
 #if defined(ENABLE_SKYRIM_VR)

--- a/include/RE/M/MagicTarget.h
+++ b/include/RE/M/MagicTarget.h
@@ -132,18 +132,21 @@ namespace RE
 		bool               CanAddActiveEffect();                                    // 06
 
 		/**
-		 * @brief Get the list of active effects on this actor
+		 * @brief Get the list of active effects on this magic target
 		 * @return Pointer to list of active effects
 		 * 
-		 * @warning Behavior differs between runtimes:
+		 * @warning In VR-enabled builds (SKYRIM_CROSS_VR or EXCLUSIVE_SKYRIM_VR),
+		 *          behavior differs depending on the runtime:
 		 * 
-		 * @note SE/AE: Returns the game's native persistent list stored in actor memory.
-		 *       The list remains valid and can be safely stored or iterated multiple times.
+		 * @note When running on Skyrim SE/AE: Calls through the game's vtable and
+		 *       returns the native persistent list. The list remains valid and can
+		 *       be safely stored or iterated multiple times.
 		 * 
-		 * @note VR (when running on Skyrim VR): Returns a thread-local temporary snapshot.
+		 * @note When running on Skyrim VR: Returns a thread-local temporary snapshot.
 		 *       VR has no native GetActiveEffectList() - this is a compatibility shim.
-		 *       The returned pointer is ONLY valid until the next call to this function on the same thread.
-		 *       DO NOT store the pointer. Iterate immediately and discard.
+		 *       The returned pointer is ONLY valid until the next call to this function
+		 *       on the same thread. DO NOT store the pointer. DO NOT call recursively.
+		 *       Iterate immediately and discard.
 		 *       For robust VR code, use MagicTarget::VisitActiveEffects() instead.
 		 */
 		BSSimpleList<ActiveEffect*>* GetActiveEffectList();

--- a/include/RE/M/MagicTarget.h
+++ b/include/RE/M/MagicTarget.h
@@ -112,7 +112,8 @@ namespace RE
 		virtual ~MagicTarget();  // 00
 
 		// add
-		virtual bool                         AddTarget(AddTargetData& a_targetData);                                               // 01
+		virtual bool AddTarget(AddTargetData& a_targetData);  // 01
+#ifndef ENABLE_SKYRIM_VR
 		virtual TESObjectREFR*               GetTargetStatsObject();                                                               // 02 - { return false; }
 		[[nodiscard]] virtual bool           MagicTargetIsActor() const;                                                           // 03 - { return false; }
 		virtual bool                         IsInvulnerable();                                                                     // 04 - { return false; }
@@ -123,7 +124,35 @@ namespace RE
 		virtual void                         EffectRemoved(ActiveEffect* a_effect);                                                // 09 - { return; }
 		virtual float                        CheckResistance(MagicItem* a_magicItem, Effect* a_effect, TESBoundObject* a_object);  // 0A - { return 1.0; }
 		virtual bool                         CheckAbsorb(Actor* a_actor, MagicItem* a_magicItem, const Effect* a_effect);          // 0B - { return false; }
+#else
+		TESObjectREFR*     GetTargetStatsObject();                                  // 02 - { return false; }
+		[[nodiscard]] bool MagicTargetIsActor() const;                              // 03 - { return false; }
+		bool               IsInvulnerable();                                        // 04 - { return false; }
+		void               InvalidateCommandedActorEffect(ActiveEffect* a_effect);  // 05 - { return; }
+		bool               CanAddActiveEffect();                                    // 06
 
+		/**
+		 * @brief Get the list of active effects on this actor
+		 * @return Pointer to list of active effects
+		 * 
+		 * @warning Behavior differs between runtimes:
+		 * 
+		 * @note SE/AE: Returns the game's native persistent list stored in actor memory.
+		 *       The list remains valid and can be safely stored or iterated multiple times.
+		 * 
+		 * @note VR (when running on Skyrim VR): Returns a thread-local temporary snapshot.
+		 *       VR has no native GetActiveEffectList() - this is a compatibility shim.
+		 *       The returned pointer is ONLY valid until the next call to this function on the same thread.
+		 *       DO NOT store the pointer. Iterate immediately and discard.
+		 *       For robust VR code, use MagicTarget::VisitActiveEffects() instead.
+		 */
+		BSSimpleList<ActiveEffect*>* GetActiveEffectList();
+		void                         EffectAdded(ActiveEffect* a_effect);                                                  // 08 - { return; }
+		void                         EffectRemoved(ActiveEffect* a_effect);                                                // 09 - { return; }
+		float                        CheckResistance(MagicItem* a_magicItem, Effect* a_effect, TESBoundObject* a_object);  // 0A - { return 1.0; }
+		bool                         CheckAbsorb(Actor* a_actor, MagicItem* a_magicItem, const Effect* a_effect);          // 0B - { return false; }
+
+#endif
 		bool DispelEffect(MagicItem* a_spell, BSPointerHandle<Actor>& a_caster, ActiveEffect* a_effect = nullptr);
 #if defined(ENABLE_SKYRIM_VR)
 		void DispelEffectsWithArchetype(Archetype a_type, bool a_force);

--- a/include/RE/N/NonActorMagicTarget.h
+++ b/include/RE/N/NonActorMagicTarget.h
@@ -25,10 +25,12 @@ namespace RE
 		ExtraDataType GetType() const override;  // 01 - { return kNonActorMagicTarget; }
 
 		// override (MagicTarget)
-		bool                         AddTarget(AddTargetData& a_targetData) override;  // 01
-		TESObjectREFR*               GetTargetStatsObject() override;                  // 02 - { return targetObject; }
-		bool                         CanAddActiveEffect() override;                    // 06 - { return true; }
-		BSSimpleList<ActiveEffect*>* GetActiveEffectList() override;                   // 07 - { return &activeEffects; }
+		bool AddTarget(AddTargetData& a_targetData) override;  // 01
+#ifndef ENABLE_SKYRIM_VR
+		TESObjectREFR*               GetTargetStatsObject() override;  // 02 - { return targetObject; }
+		bool                         CanAddActiveEffect() override;    // 06 - { return true; }
+		BSSimpleList<ActiveEffect*>* GetActiveEffectList() override;   // 07 - { return &activeEffects; }
+#endif
 
 		// members
 		TESObjectREFR*              targetObject;   // 28

--- a/include/RE/P/PlayerCharacter.h
+++ b/include/RE/P/PlayerCharacter.h
@@ -953,7 +953,7 @@ namespace RE
 	private:
 		bool CenterOnCell_Impl(const char* a_cellName, RE::TESObjectCELL* a_cell);
 	};
-	STATIC_ASSERT_SIZE(PlayerCharacter, 0xBE0, 0x9A8, 0x12F0, 0x1A0);
+	STATIC_ASSERT_SIZE(PlayerCharacter, 0xBE0, 0xA00, 0x12F0, 0x1E8);
 }
 #undef PLAYER_RUNTIME_DATA_CONTENT
 #undef VR_PLAYER_RUNTIME_DATA_CONTENT

--- a/include/RE/T/TESObjectREFR.h
+++ b/include/RE/T/TESObjectREFR.h
@@ -493,8 +493,11 @@ namespace RE
 		LOADED_REF_DATA* loadedData;  // 68
 		ExtraDataList    extraList;   // 70
 
-#ifndef ENABLE_SKYRIM_AE
-		RUNTIME_DATA_CONTENT
+#if defined(EXCLUSIVE_SKYRIM_SE) || defined(EXCLUSIVE_SKYRIM_VR)
+		RUNTIME_DATA_CONTENT;  // 0x88
+#elif defined(EXCLUSIVE_SKYRIM_AE)
+		// No padding needed - ExtraDataList naturally ends at 0x90
+		RUNTIME_DATA_CONTENT;  // 0x90
 #endif
 
 	private:
@@ -503,6 +506,6 @@ namespace RE
 		void              MoveTo_Impl(const ObjectRefHandle& a_targetHandle, TESObjectCELL* a_targetCell, TESWorldSpace* a_selfWorldSpace, const NiPoint3& a_position, const NiPoint3& a_rotation);
 		void              PlayAnimation_Impl(NiControllerManager* a_manager, NiControllerSequence* a_toSeq, NiControllerSequence* a_fromSeq, bool a_arg4 = false);
 	};
-	STATIC_ASSERT_SIZE(TESObjectREFR, 0x98, 0x78, 0x98);
+	STATIC_ASSERT_SIZE(TESObjectREFR, 0x98, 0x88, 0x98);
 }
 #undef RUNTIME_DATA_CONTENT

--- a/src/RE/A/Actor.cpp
+++ b/src/RE/A/Actor.cpp
@@ -2124,48 +2124,4 @@ namespace RE
 		return RelocateVirtual<decltype(&Actor::CheckClampDamageModifier)>(0x127, 0x129, this, a_av, a_delta);
 	}
 #endif
-
-#ifdef ENABLE_SKYRIM_VR
-	namespace
-	{
-		BSSimpleList<ActiveEffect*>* BuildActiveEffectSnapshot(MagicTarget& magicTarget)
-		{
-			static thread_local std::vector<ActiveEffect*>  effectsVec{};
-			static thread_local BSSimpleList<ActiveEffect*> activeEffects{};
-
-			effectsVec.clear();
-			activeEffects.clear();
-
-			magicTarget.VisitActiveEffects([&](ActiveEffect* ae) -> BSContainer::ForEachResult {
-				if (ae) {
-					effectsVec.push_back(ae);
-				}
-				return BSContainer::ForEachResult::kContinue;
-			});
-
-			for (auto it = effectsVec.rbegin(); it != effectsVec.rend(); ++it) {
-				activeEffects.push_front(*it);
-			}
-
-			return &activeEffects;
-		}
-	}
-#endif
-
-	BSSimpleList<ActiveEffect*>* Actor::GetActiveEffectList()
-	{
-		auto* magicTarget = this->AsMagicTarget();
-		if (!magicTarget) {
-			return nullptr;
-		}
-
-#ifdef ENABLE_SKYRIM_VR
-		if (REL::Module::IsVR()) {
-			// VR COMPATIBILITY SHIM: Skyrim VR lacks native GetActiveEffectList()
-			return BuildActiveEffectSnapshot(*magicTarget);
-		}
-#endif
-		// SE/AE: Call the game's native virtual implementation
-		return magicTarget->GetActiveEffectList();
-	}
 }

--- a/src/RE/M/MagicTarget.cpp
+++ b/src/RE/M/MagicTarget.cpp
@@ -43,7 +43,7 @@ namespace RE
 
 	BSSimpleList<ActiveEffect*>* MagicTarget::GetActiveEffectList()
 	{
-		if (REL::Module::IsVR()) {
+		if SKYRIM_REL_VR_CONSTEXPR (REL::Module::IsVR()) {
 			// VR: Build a thread-local snapshot using VisitActiveEffects
 			static thread_local std::vector<ActiveEffect*>  effectsVec{};
 			static thread_local BSSimpleList<ActiveEffect*> activeEffects{};

--- a/src/RE/M/MagicTarget.cpp
+++ b/src/RE/M/MagicTarget.cpp
@@ -2,6 +2,7 @@
 
 #include "RE/A/ActiveEffect.h"
 #include "RE/A/Actor.h"
+#include "RE/B/BSSimpleList.h"
 #include "RE/B/BSTList.h"
 #include "RE/E/EffectSetting.h"
 
@@ -15,6 +16,79 @@ namespace RE
 	}
 
 #if defined(ENABLE_SKYRIM_VR)
+	TESObjectREFR* MagicTarget::GetTargetStatsObject()
+	{
+		return REL::RelocateVirtual<decltype(&MagicTarget::GetTargetStatsObject)>(0x2, 0x2, this);
+	}
+
+	[[nodiscard]] bool MagicTarget::MagicTargetIsActor() const
+	{
+		return REL::RelocateVirtual<decltype(&MagicTarget::MagicTargetIsActor)>(0x3, 0x3, this);
+	}
+
+	[[nodiscard]] bool MagicTarget::IsInvulnerable()
+	{
+		return REL::RelocateVirtual<decltype(&MagicTarget::IsInvulnerable)>(0x4, 0x4, this);
+	}
+
+	void MagicTarget::InvalidateCommandedActorEffect(ActiveEffect* a_effect)
+	{
+		REL::RelocateVirtual<decltype(&MagicTarget::InvalidateCommandedActorEffect)>(0x5, 0x5, this, a_effect);
+	}
+
+	bool MagicTarget::CanAddActiveEffect()
+	{
+		return REL::RelocateVirtual<decltype(&MagicTarget::CanAddActiveEffect)>(0x6, 0x6, this);
+	}
+
+	BSSimpleList<ActiveEffect*>* MagicTarget::GetActiveEffectList()
+	{
+		if (REL::Module::IsVR()) {
+			// VR: Build a thread-local snapshot using VisitActiveEffects
+			static thread_local std::vector<ActiveEffect*>  effectsVec{};
+			static thread_local BSSimpleList<ActiveEffect*> activeEffects{};
+
+			effectsVec.clear();
+			activeEffects.clear();
+
+			VisitActiveEffects([&](ActiveEffect* ae) -> BSContainer::ForEachResult {
+				if (ae) {
+					effectsVec.push_back(ae);
+				}
+				return BSContainer::ForEachResult::kContinue;
+			});
+
+			for (auto it = effectsVec.rbegin(); it != effectsVec.rend(); ++it) {
+				activeEffects.push_front(*it);
+			}
+
+			return &activeEffects;
+		} else {
+			// SE/AE: Call the pure virtual function via vtable
+			return REL::RelocateVirtual<decltype(&MagicTarget::GetActiveEffectList)>(0x07, 0x07, this);
+		}
+	}
+
+	void MagicTarget::EffectAdded(ActiveEffect* a_effect)
+	{
+		REL::RelocateVirtual<decltype(&MagicTarget::EffectAdded)>(0x8, 0x8, this, a_effect);
+	}
+
+	void MagicTarget::EffectRemoved(ActiveEffect* a_effect)
+	{
+		REL::RelocateVirtual<decltype(&MagicTarget::EffectRemoved)>(0x9, 0x9, this, a_effect);
+	}
+
+	float MagicTarget::CheckResistance(MagicItem* a_magicItem, Effect* a_effect, TESBoundObject* a_object)
+	{
+		return REL::RelocateVirtual<decltype(&MagicTarget::CheckResistance)>(0xa, 0xa, this, a_magicItem, a_effect, a_object);
+	}
+
+	bool MagicTarget::CheckAbsorb(Actor* a_actor, MagicItem* a_magicItem, const Effect* a_effect)
+	{
+		return REL::RelocateVirtual<decltype(&MagicTarget::CheckAbsorb)>(0xb, 0xb, this, a_actor, a_magicItem, a_effect);
+	}
+
 	void MagicTarget::DispelEffectsWithArchetype(Archetype a_type, bool a_force)
 	{
 		std::vector<RE::ActiveEffect*> queued;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified VR vs non‑VR public interfaces for actors and magic targets under a single VR guard, removing legacy branching and compatibility shims.

* **New Features**
  * Added VR-specific active-effect handling and a VR-aware active-effect snapshot/listing behavior to improve VR runtime behavior.

* **Chores**
  * Updated several type layout and size validations to match the reorganized public interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->