### PR TITLE
docs: update README due to fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It supports Skyrim Special Edition (SE), Skyrim Anniversary Edition (AE), and Sk
 
 ## Usage
 
-For SKSE plugin development, you want to have CommonLibSSE-NG available for discovery, and included as a build dependency.
+To develop a C++ project that uses CommonLibSSE, you'll want to have this code available for discovery, and included as a build dependency by your build manager. Below are examples using the `xmake` or `cmake` managers.
 
 ### Getting the code: Git SubModule
 
@@ -36,7 +36,6 @@ remote: Compressing objects: 100% (197/197), done.
 remote: Total 66210 (delta 2397), reused 2335 (delta 2329), pack-reused 63684 (from 1)
 Receiving objects: 100% (66210/66210), 18.99 MiB | 19.58 MiB/s, done.
 Resolving deltas: 100% (51252/51252), done.
-warning: in the working copy of '.gitmodules', LF will be replaced by CRLF the next time Git touches it
 PS E:\Git\foo-bar
 ```
 
@@ -44,6 +43,11 @@ PS E:\Git\foo-bar
 > If your submodule ended up in a location where the rest of the code can't find it, you can remove & re-add submodules, see https://stackoverflow.com/a/1260982
 
 At this point, git is tracking changes to your code in your machine. You can add a cloud-based remote for backup, distribution, or collaboration; instructions are here for [GitHub](https://docs.github.com/en/migrations/importing-source-code/using-the-command-line-to-import-source-code/adding-locally-hosted-code-to-github) or [CodeBerg](https://docs.codeberg.org/getting-started/first-repository/).
+
+To update your project's submodules you can use:
+```powershell
+PS E:\Git\foo-bar> git submodule update --init --recursive
+```
 
 ### Build Dependency: Xmake
 
@@ -71,22 +75,20 @@ find_package(CommonLibSSE REQUIRED)
 target_link_libraries(${PROJECT_NAME} PUBLIC CommonLibSSE::CommonLibSSE)
 ```
 
-For more information on how to use CommonLibSSE NG, you can look at the
-[example plugin](https://gitlab.com/colorglass/commonlibsse-sample-plugin).
-
 ### Example Projects
 
-#### PrismaUI-SKSE/example-skse-plugin
+#### Community Shaders
+
+Available at https://github.com/doodlum/skyrim-community-shaders, this is an SKSE plugin for advanced graphics manipulations, replacing several of Skyrim's shaders. It uses the `cmake` build system. Hosted on Nexus Mods at https://www.nexusmods.com/skyrimspecialedition/mods/86492
+
+#### Crash Logger SSE
+
+Available at https://github.com/alandtse/CrashLoggerSSE, this is an SKSE plugin that generates logs when the game crashes. It uses the `cmake` build system. Hosted on Nexus mods at [https://www.nexusmods.com/skyrimspecialedition/mods/87706](https://www.nexusmods.com/skyrimspecialedition/mods/59818)
+
+#### PrismaUI Example Plugin
 
 Available at https://github.com/PrismaUI-SKSE/example-skse-plugin, this is a template project, meant to be forked and tinkered. It uses the `xmake` build system, and has minimal configuration requirements. The PrismaUI components are easy to remove to make a more general SKSE plugin.
 
-#### Dylbill-Iroh/Skypal_NG
-
-Available at https://github.com/Dylbill-Iroh/Skypal_NG, this is a single-file full SKSE plugin. It produces a DLL drop-in replacement for SkyPal suitable for Skyrim AE. The result is hosted on Nexus Mods at https://www.nexusmods.com/skyrimspecialedition/mods/101817
-
-#### jarari/DynamicKeyActionFramework
-
-Available at https://github.com/jarari/DynamicKeyActionFramework, this is an SKSE plugin that allows playing animations with keybinds. Hosted on Nexus mods at https://www.nexusmods.com/skyrimspecialedition/mods/87706
 
 ## New Features
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ It supports Skyrim Special Edition (SE), Skyrim Anniversary Edition (AE), and Sk
 
 To develop a C++ project that uses CommonLibSSE, you'll want to have this code available for discovery, and included as a build dependency by your build manager. Below are examples using the `xmake` or `cmake` managers.
 
+> [!TIP]
+> For examples & templates see the wiki: https://github.com/alandtse/CommonLibVR/wiki/Projects-using-CommonLib
+
 ### Getting the code: Git SubModule
 
 Assuming you have a folder with your mod material, this can be converted to a git repository, for which this repo can be added as a submodule,
@@ -74,21 +77,6 @@ If using the [CMake build system](https://cmake.org/cmake/help/v4.2/index.html#)
 find_package(CommonLibSSE REQUIRED)
 target_link_libraries(${PROJECT_NAME} PUBLIC CommonLibSSE::CommonLibSSE)
 ```
-
-### Example Projects
-
-#### Community Shaders
-
-Available at https://github.com/doodlum/skyrim-community-shaders, this is an SKSE plugin for advanced graphics manipulations, replacing several of Skyrim's shaders. It uses the `cmake` build system. Hosted on Nexus Mods at https://www.nexusmods.com/skyrimspecialedition/mods/86492
-
-#### Crash Logger SSE
-
-Available at https://github.com/alandtse/CrashLoggerSSE, this is an SKSE plugin that generates logs when the game crashes. It uses the `cmake` build system. Hosted on Nexus mods at [https://www.nexusmods.com/skyrimspecialedition/mods/87706](https://www.nexusmods.com/skyrimspecialedition/mods/59818)
-
-#### PrismaUI Example Plugin
-
-Available at https://github.com/PrismaUI-SKSE/example-skse-plugin, this is a template project, meant to be forked and tinkered. It uses the `xmake` build system, and has minimal configuration requirements. The PrismaUI components are easy to remove to make a more general SKSE plugin.
-
 
 ## New Features
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,92 @@
 # CommonLibSSE NG
 
-[![C++23](https://img.shields.io/static/v1?label=standard&message=c%2B%2B20&color=blue&logo=c%2B%2B&&logoColor=white&style=flat)](https://en.cppreference.com/w/cpp/compiler_support)
+[![C++23](https://img.shields.io/static/v1?label=standard&message=c%2B%2B23&color=blue&logo=c%2B%2B&&logoColor=white&style=flat)](https://en.cppreference.com/w/cpp/compiler_support)
 ![Platform](https://img.shields.io/static/v1?label=platform&message=windows&color=dimgray&style=flat&logo=windows)
 [![Latest Release](https://img.shields.io/github/v/release/alandtse/CommonLibVR?logo=pkgsrc&logoColor=white)](#use)
 [![Main CI](https://github.com/alandtse/CommonLibVR/actions/workflows/main_ci.yml/badge.svg?branch=ng)](https://github.com/alandtse/CommonLibVR/actions/workflows/main_ci.yml)
 
-CommonLibSSE NG is a fork of CommonLibSSE which tracks upstream updates but adds a number of enhancements.
+CommonLibSSE NG is a fork of CharmedBaryon's CommonLibSSE-NG, itself a fork of CommonLibSSE, which tracks upstream updates but adds a number of enhancements.
+It supports Skyrim Special Edition (SE), Skyrim Anniversary Edition (AE), and Skyrim Virtual Reality (VR).
+
+## Usage
+
+For SKSE plugin development, you want to have CommonLibSSE-NG available for discovery, and included as a build dependency.
+
+### Getting the code: Git SubModule
+
+Assuming you have a folder with your mod material, this can be converted to a git repository, for which this repo can be added as a submodule,
+allowing git to manage updates, paths, names, versions... To do this:
+
+Use the folder to [initialize a git repository](https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository):
+
+```powershell
+PS E:\Git\foo-bar> git init
+Initialized empty Git repository in E:/Git/foo-bar/.git/
+```
+
+Add this CommonLibSSE repo as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules), specifying the `ng` branch,
+and storing it in `lib/commonlibsse-ng` folder:
+
+```powershell
+PS E:\Git\foo-bar> git submodule add -b ng https://github.com/alandtse/CommonLibVR.git lib/commonlibsse-ng
+Cloning into 'E:/Git/foo-bar/lib/commonlibsse-ng'...
+remote: Enumerating objects: 66210, done.
+remote: Counting objects: 100% (2526/2526), done.
+remote: Compressing objects: 100% (197/197), done.
+remote: Total 66210 (delta 2397), reused 2335 (delta 2329), pack-reused 63684 (from 1)
+Receiving objects: 100% (66210/66210), 18.99 MiB | 19.58 MiB/s, done.
+Resolving deltas: 100% (51252/51252), done.
+warning: in the working copy of '.gitmodules', LF will be replaced by CRLF the next time Git touches it
+PS E:\Git\foo-bar
+```
+
+> [!TIP]
+> If your submodule ended up in a location where the rest of the code can't find it, you can remove & re-add submodules, see https://stackoverflow.com/a/1260982
+
+At this point, git is tracking changes to your code in your machine. You can add a cloud-based remote for backup, distribution, or collaboration; instructions are here for [GitHub](https://docs.github.com/en/migrations/importing-source-code/using-the-command-line-to-import-source-code/adding-locally-hosted-code-to-github) or [CodeBerg](https://docs.codeberg.org/getting-started/first-repository/).
+
+### Build Dependency: Xmake
+
+If using the [Xmake build system](https://xmake.io/guide/introduction.html), you can add a build dependency and
+a custom rule suitable for SKSE plugins by adding this to your DLL target recipe:
+
+```xmake
+target("my_plugin")
+   set_kind("shared")                         --specifies this is a DLL
+   add_deps("commonlibsse-ng")                --adds the dependency
+
+   add_rules("commonlibsse-ng.plugin", {      --adds a custom build rule, whose details are in CommonLibSSE
+      name = "my_plugin",
+      author = "Dovahkiin",
+      description = "SKSE64 plugin using CommonLibSSE-NG"
+   })
+```
+
+### Build Dependency: CMake
+
+If using the [CMake build system](https://cmake.org/cmake/help/v4.2/index.html#), you can add the following in `CMakeLists.txt` to compile and link successfully:
+
+```cmake
+find_package(CommonLibSSE REQUIRED)
+target_link_libraries(${PROJECT_NAME} PUBLIC CommonLibSSE::CommonLibSSE)
+```
+
+For more information on how to use CommonLibSSE NG, you can look at the
+[example plugin](https://gitlab.com/colorglass/commonlibsse-sample-plugin).
+
+### Example Projects
+
+#### PrismaUI-SKSE/example-skse-plugin
+
+Available at https://github.com/PrismaUI-SKSE/example-skse-plugin, this is a template project, meant to be forked and tinkered. It uses the `xmake` build system, and has minimal configuration requirements. The PrismaUI components are easy to remove to make a more general SKSE plugin.
+
+#### Dylbill-Iroh/Skypal_NG
+
+Available at https://github.com/Dylbill-Iroh/Skypal_NG, this is a single-file full SKSE plugin. It produces a DLL drop-in replacement for SkyPal suitable for Skyrim AE. The result is hosted on Nexus Mods at https://www.nexusmods.com/skyrimspecialedition/mods/101817
+
+#### jarari/DynamicKeyActionFramework
+
+Available at https://github.com/jarari/DynamicKeyActionFramework, this is an SKSE plugin that allows playing animations with keybinds. Hosted on Nexus mods at https://www.nexusmods.com/skyrimspecialedition/mods/87706
 
 ## New Features
 
@@ -72,22 +153,14 @@ example, tests to be run within a single test suite that vary between SE, AE, an
 [Read more on
 the project wiki.](https://github.com/CharmedBaryon/CommonLibSSE-NG/wiki/Unit-Testing)
 
-### Versioned Releases via Vcpkg and Conan
+### Older Releases via Vcpkg and Conan
 
-![stability-stable](https://img.shields.io/static/v1?label=vcpkg&message=stable&color=dimgreen&style=flat)
+> [!WARNING]
+> These are not part of this repository and are not currently maintained.
 
-![stability-experimental](https://img.shields.io/static/v1?label=conan&message=experimental&color=orange&style=flat)
-
-Traditionally CommonLibSSE is consumed via a Git submodule; this practice generally requires the project using it to add
-CommonLibSSE's own Vcpkg dependencies and parts of it CMake configuration, as CommonLibSSE is built as a part of the
-plugin project. CommonLibSSE NG instead uses specific releases with semantic versioning, and distributes them as their
-own Vcpkg ports, through the [Color-Glass Studios Vcpkg repository](https://gitlab.com/colorglass/vcpkg-colorglass).
-As a result, it is simpler to use, does not require absorbing transitive requirements into your own project, and needs
-only be built once (cleaning will not require rebuilding CommonLibSSE, only your own code).
-
-In addition, starting with version 3.5.0, CommonLibSSE NG can now be both built and consumed via the Conan package
-manager, both as a source build or prebuilt packages targeting Windows on x86_64 with Visual Studio compiler versions 16
-and 17 (2019 and 2022).
+Older versions of CommonLibSSE, specifically CharmedByron's, are (were) available as a
+[vcpkg port](https://gitlab.com/colorglass/vcpkg-colorglass) and as a 
+[Conan package](https://charmedbaryon.jfrog.io/artifactory/api/conan/default-conan). These are not maintained as part of this project.
 
 [See how to use CommonLibSSE NG in your project.](#use)
 
@@ -97,7 +170,7 @@ and 17 (2019 and 2022).
 
 CommonLibSSE NG migrates the build system to Ninja, resulting in faster parallel builds than NMake.
 
-## Other Changes
+### Other Changes
 
 - Ability to define offsets and address IDs for objects which can exist in only a subset of runtimes, while being able
   dynamically test for feature support before using those offsets.
@@ -107,118 +180,19 @@ CommonLibSSE NG migrates the build system to Ninja, resulting in faster parallel
   [Fully Dynamic Game Engine](https://gitlab.com/colorglass/fully-dynamic-game-engine)).
 - Better support for the CLion IDE.
 
-## Use
-
-### Via Vcpkg
-
-CommonLibSSE NG is available as a Vcpkg port. To add it to your project, create a `vcpkg-configuration.json` file in the
-project root (next to `vcpkg.json`) with the following contents:
-
-```json
-{
-  "registries": [
-    {
-      "kind": "git",
-      "repository": "https://gitlab.com/colorglass/vcpkg-colorglass",
-      // Update this baseline to the latest commit from the above repo.
-      "baseline": "9eae9f03f03e0ca96fce5031f44f4e64cd6debdc",
-      "packages": [
-        "commonlibsse-ng",
-        "commonlibsse-ng-ae",
-        "commonlibsse-ng-se",
-        "commonlibsse-ng-vr",
-        "commonlibsse-ng-flatrim"
-      ]
-    }
-  ]
-}
-```
-
-Then add `commonlibsse-ng` as a dependency in `vcpkg.json`. There are also runtime-specific versions of the project:
-
-- `commonlibsse-ng-ae`: Supports AE executables (1.6.x) only.
-- `commonlibsse-ng-se`: Supports pre-AE executables (1.5.x) only.
-- `commonlibsse-ng-vr`: Supports VR only.
-- `commonlibsse-ng-flatrim`: Support for SE/AE, but not VR.
-
-The runtime-specific ports will not attempt to dynamically lookup the version of Skyrim at runtime, and will enable
-access to reverse engineered content that is specific to that version of Skyrim and non-portable (i.e. it does not exist
-in all versions of Skyrim, or has not been reverse engineered on all versions of Skyrim).
-
-### Via Conan
-
-CommonLibSSE NG is now available via Conan. Add it as a requirement to your project's `conanfile.txt` or `conanfile.py`:
-
-```ini
-[requires]
-commonlibsse-ng/3.5.2
-```
-
-```python
-class MyProject:
-    # ...
-    requires = 'commonlibsse-ng/3.5.2'
-```
-
-Update the version number to the version constraints you want. Conan support was added in version 3.5.0, making that the
-earliest version available. Currently Conan binaries are available for the following
-`build_type`/`arch`/`os`/`compiler`/`compiler.version` combinations:
-
-- Debug/x86_64/Windows/Visual Studio/16
-- Debug/x86_64/Windows/Visual Studio/17
-- Release/x86_64/Windows/Visual Studio/16
-- Release/x86_64/Windows/Visual Studio/17
-
-Selective runtime support is handled via package options:
-
-```ini
-[requires]
-commonlibsse-ng/3.5.2
-
-[options]
-commonlibsse-ng:ae=True
-commonlibsse-ng:se=True
-commonlibsse-ng:vr=True
-```
-
-```python
-class MyProject:
-    # ...
-    requires = 'commonlibsse-ng/3.5.2'
-    default_options = {
-      # ...
-      'commonlibsse-ng:with_ae': True,
-      'commonlibsse-ng:with_se': True,
-      'commonlibsse-ng:with_vr': True
-    }
-```
-
-The above shows the default values (which includes support for all runtimes). Disable any runtimes you do not want.
-
-### Linking in CMake
-
-You should have the following in `CMakeLists.txt` to compile and link successfully:
-
-```cmake
-find_package(CommonLibSSE REQUIRED)
-target_link_libraries(${PROJECT_NAME} PUBLIC CommonLibSSE::CommonLibSSE)
-```
-
-For more information on how to use CommonLibSSE NG, you can look at the
-[example plugin](https://gitlab.com/colorglass/commonlibsse-sample-plugin).
 
 ## Build Dependencies
 
 Dependencies are managed via vcpkg. See `vcpkg.json` for the complete list.
 
 **Core Dependencies:**
-- [fmt](https://github.com/fmtlib/fmt) 12.0.0+
-- [rapidcsv](https://github.com/d99kris/rapidcsv) 8.62+
-- [spdlog](https://github.com/gabime/spdlog) 1.16.0+
-- [xbyak](https://github.com/herumi/xbyak) 6.61.2+
+- [fmt](https://github.com/fmtlib/fmt) 12.1+
+- [rapidcsv](https://github.com/d99kris/rapidcsv) 8.9+
+- [spdlog](https://github.com/gabime/spdlog) 1.16+
+- [xbyak](https://github.com/herumi/xbyak) 7.28+
 - [catch2](https://github.com/catchorg/Catch2) 3.1.0+ (for testing)
-- [directxmath](https://github.com/microsoft/DirectXMath) - DirectX Math library
-- [directxtk](https://github.com/microsoft/DirectXTK) - DirectX Toolkit
+- [directxmath](https://github.com/microsoft/DirectXMath) 2025-04-03 - DirectX Math library
+- [directxtk](https://github.com/microsoft/DirectXTK) 2025-10-27 - DirectX Toolkit
 
 **Build Tools:**
 - [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) - Desktop development with C++
@@ -237,9 +211,7 @@ Dependencies are managed via vcpkg. See `vcpkg.json` for the complete list.
   [VR Address Library for SKSEVR](https://www.nexusmods.com/skyrimspecialedition/mods/58101)
 - [clang-format 12.0.0](https://github.com/llvm/llvm-project/releases)
 - [CMake](https://cmake.org/)
-- [Conan](https://conan.io) or [Vcpkg](https://github.com/microsoft/vcpkg)
 
 ## Notes
 
-- CommonLib is incompatible with SKSE and is intended to replace it as a static dependency. However, you will still need
-- the runtime component.
+- CommonLib is incompatible with SKSE and is intended to replace it as a static dependency. However, you will still need the runtime component.


### PR DESCRIPTION
Address #121 

Overhaul of usage part, de-prioritize old builds in Conan and vcpkg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated C++ standard support information to C++23
  * Added comprehensive Usage section with build system examples (XMake, CMake, git submodule)
  * Refreshed dependency versions and build guidance
  * Reorganized release information with updated tooling references
  * Expanded compatibility notes and development guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->