### PR TITLE
build(cache): use string check for plugin_content

### DIFF
--- a/cmake/CommonLibSSE.cmake
+++ b/cmake/CommonLibSSE.cmake
@@ -164,11 +164,12 @@ function(target_commonlibsse_properties TARGET)
 
     if(EXISTS "${commonlibsse_plugin_file}")
         file(READ "${commonlibsse_plugin_file}" _existing_content)
+        string(REPLACE "\r\n" "\n" _existing_content "${_existing_content}")
     else()
         set(_existing_content "")
     endif()
 
-    if(NOT _existing_content STREQUAL _plugin_content)
+    if(NOT "${_existing_content}" STREQUAL "${_plugin_content}")
         file(WRITE "${commonlibsse_plugin_file}" "${_plugin_content}")
     endif()
 

--- a/cmake/CommonLibSSE.cmake
+++ b/cmake/CommonLibSSE.cmake
@@ -147,7 +147,7 @@ function(target_commonlibsse_properties TARGET)
         set(commonlibsse_plugin_compatibility "{ ${commonlibsse_plugin_compatibility} }")
     endif()
 
-    file(WRITE "${commonlibsse_plugin_file}"
+    string(CONCAT _plugin_content
         "#include \"REL/Relocation.h\"\n"
         "#include \"SKSE/SKSE.h\"\n"
         "\n"
@@ -159,7 +159,18 @@ function(target_commonlibsse_properties TARGET)
         "    .StructCompatibility = ${commonlibsse_plugin_struct_compatibility},\n"
         "    .RuntimeCompatibility = ${commonlibsse_plugin_compatibility},\n"
         "    .MinimumSKSEVersion = ${commonlibsse_min_skse_version}\n"
-        ")\n")
+        ")\n"
+    )
+
+    if(EXISTS "${commonlibsse_plugin_file}")
+        file(READ "${commonlibsse_plugin_file}" _existing_content)
+    else()
+        set(_existing_content "")
+    endif()
+
+    if(NOT _existing_content STREQUAL _plugin_content)
+        file(WRITE "${commonlibsse_plugin_file}" "${_plugin_content}")
+    endif()
 
     target_sources("${TARGET}" PRIVATE "${commonlibsse_plugin_file}")
     target_compile_definitions("${TARGET}" PRIVATE __CMAKE_COMMONLIBSSE_PLUGIN=1)


### PR DESCRIPTION
When building with alandtse/CommonLibVR "ng" we noticed that we would always get a cache miss pointing to the `*Plugin.cpp` from add_commonlibsse_plugin().

This PR just changes a constant file write into a string compare on the current _plugin_content data versus the data in the previous `*Plugin.cpp` it that exists. If no changes were found then file is not updated. If no previous file is found then it is written as previously.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the build system to avoid unnecessary regeneration of generated source files by comparing existing and newly produced content; files are rewritten only when content changes. This reduces needless disk churn, speeds up incremental builds, and improves overall build reliability and developer workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->