### PR TITLE
fix: Main members

### DIFF
--- a/include/RE/M/Main.h
+++ b/include/RE/M/Main.h
@@ -122,5 +122,5 @@ namespace RE
 		BSSaveDataSystemUtilityImage saveDataBackgroundImages[3];  // 1E0
 		BSSaveDataSystemUtilityImage saveDataIconImages[3];        // 228
 	};
-	STATIC_ASSERT_SIZE(Main, 0x270, 0x270, 0x268, 0x268);
+	STATIC_ASSERT_SIZE(Main, 0x268, 0x268, 0x260, 0x260);
 }

--- a/include/RE/M/Main.h
+++ b/include/RE/M/Main.h
@@ -50,6 +50,21 @@ namespace RE
 	};
 	static_assert(sizeof(BSSaveDataSystemUtilityImage) == 0x18);
 
+	struct MainRuntimeData
+	{
+	public:
+		// members
+		bool quitGame;        // 010 VR 08
+		bool resetGame;       // 011 VR 09
+		bool fullReset;       // 012 VR 0a
+		bool gameActive;      // 013 VR 0b
+		bool onIdle;          // 014 VR 0c
+		bool reloadContent;   // 015 VR 0d
+		bool freezeTime;      // 016 VR 0e
+		bool freezeNextFrame; // 017 VR 0f
+	};
+	static_assert(sizeof(MainRuntimeData) == 0x08);
+
 	class Main :
 #if defined(EXCLUSIVE_SKYRIM_FLAT)
 		public BSTEventSink<PositionPlayerEvent>,  // 00
@@ -79,16 +94,18 @@ namespace RE
 
 		bool IsRoomVisible(NiNode* a_room);
 		void SetActive(bool a_active);
+		
+		[[nodiscard]] inline MainRuntimeData& GetRuntimeData() noexcept
+		{
+			return REL::RelocateMember<MainRuntimeData>(this, 0x10, 0x08);
+		}
+
+		[[nodiscard]] inline const MainRuntimeData& GetRuntimeData() const noexcept
+		{
+			return REL::RelocateMember<MainRuntimeData>(this, 0x10, 0x08);
+		}
 
 		// members
-		bool                         quitGame;                     // 010 VR 08
-		bool                         resetGame;                    // 011 VR 09
-		bool                         fullReset;                    // 012 VR 0a
-		bool                         gameActive;                   // 013 VR 0b
-		bool                         onIdle;                       // 014 VR 0c
-		bool                         reloadContent;                // 015 VR 0d
-		bool                         freezeTime;                   // 016 VR 0e
-		bool                         freezeNextFrame;              // 017 VR 0f This continues for all members I assume
 		REX::W32::HWND               wnd;                          // 018
 		REX::W32::HINSTANCE          instance;                     // 020
 		std::uint32_t                threadID;                     // 028

--- a/include/RE/M/Main.h
+++ b/include/RE/M/Main.h
@@ -4,6 +4,7 @@
 #include "RE/B/BSTMessageQueue.h"
 #include "RE/S/ScrapHeap.h"
 
+#include "REL/RuntimeDataAccessors.h"
 #include "REX/W32/BASE.h"
 
 namespace RE
@@ -50,21 +51,6 @@ namespace RE
 	};
 	static_assert(sizeof(BSSaveDataSystemUtilityImage) == 0x18);
 
-	struct MainRuntimeData
-	{
-	public:
-		// members
-		bool quitGame;        // 010 VR 08
-		bool resetGame;       // 011 VR 09
-		bool fullReset;       // 012 VR 0a
-		bool gameActive;      // 013 VR 0b
-		bool onIdle;          // 014 VR 0c
-		bool reloadContent;   // 015 VR 0d
-		bool freezeTime;      // 016 VR 0e
-		bool freezeNextFrame; // 017 VR 0f
-	};
-	static_assert(sizeof(MainRuntimeData) == 0x08);
-
 	class Main :
 #if defined(EXCLUSIVE_SKYRIM_FLAT)
 		public BSTEventSink<PositionPlayerEvent>,  // 00
@@ -94,18 +80,29 @@ namespace RE
 
 		bool IsRoomVisible(NiNode* a_room);
 		void SetActive(bool a_active);
-		
-		[[nodiscard]] inline MainRuntimeData& GetRuntimeData() noexcept
-		{
-			return REL::RelocateMember<MainRuntimeData>(this, 0x10, 0x08);
-		}
 
-		[[nodiscard]] inline const MainRuntimeData& GetRuntimeData() const noexcept
+		struct RUNTIME_DATA
 		{
-			return REL::RelocateMember<MainRuntimeData>(this, 0x10, 0x08);
-		}
+#define RUNTIME_DATA_CONTENT       \
+	bool quitGame;        /* 00 */ \
+	bool resetGame;       /* 01 */ \
+	bool fullReset;       /* 02 */ \
+	bool gameActive;      /* 03 */ \
+	bool onIdle;          /* 04 */ \
+	bool reloadContent;   /* 05 */ \
+	bool freezeTime;      /* 06 */ \
+	bool freezeNextFrame; /* 07 */
+
+			RUNTIME_DATA_CONTENT
+		};
+		static_assert(sizeof(RUNTIME_DATA) == 0x08);
+
+		RUNTIME_DATA_ACCESSOR(RUNTIME_DATA, 0x10, 0x08);
 
 		// members
+#ifndef SKYRIM_CROSS_VR
+		RUNTIME_DATA_CONTENT;  // 10, 08
+#endif
 		REX::W32::HWND               wnd;                          // 018
 		REX::W32::HINSTANCE          instance;                     // 020
 		std::uint32_t                threadID;                     // 028
@@ -122,5 +119,6 @@ namespace RE
 		BSSaveDataSystemUtilityImage saveDataBackgroundImages[3];  // 1E0
 		BSSaveDataSystemUtilityImage saveDataIconImages[3];        // 228
 	};
-	STATIC_ASSERT_SIZE(Main, 0x268, 0x268, 0x260, 0x260);
+	STATIC_ASSERT_SIZE(Main, 0x270, 0x270, 0x268, 0x260);
 }
+#undef RUNTIME_DATA_CONTENT


### PR DESCRIPTION
Encapsulate the first 8 boolean members in a MainRuntimeData struct with a GetRuntimeData() accessor that properly handles cross-runtime offset resolution (SE 0x10 vs VR 0x08).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal runtime state storage and adjusted class layout for maintainability and portability. No changes to user-facing behavior or features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->