### PR TITLE
fix(BSShadowLight): GetIsDirectionalLight return

### DIFF
--- a/include/RE/B/BSShadowDirectionalLight.h
+++ b/include/RE/B/BSShadowDirectionalLight.h
@@ -30,7 +30,7 @@ namespace RE
 
 		// override (BSShadowLight)
 		bool          GetIsFrustumOrDirectionalLight() override;                                                                                                                     // 04
-		void          GetIsDirectionalLight() override;                                                                                                                              // 06
+		bool          GetIsDirectionalLight() override;                                                                                                                              // 06
 		void          Accumulate(std::uint32_t& a_globalShadowLightCount, std::uint32_t a_shadowMaskChannel, NiAVObject* a_cullingScene, std::uint8_t a_vrUpdateFlag = 0) override;  // 09
 		void          Render(std::uint32_t& a_index) override;                                                                                                                       // 0A
 		void          ReturnShadowmaps() override;                                                                                                                                   // 0C

--- a/include/RE/B/BSShadowLight.h
+++ b/include/RE/B/BSShadowLight.h
@@ -116,7 +116,7 @@ namespace RE
 		// add
 		virtual bool          GetIsFrustumOrDirectionalLight() = 0;                                                                                                                     // 04
 		virtual bool          GetIsFrustumLight();                                                                                                                                      // 05
-		virtual void          GetIsDirectionalLight();                                                                                                                                  // 06
+		virtual bool          GetIsDirectionalLight();                                                                                                                                  // 06
 		virtual bool          GetIsParabolicLight();                                                                                                                                    // 07
 		virtual bool          GetIsOmniLight();                                                                                                                                         // 08
 		virtual void          Accumulate(std::uint32_t& a_globalShadowLightCount, std::uint32_t a_shadowMaskChannel, NiAVObject* a_cullingScene, std::uint8_t a_vrUpdateFlag = 0) = 0;  // 09 - a_vrUpdateFlag used by VR only, ignored by SE/AE


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated `GetIsDirectionalLight()` method signature to return `bool` instead of `void`, aligning with related directional light interface methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->