### PR TITLE
docs(BSShadowLight): document maskIndex as shadow mask channel index

### DIFF
--- a/include/RE/B/BSShadowLight.h
+++ b/include/RE/B/BSShadowLight.h
@@ -77,36 +77,36 @@ namespace RE
 
 		struct RUNTIME_DATA
 		{
-#define RUNTIME_DATA_CONTENT                                                                     \
-	BSTArray<ShadowmapDescriptor>   shadowmapDescriptors;         /* 148 shadowMapDataList */    \
-	ShadowmapDescriptor             focusShadowmapDescriptors[4]; /* 160 shadowMapData */        \
-	std::uint32_t                   maskIndex;                    /* 520 */                      \
-	std::uint32_t                   accumulatedIndex;             /* 524 */                      \
-	BSTArray<NiPointer<NiAVObject>> sceneAccumArray;              /* 528 sceneAccumArray */      \
-	float                           shadowBiasScale;              /* 540 */                      \
-	NiRect<std::uint32_t>           projectedBoundingBox;         /* 544 projectedBoundingBox */ \
-	std::uint32_t                   sceneGraphIndex;              /* 554 */                      \
-	bool                            drawFocusShadows;             /* 558 */                      \
-	std::uint8_t                    pad559;                       /* 559 */                      \
-	std::uint8_t                    pad55A;                       /* 55A */                      \
+#define RUNTIME_DATA_CONTENT                                                                                                                                                                                                                                                \
+	BSTArray<ShadowmapDescriptor>   shadowmapDescriptors;         /* 148 shadowMapDataList */                                                                                                                                                                               \
+	ShadowmapDescriptor             focusShadowmapDescriptors[4]; /* 160 shadowMapData */                                                                                                                                                                                   \
+	std::uint32_t                   maskIndex;                    /* 520 - shadow mask channel index (0..3 for R/G/B/A). Used as a direct index into a 4-entry shader-technique lookup table; engine does not bounds-check, so values outside [0..3] read out of bounds. */ \
+	std::uint32_t                   accumulatedIndex;             /* 524 */                                                                                                                                                                                                 \
+	BSTArray<NiPointer<NiAVObject>> sceneAccumArray;              /* 528 sceneAccumArray */                                                                                                                                                                                 \
+	float                           shadowBiasScale;              /* 540 */                                                                                                                                                                                                 \
+	NiRect<std::uint32_t>           projectedBoundingBox;         /* 544 projectedBoundingBox */                                                                                                                                                                            \
+	std::uint32_t                   sceneGraphIndex;              /* 554 */                                                                                                                                                                                                 \
+	bool                            drawFocusShadows;             /* 558 */                                                                                                                                                                                                 \
+	std::uint8_t                    pad559;                       /* 559 */                                                                                                                                                                                                 \
+	std::uint8_t                    pad55A;                       /* 55A */                                                                                                                                                                                                 \
 	std::uint32_t                   pad55B;                       /* 55B */
             RUNTIME_DATA_CONTENT
 		};
 
 		struct RUNTIME_DATA_VR
 		{
-#define RUNTIME_DATA_CONTENT_VR                                                                    \
-	BSTArray<ShadowmapDescriptorVR> shadowmapDescriptors;         /* 148 shadowMapDataList (VR) */ \
-	ShadowmapDescriptorVR           focusShadowmapDescriptors[4]; /* 160 shadowMapData (VR) */     \
-	std::uint32_t                   maskIndex;                    /* 580 */                        \
-	std::uint32_t                   accumulatedIndex;             /* 584 */                        \
-	BSTArray<NiPointer<NiAVObject>> sceneAccumArray;              /* 588 */                        \
-	float                           shadowBiasScale;              /* 5A0 */                        \
-	NiRect<std::uint32_t>           projectedBoundingBox;         /* 5A4 */                        \
-	std::uint32_t                   sceneGraphIndex;              /* 5B4 */                        \
-	bool                            drawFocusShadows;             /* 5B8 */                        \
-	std::uint8_t                    pad559;                       /* 5B9 */                        \
-	std::uint8_t                    pad55A;                       /* 5BA */                        \
+#define RUNTIME_DATA_CONTENT_VR                                                                                                             \
+	BSTArray<ShadowmapDescriptorVR> shadowmapDescriptors;         /* 148 shadowMapDataList (VR) */                                          \
+	ShadowmapDescriptorVR           focusShadowmapDescriptors[4]; /* 160 shadowMapData (VR) */                                              \
+	std::uint32_t                   maskIndex;                    /* 580 - shadow mask channel index (0..3); see SE branch comment above */ \
+	std::uint32_t                   accumulatedIndex;             /* 584 */                                                                 \
+	BSTArray<NiPointer<NiAVObject>> sceneAccumArray;              /* 588 */                                                                 \
+	float                           shadowBiasScale;              /* 5A0 */                                                                 \
+	NiRect<std::uint32_t>           projectedBoundingBox;         /* 5A4 */                                                                 \
+	std::uint32_t                   sceneGraphIndex;              /* 5B4 */                                                                 \
+	bool                            drawFocusShadows;             /* 5B8 */                                                                 \
+	std::uint8_t                    pad559;                       /* 5B9 */                                                                 \
+	std::uint8_t                    pad55A;                       /* 5BA */                                                                 \
 	std::uint32_t                   pad55B;                       /* 5BB */
             RUNTIME_DATA_CONTENT_VR
 		};


### PR DESCRIPTION
## Summary
Clarify that `BSShadowLight::maskIndex` (uint32 at SE 0x520 / VR 0x580) is the shadow MASK CHANNEL index — one per RGBA channel, valid range `[0..3]`.

## Engine behavior
The engine uses `maskIndex` as a direct index into a 4-entry shader-technique lookup table during parabolic-shadow rendering. **There is no bounds check before the read** — values outside `[0..3]` read out of bounds.

The lookup table maps one shader technique per shadow mask channel (R/G/B/A). Game-only code keeps `maskIndex` in range by construction, but mods that synthesize or modify `BSShadowLight` instances (e.g., lifting the engine's 4-shadow-caster cap, custom shadow renderers) need to ensure `maskIndex` stays in `[0..3]` to avoid an OOB read.

## Test plan
- [x] All 5 build presets (se / ae / vr / flatrim / all) succeed
- [x] No layout changes — comment-only update to an existing named field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted internal runtime data layouts to improve consistency and maintainability.

* **Documentation**
  * Clarified and expanded inline documentation describing runtime data field semantics and VR-specific behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/CommonLibVR/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->