### PR TITLE
ci: bump actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -51,7 +51,9 @@ jobs:
           echo "✓ Using vcpkg baseline from vcpkg.json: $baseline"
 
       - name: Setup MSVC Environment
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: TheMrMilchmann/setup-msvc-dev@v4.0.0
+        with:
+          arch: x64
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -36,7 +36,7 @@ jobs:
           - clang-cl
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: main
           submodules: recursive

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         ref: ${{ github.head_ref || github.ref_name }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.10'
 
@@ -40,7 +40,7 @@ jobs:
         steps.verify_diff.outputs.changed == 'true' &&
         (github.event_name == 'push' || 
          github.event.pull_request.head.repo.full_name == github.repository)
-      uses: stefanzweifel/git-auto-commit-action@v5
+      uses: stefanzweifel/git-auto-commit-action@v7
       with:
         commit_message: "style: apply automated maintenance (formatting & file lists)"
         commit_options: '--no-verify'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: true
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/test-consumer.yml
+++ b/.github/workflows/test-consumer.yml
@@ -18,7 +18,9 @@ jobs:
           submodules: recursive
       
       - name: Setup MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: TheMrMilchmann/setup-msvc-dev@v4.0.0
+        with:
+          arch: x64
       
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11

--- a/.github/workflows/test-consumer.yml
+++ b/.github/workflows/test-consumer.yml
@@ -13,7 +13,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
       


### PR DESCRIPTION
## Summary

CommonLibVR's CI emits the GitHub Actions **Node.js 20 deprecation** warning on every run. Node 20 actions are force-migrated to Node 24 on **2026-06-16** and Node 20 is removed from runners on **2026-09-16**. This moves every action onto a Node 24 runtime.

| Action | Before | After | Node |
|---|---|---|---|
| `actions/checkout` | v4 | **v5** | 20 → 24 |
| `actions/setup-python` | v5 | **v6** | 20 → 24 |
| `cycjimmy/semantic-release-action` | v4 | **v5** | 20 → 24 |
| `stefanzweifel/git-auto-commit-action` | v5 | **v7** | 20 → 24 (v6 is still Node 20) |
| `ilammy/msvc-dev-cmd` | v1 | **`TheMrMilchmann/setup-msvc-dev@v4.0.0`** | 20 → 24 |
| `lukka/run-vcpkg` | v11 | v11 | already 24 ✓ |
| `lukka/run-cmake` | v10 | v10 | already 24 ✓ |

For the version bumps I verified each target's `runs.using` is `node24` and chose the lowest major that satisfies it, and confirmed only inputs unchanged across the bumps are in use.

## MSVC action replacement

`ilammy/msvc-dev-cmd` has no Node 24 release (even latest `v1.13.0` is Node 20), so it's replaced with [`TheMrMilchmann/setup-msvc-dev@v4.0.0`](https://github.com/TheMrMilchmann/setup-msvc-dev) (`runs.using: node24`) — the same swap made in [alandtse/open-shaders](https://github.com/alandtse/open-shaders/blob/dev/.github/actions/setup-build-environment/action.yaml).

- Auto-detects the runner's pre-installed Visual Studio via `vswhere`, so (unlike open-shaders, which targets VS Build Tools 2026) no manual VS install step is needed — the GitHub `windows` runner's bundled VS 2022 is picked up.
- `arch: x64` is pinned to match the old `ilammy` default and the all-x64 build matrix (`msvc` + `clang-cl`).
- Pinned to `v4.0.0` because no floating `v4` tag exists upstream (also matches open-shaders).

## Validation

- `main_ci.yml` and `test-consumer.yml` (the MSVC swap) are exercised by this PR's checks.
- `release.yml` (semantic-release) and `maintenance.yml` (auto-commit + setup-python) only run on push to `ng` / schedule, so they aren't exercised here — worth a glance on the next release/maintenance run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)