### PR TITLE
fix(vr): niskindata and bsgeometry runtime layouts

### DIFF
--- a/include/RE/B/BSDynamicTriShape.h
+++ b/include/RE/B/BSDynamicTriShape.h
@@ -36,7 +36,7 @@ namespace RE
 		void               SaveBinary(NiStream& a_stream) override;            // 1B
 		bool               IsEqual(NiObject* a_object) override;               // 1C
 
-		RUNTIME_DATA_ACCESSOR_EX(DYNAMIC_TRISHAPE_RUNTIME_DATA, GetDynamicTrishapeRuntimeData, 0x160, 0x1A8);
+		RUNTIME_DATA_ACCESSOR_EX(DYNAMIC_TRISHAPE_RUNTIME_DATA, GetDynamicTrishapeRuntimeData, 0x160, 0x1A0);
 		BSDynamicTriShape* ctor()
 		{
 			using func_t = decltype(&BSDynamicTriShape::ctor);
@@ -45,9 +45,9 @@ namespace RE
 		}
 
 #ifndef SKYRIM_CROSS_VR
-		RUNTIME_DATA_CONTENT;  // 160, 1A8
+		RUNTIME_DATA_CONTENT;  // 160, 1A0
 #endif
 	};
-	STATIC_ASSERT_SIZE(BSDynamicTriShape, 0x180, 0x180, 0x1C8, 0x110);
+	STATIC_ASSERT_SIZE(BSDynamicTriShape, 0x180, 0x180, 0x1C0, 0x110);
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/B/BSGeometry.h
+++ b/include/RE/B/BSGeometry.h
@@ -125,14 +125,14 @@ namespace RE
 		std::uint16_t                    pad152;  // 152
 		std::uint32_t                    pad154;  // 154
 #	elif defined(EXCLUSIVE_SKYRIM_VR)
-		REX::EnumSet<Type, std::uint32_t> type;    // 190
-		std::uint8_t                      pad151;  // 194
-		std::uint16_t                     pad152;  // 195
-		std::uint32_t                     pad154;  // 197
+		BSGeometryTypeSet type;    // 190
+		std::uint8_t      pad191;  // 191
+		std::uint16_t     pad192;  // 192
+		std::uint32_t     pad194;  // 194
 #	endif
 #endif
 	};
-	STATIC_ASSERT_SIZE(BSGeometry, 0x158, 0x1A0);
+	STATIC_ASSERT_SIZE(BSGeometry, 0x158, 0x198);
 }
 #undef MODEL_DATA_CONTENT
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/B/BSInstanceTriShape.h
+++ b/include/RE/B/BSInstanceTriShape.h
@@ -25,5 +25,5 @@ namespace RE
 		SKYRIM_REL_VR_VIRTUAL std::uint32_t AddGroup(std::uint32_t a_numInstances, std::uint16_t& a_instanceData, std::uint32_t a_arg3, float a_arg4);  // 3C
 		SKYRIM_REL_VR_VIRTUAL void          RemoveGroup(std::uint32_t a_numInstance);                                                                   // 3D
 	};
-	STATIC_ASSERT_SIZE(BSInstanceTriShape, 0x160, 0x1A8);
+	STATIC_ASSERT_SIZE(BSInstanceTriShape, 0x160, 0x1A0);
 }

--- a/include/RE/B/BSMultiIndexTriShape.h
+++ b/include/RE/B/BSMultiIndexTriShape.h
@@ -54,12 +54,12 @@ namespace RE
 		BSMultiIndexTriShape* AsMultiIndexTriShape() override;  // 35 - { return this; }
 #endif
 
-		RUNTIME_DATA_ACCESSOR_EX(MULTI_INDEX_TRISHAPE_RUNTIME_DATA, GetMultiIndexTrishapeRuntimeData, 0x160, 0x1A8);
+		RUNTIME_DATA_ACCESSOR_EX(MULTI_INDEX_TRISHAPE_RUNTIME_DATA, GetMultiIndexTrishapeRuntimeData, 0x160, 0x1A0);
 		// members
 #ifndef SKYRIM_CROSS_VR
-		RUNTIME_DATA_CONTENT  // 160, 1A8
+		RUNTIME_DATA_CONTENT  // 160, 1A0
 #endif
 	};
-	STATIC_ASSERT_SIZE(BSMultiIndexTriShape, 0x1D8, 0x1D8, 0x220, 0x110);
+	STATIC_ASSERT_SIZE(BSMultiIndexTriShape, 0x1D8, 0x1D8, 0x218, 0x110);
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/B/BSMultiStreamInstanceTriShape.h
+++ b/include/RE/B/BSMultiStreamInstanceTriShape.h
@@ -58,12 +58,12 @@ namespace RE
 		void          RemoveGroup(std::uint32_t a_numInstance) override;                                                                   // 3D
 #endif
 
-		RUNTIME_DATA_ACCESSOR_EX(MULTISTREAM_TRISHAPE_RUNTIME_DATA, GetMultiStreamTrishapeRuntimeData, 0x160, 0x1A8);
+		RUNTIME_DATA_ACCESSOR_EX(MULTISTREAM_TRISHAPE_RUNTIME_DATA, GetMultiStreamTrishapeRuntimeData, 0x160, 0x1A0);
 		// members
 #ifndef SKYRIM_CROSS_VR
-		RUNTIME_DATA_CONTENT  // 160, 1A8
+		RUNTIME_DATA_CONTENT  // 160, 1A0
 #endif
 	};
-	STATIC_ASSERT_SIZE(BSMultiStreamInstanceTriShape, 0x1A0, 0x1A0, 0x1E8, 0x110);
+	STATIC_ASSERT_SIZE(BSMultiStreamInstanceTriShape, 0x1A0, 0x1A0, 0x1E0, 0x110);
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/B/BSStripParticleSystem.h
+++ b/include/RE/B/BSStripParticleSystem.h
@@ -26,5 +26,5 @@ namespace RE
 		void OnVisible(NiCullingProcess& a_process, std::int32_t a_alphaGroupIndex) override;  // 34
 #endif
 	};
-	STATIC_ASSERT_SIZE(BSStripParticleSystem, 0x198, 0x198, 0x1E0, 0x110);
+	STATIC_ASSERT_SIZE(BSStripParticleSystem, 0x198, 0x198, 0x1D8, 0x110);
 }

--- a/include/RE/B/BSSubIndexTriShape.h
+++ b/include/RE/B/BSSubIndexTriShape.h
@@ -49,13 +49,13 @@ namespace RE
 		void Unk_37(void) override;                                                            // 37
 #endif
 
-		RUNTIME_DATA_ACCESSOR_EX(SUB_INDEX_TRISHAPE_RUNTIME_DATA, GetSubIndexedTrishapeRuntimeData, 0x160, 0x1A8);
+		RUNTIME_DATA_ACCESSOR_EX(SUB_INDEX_TRISHAPE_RUNTIME_DATA, GetSubIndexedTrishapeRuntimeData, 0x160, 0x1A0);
 
 		// members
 #ifndef SKYRIM_CROSS_VR
-		RUNTIME_DATA_CONTENT  // 160, 1A8
+		RUNTIME_DATA_CONTENT  // 160, 1A0
 #endif
 	};
-	STATIC_ASSERT_SIZE(BSSubIndexTriShape, 0x178, 0x178, 0x1C0, 0x110);
+	STATIC_ASSERT_SIZE(BSSubIndexTriShape, 0x178, 0x178, 0x1B8, 0x110);
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/B/BSTriShape.h
+++ b/include/RE/B/BSTriShape.h
@@ -17,7 +17,7 @@ namespace RE
 #define RUNTIME_DATA_CONTENT             \
 	std::uint16_t triangleCount; /* 0 */ \
 	std::uint16_t vertexCount;   /* 2 */ \
-	std::uint32_t pad15C;        /* 3 */
+	std::uint32_t pad15C;        /* 4 */
 
 			RUNTIME_DATA_CONTENT
 		};
@@ -35,12 +35,12 @@ namespace RE
 		void          SaveBinary(NiStream& a_stream) override;            // 1B
 		bool          IsEqual(NiObject* a_object) override;               // 1C - { return false; }
 
-		RUNTIME_DATA_ACCESSOR_EX(TRISHAPE_RUNTIME_DATA, GetTrishapeRuntimeData, 0x158, 0x1A0);
+		RUNTIME_DATA_ACCESSOR_EX(TRISHAPE_RUNTIME_DATA, GetTrishapeRuntimeData, 0x158, 0x198);
 		// members
 #ifndef SKYRIM_CROSS_VR
-		RUNTIME_DATA_CONTENT  // 158, 1A0
+		RUNTIME_DATA_CONTENT  // 158, 198
 #endif
 	};
-	STATIC_ASSERT_SIZE(BSTriShape, 0x160, 0x1A8);
+	STATIC_ASSERT_SIZE(BSTriShape, 0x160, 0x1A0);
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/N/NiParticleSystem.h
+++ b/include/RE/N/NiParticleSystem.h
@@ -65,6 +65,6 @@ namespace RE
 		RUNTIME_DATA_CONTENT;
 #endif
 	};
-	STATIC_ASSERT_SIZE(NiParticleSystem, 0x198, 0x198, 0x1E0, 0x110);
+	STATIC_ASSERT_SIZE(NiParticleSystem, 0x198, 0x198, 0x1D8, 0x110);
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/N/NiParticles.h
+++ b/include/RE/N/NiParticles.h
@@ -41,6 +41,6 @@ namespace RE
 		RUNTIME_DATA_CONTENT;
 #endif
 	};
-	STATIC_ASSERT_SIZE(NiParticles, 0x168, 0x168, 0x1B0, 0x110);
+	STATIC_ASSERT_SIZE(NiParticles, 0x168, 0x168, 0x1A8, 0x110);
 }
 #undef RUNTIME_DATA_CONTENT

--- a/include/RE/N/NiSkinData.h
+++ b/include/RE/N/NiSkinData.h
@@ -6,6 +6,7 @@
 #include "RE/N/NiTransform.h"
 #include "REL/Common.h"
 #include "REL/Module.h"
+#include "REL/Relocation.h"
 
 namespace RE
 {
@@ -73,16 +74,6 @@ namespace RE
 			}
 		}
 
-		[[nodiscard]] std::byte* GetBoneDataAddress(std::uint32_t a_idx) noexcept
-		{
-			return reinterpret_cast<std::byte*>(boneData) + (static_cast<std::size_t>(a_idx) * GetBoneDataStride());
-		}
-
-		[[nodiscard]] const std::byte* GetBoneDataAddress(std::uint32_t a_idx) const noexcept
-		{
-			return reinterpret_cast<const std::byte*>(boneData) + (static_cast<std::size_t>(a_idx) * GetBoneDataStride());
-		}
-
 		[[nodiscard]] NiTransform& GetBoneDataSkinToBone(std::uint32_t a_idx) noexcept
 		{
 			return *reinterpret_cast<NiTransform*>(GetBoneDataAddress(a_idx));
@@ -127,12 +118,45 @@ namespace RE
 			return *reinterpret_cast<const std::uint16_t*>(GetBoneDataAddress(a_idx) + offset);
 		}
 
+		[[nodiscard]] std::uint32_t& GetBoneCount() noexcept
+		{
+			return REL::RelocateMember<std::uint32_t>(this, 0x58, 0x58);
+		}
+
+		[[nodiscard]] const std::uint32_t& GetBoneCount() const noexcept
+		{
+			return REL::RelocateMember<std::uint32_t>(this, 0x58, 0x58);
+		}
+
 		// members
 		NiPointer<NiSkinPartition> skinPartition;     // 10
 		NiTransform                rootParentToSkin;  // 18
-		BoneData*                  boneData;          // 50
-		std::uint32_t              bones;             // 58
-		std::uint32_t              pad5C;             // 5C
+#ifndef SKYRIM_CROSS_VR
+		BoneData*     boneData;  // 50
+		std::uint32_t bones;     // 58
+		std::uint32_t pad5C;     // 5C
+#endif
+
+	private:
+		[[nodiscard]] std::byte* GetBoneDataAddress(std::uint32_t a_idx) noexcept
+		{
+			return reinterpret_cast<std::byte*>(GetBoneData()) + (static_cast<std::size_t>(a_idx) * GetBoneDataStride());
+		}
+
+		[[nodiscard]] const std::byte* GetBoneDataAddress(std::uint32_t a_idx) const noexcept
+		{
+			return reinterpret_cast<const std::byte*>(GetBoneData()) + (static_cast<std::size_t>(a_idx) * GetBoneDataStride());
+		}
+
+		[[nodiscard]] BoneData* GetBoneData() noexcept
+		{
+			return REL::RelocateMember<BoneData*>(this, 0x50, 0x50);
+		}
+
+		[[nodiscard]] const BoneData* GetBoneData() const noexcept
+		{
+			return REL::RelocateMember<BoneData*>(this, 0x50, 0x50);
+		}
 	};
-	static_assert(sizeof(NiSkinData) == 0x60);
+	STATIC_ASSERT_SIZE(NiSkinData, 0x60, 0x60, 0x60, 0x50, 0x60);
 }

--- a/include/RE/N/NiSkinData.h
+++ b/include/RE/N/NiSkinData.h
@@ -4,6 +4,8 @@
 #include "RE/N/NiObject.h"
 #include "RE/N/NiSmartPointer.h"
 #include "RE/N/NiTransform.h"
+#include "REL/Common.h"
+#include "REL/Module.h"
 
 namespace RE
 {
@@ -30,15 +32,27 @@ namespace RE
 		{
 		public:
 			// members
-			NiTransform   skinToBone;    // 00
-			NiBound       bound;         // 34
+			NiTransform skinToBone;  // 00
+			NiBound     bound;       // 34
+#if defined(EXCLUSIVE_SKYRIM_VR)
+			std::byte     vrExtra[0x1C];  // 44
+			BoneVertData* boneVertData;   // 60
+			std::uint16_t verts;          // 68
+			std::uint16_t pad6A;          // 6A
+			std::uint32_t pad6C;          // 6C
+#else
 			std::uint32_t pad44;         // 44
 			BoneVertData* boneVertData;  // 48
 			std::uint16_t verts;         // 50
 			std::uint16_t pad52;         // 52
 			std::uint32_t pad54;         // 54
+#endif
 		};
+#if defined(EXCLUSIVE_SKYRIM_VR)
+		static_assert(sizeof(BoneData) == 0x70);
+#else
 		static_assert(sizeof(BoneData) == 0x58);
+#endif
 
 		~NiSkinData() override;  // 00
 
@@ -49,6 +63,69 @@ namespace RE
 		bool          RegisterStreamables(NiStream& a_stream) override;  // 1A - { NiObject::RegisterStreamables(a_stream) != false; }
 		void          SaveBinary(NiStream& a_stream) override;           // 1B
 		bool          IsEqual(NiObject* a_object) override;              // 1C
+
+		[[nodiscard]] static SKYRIM_REL_VR std::size_t GetBoneDataStride() noexcept
+		{
+			if SKYRIM_REL_VR_CONSTEXPR (REL::Module::IsVR()) {
+				return 0x70;
+			} else {
+				return 0x58;
+			}
+		}
+
+		[[nodiscard]] std::byte* GetBoneDataAddress(std::uint32_t a_idx) noexcept
+		{
+			return reinterpret_cast<std::byte*>(boneData) + (static_cast<std::size_t>(a_idx) * GetBoneDataStride());
+		}
+
+		[[nodiscard]] const std::byte* GetBoneDataAddress(std::uint32_t a_idx) const noexcept
+		{
+			return reinterpret_cast<const std::byte*>(boneData) + (static_cast<std::size_t>(a_idx) * GetBoneDataStride());
+		}
+
+		[[nodiscard]] NiTransform& GetBoneDataSkinToBone(std::uint32_t a_idx) noexcept
+		{
+			return *reinterpret_cast<NiTransform*>(GetBoneDataAddress(a_idx));
+		}
+
+		[[nodiscard]] const NiTransform& GetBoneDataSkinToBone(std::uint32_t a_idx) const noexcept
+		{
+			return *reinterpret_cast<const NiTransform*>(GetBoneDataAddress(a_idx));
+		}
+
+		[[nodiscard]] NiBound& GetBoneDataBound(std::uint32_t a_idx) noexcept
+		{
+			return *reinterpret_cast<NiBound*>(GetBoneDataAddress(a_idx) + 0x34);
+		}
+
+		[[nodiscard]] const NiBound& GetBoneDataBound(std::uint32_t a_idx) const noexcept
+		{
+			return *reinterpret_cast<const NiBound*>(GetBoneDataAddress(a_idx) + 0x34);
+		}
+
+		[[nodiscard]] BoneVertData*& GetBoneDataBoneVertData(std::uint32_t a_idx) noexcept
+		{
+			const auto offset = REL::Module::IsVR() ? 0x60 : 0x48;
+			return *reinterpret_cast<BoneVertData**>(GetBoneDataAddress(a_idx) + offset);
+		}
+
+		[[nodiscard]] BoneVertData* GetBoneDataBoneVertData(std::uint32_t a_idx) const noexcept
+		{
+			const auto offset = REL::Module::IsVR() ? 0x60 : 0x48;
+			return *reinterpret_cast<BoneVertData* const*>(GetBoneDataAddress(a_idx) + offset);
+		}
+
+		[[nodiscard]] std::uint16_t& GetBoneDataVerts(std::uint32_t a_idx) noexcept
+		{
+			const auto offset = REL::Module::IsVR() ? 0x68 : 0x50;
+			return *reinterpret_cast<std::uint16_t*>(GetBoneDataAddress(a_idx) + offset);
+		}
+
+		[[nodiscard]] const std::uint16_t& GetBoneDataVerts(std::uint32_t a_idx) const noexcept
+		{
+			const auto offset = REL::Module::IsVR() ? 0x68 : 0x50;
+			return *reinterpret_cast<const std::uint16_t*>(GetBoneDataAddress(a_idx) + offset);
+		}
 
 		// members
 		NiPointer<NiSkinPartition> skinPartition;     // 10


### PR DESCRIPTION
Fix VR-specific NiSkinData bone entry stride and BSGeometry-derived runtime offsets. 

VR NiSkinData uses 0x70-byte BoneData entries, not 0x58. 

VR BSGeometry is 0x198 bytes, which places BSTriShape runtime data at 0x198 and BSDynamicTriShape runtime data at 0x1A0.

VR uses a different `NiSkinData::BoneData` stride (`0x70` vs flat `0x58`). Since cross-runtime builds cannot express both strides through a single `BoneData*`, the new accessors avoid unsafe direct indexing on VR. Which is why there's so many accessor methods. Wasn't sure the best way to implement this.. 

VR disassembly shows:

- `NiSkinData::LoadBinary` allocates/indexes bones with a `0x70` stride
- VR bone data uses `boneVertData` at `+0x60` and `verts` at `+0x68`
- `BSGeometry` deleting destructor passes size `0x198`
- `BSTriShape::SaveBinary` reads `triangleCount` at `+0x198` and `vertexCount` at `+0x19A`
- `BSDynamicTriShape::LoadBinary` reads/writes `dynamicData` at `+0x1A0` and `dataSize` at `+0x1B0`
- `NiParticles::LoadBinary` also reads derived data at `this + 0x1A0..0x1A7`, supporting `BSGeometry` ending at `0x198` rather than `0x1A0`

Just to be clear: Direct `boneData[i]` indexing remains unsafe for VR in cross-runtime builds because the compile-time `BoneData` size is still the flat-runtime size there. New accessor methods should be used for runtime-correct indexing

(I will test this more extensively tomorrow)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected memory/layout and size assertions across multiple geometry, tri-shape and particle system components to improve stability and prevent alignment/runtime issues.

* **New Features**
  * Added enhanced skinning data accessors and VR-aware handling for bone data, improving compatibility and reliability for VR and non-VR rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->