### PR TITLE
ci: skip maintenance job on fork PRs

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -13,6 +13,11 @@ permissions:
 jobs:
   maintenance:
     runs-on: ubuntu-latest
+    # Skip on fork PRs: the head branch does not exist on this repo (so the ref
+    # checkout below fails), and the auto-commit step cannot push to a fork anyway.
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
@
## Problem
PR #162 (and any fork PR) fails CI in the **Scripted maintenance** job at `actions/checkout`:
```
git fetch ... +refs/heads/fix-1*:refs/remotes/origin/fix-1* ...
The process /usr/bin/git failed with exit code 1
```
The job checks out `ref: ${{ github.head_ref }}` (e.g. `fix-1`), but on a **fork PR** that branch lives on the contributors fork (`asdasdduck/CommonLibVR`), **not** on this repo — so the fetch from `origin` finds nothing and exits 1.

Its a guaranteed failure with no upside: the auto-commit step is already gated to same-repo events (`head.repo.full_name == github.repository`), so on a fork PR the job regenerates the CMake lists and then **cannot push** anyway.

## Fix
Guard the whole `maintenance` job to push events + same-repo PRs, matching the existing commit-step condition. Fork PRs now skip it cleanly (green); same-repo PRs and pushes to `ng` are unaffected (still regenerate + auto-commit the CMake file lists).

Not a code change — unblocks #162 and all future external contributions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated maintenance workflow to conditionally execute for push events and same-repository pull requests, improving CI/CD efficiency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->