### PR TITLE
ci: enable pre-commit.ci and debounce semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - ng
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -11,10 +12,34 @@ permissions:
   pull-requests: write
 
 jobs:
-  release:
-    name: Semantic Release
+  # Debounce: a leading wait so several merges in close succession collapse into
+  # one release. Each new push cancels the still-waiting run (cancel-in-progress)
+  # and restarts the timer; once the branch is quiet for the window, the release
+  # job runs once and semantic-release batches every accumulated commit.
+  debounce:
+    name: Debounce
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    concurrency:
+      group: semantic-release-debounce
+      cancel-in-progress: true
+    steps:
+      - name: Wait for quiet period
+        # Only debounce real merges; manual dispatch releases immediately.
+        if: github.event_name == 'push'
+        run: sleep 600 # 10 min; a newer merge cancels+restarts this wait
+
+  # Release runs only after the debounce settles. It has its own concurrency
+  # group with cancel-in-progress: false so an in-progress publish is never
+  # aborted by a newer push (which would risk a partial release); concurrent
+  # publishes queue instead.
+  release:
+    name: Semantic Release
+    needs: debounce
+    runs-on: ubuntu-latest
+    concurrency:
+      group: semantic-release-publish
+      cancel-in-progress: false
 
     steps:
       - name: Checkout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,11 @@
+ci:
+  autofix_prs: true
+  autoupdate_schedule: monthly
+  # cmake-generate is a language: system hook (needs the repo's python + scripts);
+  # it can't run in the pre-commit.ci container, so skip it there. Contributors
+  # still run it via the local pre-commit hook.
+  skip: [cmake-generate]
+
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v16.0.6


### PR DESCRIPTION
## Summary
Two CI changes:

### 1. pre-commit.ci config (`.pre-commit-config.yaml`)
Adds a `ci:` block so the now-enabled pre-commit.ci app behaves correctly:
- `autofix_prs: true` + `autoupdate_schedule: monthly`
- `skip: [cmake-generate]` - that hook is `language: system` and can't run in the pre-commit.ci container. Contributors still run it via the local pre-commit hook.

No formatting changes - the repo is already clang-format (v16, the pinned mirror) clean.

### 2. Debounced semantic-release (`.github/workflows/release.yml`)
Several PRs merged in close succession currently produce one release each. Split the release into two jobs so they batch into a single release:
- **debounce** - a leading `sleep` (10 min) in concurrency group `semantic-release-debounce` with `cancel-in-progress: true`. A newer merge cancels the still-waiting run and restarts the timer; once `ng` is quiet for the window, release runs once and semantic-release batches every accumulated commit. `workflow_dispatch` skips the wait for on-demand releases.
- **release** - `needs: debounce`, in its own group `semantic-release-publish` with `cancel-in-progress: false`, so an in-progress publish is never aborted by a newer push (avoids partial releases); concurrent publishes queue.

Tune the `sleep` value to taste (currently 600s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)