### PR TITLE
feat(BSEffectShaderProperty): name emittanceColor and render passes

### DIFF
--- a/include/RE/B/BSEffectShaderProperty.h
+++ b/include/RE/B/BSEffectShaderProperty.h
@@ -37,9 +37,8 @@ namespace RE
 		BSEffectShaderMaterial* GetMaterial() { return static_cast<BSEffectShaderMaterial*>(GetBaseMaterial()); }
 
 		// members
-		NiColor*      unk88;  // 88
-		std::uint64_t unk90;  // 90
-		std::uint64_t unk98;  // 98
+		NiColor*        emittanceColor;                 // 88 - external emittance override (kExternalEmittance); null = white
+		RenderPassArray shadowMapOrMaskRenderPassList;  // 90
 	};
 	static_assert(sizeof(BSEffectShaderProperty) == 0xA0);
 }


### PR DESCRIPTION
## Summary

Replaces the three `unkXX` members of `BSEffectShaderProperty` with their identified types/names, reverse-engineered via Ghidra across **SE 1.5.97, AE 1.6.1170, and VR** (and confirmed against the live 1.6.1170 process).

| offset | before | after |
|---|---|---|
| `0x88` | `NiColor* unk88` | `NiColor* emittanceColor` |
| `0x90`–`0x98` | `uint64 unk90` + `uint64 unk98` | `RenderPassArray shadowMapOrMaskRenderPassList` |

`sizeof == 0xA0` is unchanged.

## Evidence

**`emittanceColor` (0x88)** — `BSEffectShader::SetupGeometry` reads `[property+0x88]` as a `NiColor` and writes its RGB into the shader constant buffer, null-defaulting to white `(1,1,1)`:
- SE `BSEffectShader::SetupGeometry` read site `0x141300016` (`MOV RCX,[R13+0x88]` → null-check → RGB → white default).
- VR equivalent at `0x14134268f` — identical null-check + RGB pattern.
- Populated for effects flagged `kExternalEmittance` from the ref's `ExtraEmittanceSource`.

**`shadowMapOrMaskRenderPassList` (0x90)** — a 16-byte `RenderPassArray` (`BSRenderPass* head` + unused qword), mirroring the base class's `renderPassList`/`debugRenderPassList`:
- The destructor walks the `BSRenderPass.next_28` linked list at `+0x90` and frees it.
- Only `GetRenderPasses_ShadowMapOrMask` (vfunc `0x2B`) references `+0x90`; the normal `GetRenderPasses` uses the base `0x40` list.

**Cross-runtime layout** — verified identical via each constructor's zero-init of `0x88`/`0x90`/`0x98` (SE `FUN_1412d5090`, AE `FUN_1414bd5e0`, VR `FUN_141313fa0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal shader property member field organization with improved naming conventions for enhanced code clarity and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/CommonLibVR/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->