### PR TITLE
feat: MessageBoxMenu API + LoadGameMissingContentCallBack

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -1380,6 +1380,7 @@ set(SOURCES
 	include/RE/L/LevelUpMenu.h
 	include/RE/L/LightEffect.h
 	include/RE/L/LinkerProcessor.h
+	include/RE/L/LoadGameMissingContentCallBack.h
 	include/RE/L/LoadStorageWrapper.h
 	include/RE/L/LoadWaitSpinner.h
 	include/RE/L/LoadingMenu.h

--- a/include/RE/L/LoadGameMissingContentCallBack.h
+++ b/include/RE/L/LoadGameMissingContentCallBack.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "RE/I/IMessageBoxCallback.h"
+
+namespace RE
+{
+	// IMessageBoxCallback for the save-load dialog:
+	//   "This save relies on content that is no longer present. Some objects may no longer be
+	//    available. Continue Loading?"  (missing masters/plugins).
+	// Present in all runtimes (SE/AE/VR). In SE/VR it lives in an anonymous namespace, in AE it is
+	// global (hence the generated RTTI___/VTABLE___ names). Run(Message) receives the selected button
+	// index: 1 ("Continue Loading") builds a LoadRequest and submits it to BGSSaveLoadManager; any
+	// other value cancels the load.
+	// Sibling: LoadGameUnrecognizedContentCallBack (AE-only, the Creations "unrecognized content" dialog).
+	class LoadGameMissingContentCallBack : public IMessageBoxCallback
+	{
+	public:
+		inline static constexpr auto             RTTI = RTTI___LoadGameMissingContentCallBack;
+		inline static constexpr auto             VTABLE = VTABLE___LoadGameMissingContentCallBack;
+		inline static constexpr std::string_view CLASS_NAME = "LoadGameMissingContentCallBack";
+
+		~LoadGameMissingContentCallBack() override;  // 00
+
+		// override (IMessageBoxCallback)
+		void Run(Message a_msg) override;  // 01
+
+		// members beyond IMessageBoxCallback (0x10) hold the save-file info used to build the
+		// LoadRequest; layout not fully reversed.
+	};
+}

--- a/include/RE/M/MessageBoxMenu.h
+++ b/include/RE/M/MessageBoxMenu.h
@@ -38,6 +38,16 @@ namespace RE
 		static std::uint32_t   GetQueueSize();
 		static void            QueueMessage(MessageBoxData* a_data);
 
+		// The currently-displayed message (the most recently queued; the queue is LIFO), or nullptr if
+		// no message box is active. Read bodyText/buttonText/type/optionIndexOffset from it.
+		static MessageBoxData* GetCurrentMessageBoxData();
+		// Removes a_data from the message-box queue and destroys it.
+		static void RemoveMessageFromQueue(MessageBoxData* a_data);
+		// Programmatically answer the active message box as if button a_buttonIndex (0-based into
+		// buttonText) was clicked: pops the message, hides the menu if the queue empties, then invokes
+		// the data's IMessageBoxCallback with (optionIndexOffset + a_buttonIndex).
+		static void SelectOption(std::int32_t a_buttonIndex);
+
 		RUNTIME_DATA_ACCESSOR(RUNTIME_DATA, 0x30, 0x40);
 		// members
 #ifndef SKYRIM_CROSS_VR

--- a/include/RE/Offsets_RTTI.h
+++ b/include/RE/Offsets_RTTI.h
@@ -2232,7 +2232,7 @@ namespace RE
 	constexpr REL::VariantID RTTI_BGSSaveLoadManager__Thread(686610, 394453, 0x1f02280);
 	constexpr REL::VariantID RTTI_BGSSaveLoadManager(686602, 394445, 0x1f02078);
 	constexpr REL::VariantID RTTI_BSTEventSource_BGSSaveLoadManagerEvent_(686605, 394448, 0x1f02130);
-	constexpr REL::VariantID RTTI___LoadGameMissingContentCallBack(686614, 394457, 0x1f02440);
+	constexpr REL::VariantID RTTI___LoadGameMissingContentCallBack(686614, 502590, 0x1f02440);
 	constexpr REL::VariantID RTTI_NiTMapBase_DFALL_NiTMapItem_ENUM_FORM_ID_BSSimpleList_SavedFormData________ENUM_FORM_ID_BSSimpleList_SavedFormData______(686617, 394460, 0x1f02520);
 	constexpr REL::VariantID RTTI_NiTMap_ENUM_FORM_ID_BSSimpleList_SavedFormData______(686616, 394459, 0x1f024c0);
 	constexpr REL::VariantID RTTI_BGSSaveLoadStatsMap(686615, 394458, 0x1f02488);

--- a/include/RE/Offsets_VTABLE.h
+++ b/include/RE/Offsets_VTABLE.h
@@ -1982,7 +1982,7 @@ namespace RE
 	constexpr std::array<REL::VariantID, 1>  VTABLE_BSTCommonStaticMessageQueue_BSTSmartPointer_bgs__saveload__Request_BSTSmartPointerIntrusiveRefCount__8_{ REL::VariantID(258754, 206618, 0x16bcdd8) };
 	constexpr std::array<REL::VariantID, 1>  VTABLE_BGSSaveLoadManager__Thread{ REL::VariantID(258755, 206620, 0x16bce18) };
 	constexpr std::array<REL::VariantID, 3>  VTABLE_BGSSaveLoadManager{ REL::VariantID(258756, 206622, 0x16bce38), REL::VariantID(258757, 206624, 0x16bce50), REL::VariantID(258758, 206626, 0x16bce68) };
-	constexpr std::array<REL::VariantID, 1>  VTABLE___LoadGameMissingContentCallBack{ REL::VariantID(258783, 206638, 0x16bd138) };
+	constexpr std::array<REL::VariantID, 1>  VTABLE___LoadGameMissingContentCallBack{ REL::VariantID(258783, 465335, 0x16bd138) };
 	constexpr std::array<REL::VariantID, 1>  VTABLE_bgs__saveload__Request{ REL::VariantID(258818, 206668, 0x16bd670) };
 	constexpr std::array<REL::VariantID, 1>  VTABLE_NiTMapBase_DFALL_NiTMapItem_ENUM_FORM_ID_BSSimpleList_SavedFormData________ENUM_FORM_ID_BSSimpleList_SavedFormData______{ REL::VariantID(258840, 206675, 0x16bd9c8) };
 	constexpr std::array<REL::VariantID, 1>  VTABLE_NiTMap_ENUM_FORM_ID_BSSimpleList_SavedFormData______{ REL::VariantID(258841, 206677, 0x16bda08) };

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -1382,6 +1382,7 @@
 #include "RE/L/LevelUpMenu.h"
 #include "RE/L/LightEffect.h"
 #include "RE/L/LinkerProcessor.h"
+#include "RE/L/LoadGameMissingContentCallBack.h"
 #include "RE/L/LoadStorageWrapper.h"
 #include "RE/L/LoadWaitSpinner.h"
 #include "RE/L/LoadingMenu.h"

--- a/src/RE/M/MessageBoxMenu.cpp
+++ b/src/RE/M/MessageBoxMenu.cpp
@@ -15,9 +15,14 @@ namespace RE
 		return *menu;
 	}
 
+	// The message-box queue is the BSTArray<MessageBoxData*> that QueueMessage appends to and that
+	// holds the displayed box until it is answered (SE 0x142f4e690 / AE 0x1431af0c8 / VR 0x143013ac8
+	// = id 519819 / 406362). NOTE: ids 519818 / 406360 are the *per-type skip-filter* byte-table, not
+	// the queue — using them here returns an empty/garbage array. (VR address library needs id 519819
+	// added; see skyrim_vr_address_library.)
 	std::uint32_t MessageBoxMenu::GetQueueSize()
 	{
-		static REL::Relocation<BSTArray<MessageBoxData*>*> queue{ RELOCATION_ID(519818, 406360) };
+		static REL::Relocation<BSTArray<MessageBoxData*>*> queue{ RELOCATION_ID(519819, 406362) };
 		return queue->size();
 	}
 
@@ -30,7 +35,7 @@ namespace RE
 
 	MessageBoxData* MessageBoxMenu::GetCurrentMessageBoxData()
 	{
-		static REL::Relocation<BSTArray<MessageBoxData*>*> queue{ RELOCATION_ID(519818, 406360) };
+		static REL::Relocation<BSTArray<MessageBoxData*>*> queue{ RELOCATION_ID(519819, 406362) };
 		return queue->empty() ? nullptr : queue->back();
 	}
 
@@ -46,7 +51,7 @@ namespace RE
 
 	void MessageBoxMenu::SelectOption(std::int32_t a_buttonIndex)
 	{
-		static REL::Relocation<BSTArray<MessageBoxData*>*> queue{ RELOCATION_ID(519818, 406360) };
+		static REL::Relocation<BSTArray<MessageBoxData*>*> queue{ RELOCATION_ID(519819, 406362) };
 		if (queue->empty()) {
 			return;
 		}

--- a/src/RE/M/MessageBoxMenu.cpp
+++ b/src/RE/M/MessageBoxMenu.cpp
@@ -1,7 +1,11 @@
 #include "RE/M/MessageBoxMenu.h"
 
 #include "RE/B/BSTArray.h"
+#include "RE/B/BSTSmartPointer.h"
+#include "RE/I/IMessageBoxCallback.h"
 #include "RE/M/MessageBoxData.h"
+#include "RE/U/UIMessage.h"
+#include "RE/U/UIMessageQueue.h"
 
 namespace RE
 {
@@ -22,5 +26,47 @@ namespace RE
 		using func_t = decltype(&MessageBoxMenu::QueueMessage);
 		static REL::Relocation<func_t> func{ RELOCATION_ID(51422, 52271) };
 		return func(a_data);
+	}
+
+	MessageBoxData* MessageBoxMenu::GetCurrentMessageBoxData()
+	{
+		static REL::Relocation<BSTArray<MessageBoxData*>*> queue{ RELOCATION_ID(519818, 406360) };
+		return queue->empty() ? nullptr : queue->back();
+	}
+
+	void MessageBoxMenu::RemoveMessageFromQueue(MessageBoxData* a_data)
+	{
+		// Engine ABI: (MessageBoxMenu* a_menu, MessageBoxData* a_data). The menu 'this' is ignored
+		// (the queue is a global), so nullptr is safe. Finds a_data in the queue, removes it, and
+		// runs its scalar-deleting destructor.
+		using func_t = void (*)(MessageBoxMenu*, MessageBoxData*);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(51426, 52284) };
+		func(nullptr, a_data);
+	}
+
+	void MessageBoxMenu::SelectOption(std::int32_t a_buttonIndex)
+	{
+		static REL::Relocation<BSTArray<MessageBoxData*>*> queue{ RELOCATION_ID(519818, 406360) };
+		if (queue->empty()) {
+			return;
+		}
+
+		auto* data = queue->back();
+		// Hold a ref so the callback survives RemoveMessageFromQueue destroying `data`.
+		BSTSmartPointer<IMessageBoxCallback> callback = data->callback;
+		const auto                           option = static_cast<IMessageBoxCallback::Message>(data->optionIndexOffset + a_buttonIndex);
+
+		RemoveMessageFromQueue(data);
+
+		// No SWF is driving the close, so hide the menu ourselves once nothing else is queued.
+		if (queue->empty()) {
+			if (auto* uiQueue = UIMessageQueue::GetSingleton()) {
+				uiQueue->AddMessage(MENU_NAME.data(), UI_MESSAGE_TYPE::kHide, nullptr);
+			}
+		}
+
+		if (callback) {
+			callback->Run(option);
+		}
 	}
 }

--- a/src/RE/M/MessageBoxMenu.cpp
+++ b/src/RE/M/MessageBoxMenu.cpp
@@ -51,12 +51,11 @@ namespace RE
 
 	void MessageBoxMenu::SelectOption(std::int32_t a_buttonIndex)
 	{
-		static REL::Relocation<BSTArray<MessageBoxData*>*> queue{ RELOCATION_ID(519819, 406362) };
-		if (queue->empty()) {
+		auto* data = GetCurrentMessageBoxData();
+		if (!data) {
 			return;
 		}
 
-		auto* data = queue->back();
 		// Hold a ref so the callback survives RemoveMessageFromQueue destroying `data`.
 		BSTSmartPointer<IMessageBoxCallback> callback = data->callback;
 		const auto                           option = static_cast<IMessageBoxCallback::Message>(data->optionIndexOffset + a_buttonIndex);
@@ -64,7 +63,7 @@ namespace RE
 		RemoveMessageFromQueue(data);
 
 		// No SWF is driving the close, so hide the menu ourselves once nothing else is queued.
-		if (queue->empty()) {
+		if (!GetCurrentMessageBoxData()) {
 			if (auto* uiQueue = UIMessageQueue::GetSingleton()) {
 				uiQueue->AddMessage(MENU_NAME.data(), UI_MESSAGE_TYPE::kHide, nullptr);
 			}


### PR DESCRIPTION
@
Adds read + programmatic-answer support for a blocking `MessageBoxMenu` (e.g. the save-load *"This save relies on content that is no longer present… Continue Loading?"* dialog) **without hooking the SEH-guarded `MessageBoxData::QueueMessage`**.

## New API (`RE::MessageBoxMenu`)
- `GetCurrentMessageBoxData()` — the displayed box (`queue.back()`; the queue is LIFO and is *not* popped until answered, so this is race-free on all runtimes).
- `RemoveMessageFromQueue(MessageBoxData*)` — pop + destroy a queued message (`RELOCATION_ID(51426, 52284)`).
- `SelectOption(buttonIndex)` — replays the engine `ProcessButtonPress`: `optionIndexOffset + index` → `callback->Run`, pops the queue, posts `kHide` when empty. **Main-thread only** (mutates UI/game state; `Run(1)` starts a real load).

## New type
- `LoadGameMissingContentCallBack` (`RE::IMessageBoxCallback`) — the all-runtime (SE/AE/VR) missing-masters/plugins callback. Sibling of the AE-only `LoadGameUnrecognizedContentCallBack`.

## AE-id fix
Corrects the AE ids on the **existing** `RTTI___`/`VTABLE___LoadGameMissingContentCallBack` entries:
- RTTI `394457 → 502590`, VTABLE `206638 → 465335`.

The old AE ids are **absent from the 1.6.1170 address library**; the new ids resolve to the Ghidra-verified addresses (RTTI type-descriptor `0x2064328`, vftable `0x188d430`). SE ids / VR offsets unchanged. All functions named in Ghidra SE/AE/VR; address-library data submitted separately to `skyrim_vr_address_library`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a missing-content warning for the save/load dialog that notifies users when a save depends on unavailable content and lets them continue or cancel.
  * Extended message-box controls so code can query the active message, remove queued messages, and programmatically choose an option—enabling more reliable UI-driven workflows and scripted responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->