### PR TITLE
ci: enable pre-commit.ci and debounce semantic-release

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -24,9 +24,6 @@ jobs:
       with:
         python-version: '3.10'
 
-    - name: Run clang-format
-      run: find -type f \( -name '*.h' -o -name '*.cpp' \) | xargs clang-format-16 -style=file -i
-
     - name: Generate CMake file lists
       run: python ${{ github.workspace }}/scripts/cmake_generate.py
 
@@ -42,5 +39,5 @@ jobs:
          github.event.pull_request.head.repo.full_name == github.repository)
       uses: stefanzweifel/git-auto-commit-action@v5
       with:
-        commit_message: "style: apply automated maintenance (formatting & file lists)"
+        commit_message: "chore: regenerate CMake file lists"
         commit_options: '--no-verify'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - ng
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -11,10 +12,34 @@ permissions:
   pull-requests: write
 
 jobs:
-  release:
-    name: Semantic Release
+  # Debounce: a leading wait so several merges in close succession collapse into
+  # one release. Each new push cancels the still-waiting run (cancel-in-progress)
+  # and restarts the timer; once the branch is quiet for the window, the release
+  # job runs once and semantic-release batches every accumulated commit.
+  debounce:
+    name: Debounce
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    concurrency:
+      group: semantic-release-debounce
+      cancel-in-progress: true
+    steps:
+      - name: Wait for quiet period
+        # Only debounce real merges; manual dispatch releases immediately.
+        if: github.event_name == 'push'
+        run: sleep 600 # 10 min; a newer merge cancels+restarts this wait
+
+  # Release runs only after the debounce settles. It has its own concurrency
+  # group with cancel-in-progress: false so an in-progress publish is never
+  # aborted by a newer push (which would risk a partial release); concurrent
+  # publishes queue instead.
+  release:
+    name: Semantic Release
+    needs: debounce
+    runs-on: ubuntu-latest
+    concurrency:
+      group: semantic-release-publish
+      cancel-in-progress: false
 
     steps:
       - name: Checkout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,11 @@
+ci:
+  autofix_prs: true
+  autoupdate_schedule: monthly
+  # cmake-generate is a language: system hook (needs the repo's python + scripts);
+  # it can't run in the pre-commit.ci container, so skip it there. Contributors
+  # still run it via the local pre-commit hook.
+  skip: [cmake-generate]
+
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v16.0.6


### PR DESCRIPTION
> Supersedes #158 (auto-closed when its branch was renamed).

## Summary
Two CI changes.

### 1. pre-commit.ci config (`.pre-commit-config.yaml`)
`ci:` block for the now-enabled pre-commit.ci app:
- `autofix_prs: true` + `autoupdate_schedule: monthly`
- `skip: [cmake-generate]` - that hook is `language: system` and can't run in the pre-commit.ci container. Contributors still run it via the local pre-commit hook.

No formatting changes - repo is already clang-format (v16) clean.

### 2. Debounced semantic-release (`.github/workflows/release.yml`)
Several PRs merged in close succession currently produce one release each. Split into two jobs so they batch into one:
- **debounce** - leading `sleep` (10 min), group `semantic-release-debounce`, `cancel-in-progress: true`. A newer merge cancels the waiting run and restarts the timer; once `ng` is quiet, release runs once and batches every accumulated commit. `workflow_dispatch` skips the wait.
- **release** - `needs: debounce`, group `semantic-release-publish`, `cancel-in-progress: false`, so an in-progress publish is never aborted by a newer push.

Tune the `sleep` value to taste (currently 600s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow with manual trigger support and improved release timing controls.
  * Updated maintenance and pre-commit configuration for automated processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/CommonLibVR/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->