### PR TITLE
fix(VR): use atomics for lazy esl

### DIFF
--- a/include/RE/T/TESDataHandler.h
+++ b/include/RE/T/TESDataHandler.h
@@ -43,8 +43,8 @@ namespace RE
 	{
 	public:
 		inline static std::atomic<RE::TESFileCollection*> VRcompiledFileCollection{ nullptr };  // used by SkyrimVRESL to store pointer to VR version
-		static TESDataHandler*               GetSingleton(bool a_VRESL = true);
-		[[nodiscard]] static TESFileCollection* GetVRCompiledFileCollection(bool a_allowRefresh = true) noexcept;
+		static TESDataHandler*                            GetSingleton(bool a_VRESL = true);
+		[[nodiscard]] static TESFileCollection*           GetVRCompiledFileCollection(bool a_allowRefresh = true) noexcept;
 
 		[[nodiscard]] static inline bool HasValidVRCompiledFileCollection(const TESFileCollection* a_collection) noexcept
 		{

--- a/include/RE/T/TESDataHandler.h
+++ b/include/RE/T/TESDataHandler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include "RE/B/BSPointerHandle.h"
 #include "RE/B/BSSimpleList.h"
 #include "RE/B/BSTArray.h"
@@ -40,7 +42,7 @@ namespace RE
 	class TESDataHandler : public BSTSingletonSDM<TESDataHandler>
 	{
 	public:
-		inline static RE::TESFileCollection* VRcompiledFileCollection = nullptr;  // used by SkyrimVRESL to store pointer to VR version
+		inline static std::atomic<RE::TESFileCollection*> VRcompiledFileCollection{ nullptr };  // used by SkyrimVRESL to store pointer to VR version
 		static TESDataHandler*               GetSingleton(bool a_VRESL = true);
 		[[nodiscard]] static TESFileCollection* GetVRCompiledFileCollection(bool a_allowRefresh = true) noexcept;
 

--- a/src/RE/T/TESDataHandler.cpp
+++ b/src/RE/T/TESDataHandler.cpp
@@ -51,12 +51,12 @@ namespace RE
 			return nullptr;
 		}
 
-		auto collection = VRcompiledFileCollection;
+		auto collection = VRcompiledFileCollection.load(std::memory_order_acquire);
 		if (HasValidVRCompiledFileCollection(collection)) {
 			return collection;
 		}
 
-		VRcompiledFileCollection = nullptr;
+		VRcompiledFileCollection.store(nullptr, std::memory_order_release);
 
 		if (!a_allowRefresh) {
 			return nullptr;
@@ -83,7 +83,7 @@ namespace RE
 			return nullptr;
 		}
 
-		VRcompiledFileCollection = collection;
+		VRcompiledFileCollection.store(collection, std::memory_order_release);
 		return collection;
 	}
 

--- a/src/RE/T/TESDataHandler.cpp
+++ b/src/RE/T/TESDataHandler.cpp
@@ -56,7 +56,7 @@ namespace RE
 			return collection;
 		}
 
-		VRcompiledFileCollection.store(nullptr, std::memory_order_release);
+		VRcompiledFileCollection.compare_exchange_strong(collection, nullptr, std::memory_order_release, std::memory_order_relaxed);
 
 		if (!a_allowRefresh) {
 			return nullptr;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to enhance thread-safety in VR file-collection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->