### PR TITLE
feat(BSShaderRenderTargets): name VR slot 114

### DIFF
--- a/include/RE/B/BSShaderRenderTargets.h
+++ b/include/RE/B/BSShaderRenderTargets.h
@@ -122,8 +122,11 @@ namespace RE
 			kSNOW_SPECALPHA,
 			kSNOW_SWAP,
 
-			kTOTAL,  // SE 114, 125 in VR, 116 in AE1130
-			//VR
+			kTOTAL,  // SE/VR 114, 116 in AE1130. In SE/AE this is the array size; in
+			         // VR slot 114 is a real entry (kVR_FRAMEBUFFER below) and the
+			         // array size is kVRTOTAL.
+			// VR-only slots (115..124).
+			kVR_FRAMEBUFFER = kTOTAL,  // Side-by-side framebuffer headed to the HMD compositor.
 			kPROJECTEDMENU = 115,
 			kHUDMENU,
 			kFADERUI,

--- a/include/RE/B/BSShaderRenderTargets.h
+++ b/include/RE/B/BSShaderRenderTargets.h
@@ -123,8 +123,8 @@ namespace RE
 			kSNOW_SWAP,
 
 			kTOTAL,  // SE/VR 114, 116 in AE1130. In SE/AE this is the array size; in
-			         // VR slot 114 is a real entry (kVR_FRAMEBUFFER below) and the
-			         // array size is kVRTOTAL.
+					 // VR slot 114 is a real entry (kVR_FRAMEBUFFER below) and the
+					 // array size is kVRTOTAL.
 			// VR-only slots (115..124).
 			kVR_FRAMEBUFFER = kTOTAL,  // Side-by-side framebuffer headed to the HMD compositor.
 			kPROJECTEDMENU = 115,


### PR DESCRIPTION
The renderTargets[] array carries 125 slots in VR (kVRTOTAL) versus 114 in SE/AE. Slot 114 in VR is the side-by-side framebuffer that Skyrim's final ISCopy writes (input: kMENUBG) and that gets distributed via CopySubresourceRegion to the per-eye DXGI shared textures the HMD compositor consumes - confirmed by RenderDoc capture audit.

The slot was previously unnamed; consumers had to use kTOTAL (the SE/AE element count) as a slot index in VR, which is misleading. Add kVR_FRAMEBUFFER aliased to kTOTAL so VR call sites can name the slot for what it is, and update the kTOTAL comment to distinguish its element-count role in SE/AE from its slot-index role in VR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Clarified VR framebuffer handling in the rendering system with improved documentation for platform-specific render target configurations (SE/VR/AE1130).
  * Added explicit VR framebuffer slot designation for better code clarity and maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/CommonLibVR/pull/150)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->