### PR TITLE
feat(build): publish prebuilt static-library bundles for xmake consumers

### DIFF
--- a/.github/workflows/prebuilt.yml
+++ b/.github/workflows/prebuilt.yml
@@ -72,7 +72,10 @@ jobs:
         id: bundle
         shell: pwsh
         run: |
-          $stage = "commonlibsse-ng-prebuilt-all-msvc"
+          # Version the asset name with the release tag when publishing (matches the
+          # name documented in PREBUILT.md); fall back to an unversioned name for PR runs.
+          $tag = "${{ inputs.attach_tag }}"
+          $stage = if ($tag) { "commonlibsse-ng-prebuilt-$tag-all-msvc" } else { "commonlibsse-ng-prebuilt-all-msvc" }
           New-Item -ItemType Directory -Force -Path "$stage/lib","$stage/extern/openvr" | Out-Null
           # Drop-in replacement for the lib/commonlibsse-ng source tree: same xmake.lua
           # (auto-detects the shipped lib), headers, plugin-rule templates, VR headers.

--- a/.github/workflows/prebuilt.yml
+++ b/.github/workflows/prebuilt.yml
@@ -1,0 +1,117 @@
+# Build a prebuilt CommonLib bundle for the canonical "all" config and prove it is
+# consumable. Runs on every PR to ng (validation only) and is called by release.yml on
+# a published release (with attach_tag set) to attach the bundle to the GitHub release.
+#
+# xmake consumers only: the bundle ships the same xmake.lua (auto-detects the prebuilt),
+# headers, plugin-rule templates and VR headers, so a consumer's includes()/the
+# commonlibsse-ng.plugin rule work unchanged with zero CommonLib recompile. Baked
+# config: skyrim all (SE+AE+VR) + rex_ini + skse_xbyak, releasedbg, MSVC.
+#
+# CMake consumers are intentionally not served here — see PREBUILT.md (use vcpkg
+# binary caching for the vcpkg-port consumers).
+name: Prebuilt bundles
+
+on:
+  pull_request:
+    branches: [ng]
+    paths:
+      - xmake.lua
+      - CMakeLists.txt
+      - cmake/**
+      - include/**
+      - src/**
+      - res/**
+      - vcpkg.json
+      - .github/workflows/prebuilt.yml
+      - tests/prebuilt-consumer/**
+      - tests/prebuilt-consumer-cmake/**
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        default: ""
+      attach_tag:
+        description: "If set, create/attach the bundles to this release tag."
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  xmake:
+    name: xmake bundle + self-test
+    runs-on: windows-latest
+    permissions:
+      contents: write # only used when attach_tag is set
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+          submodules: recursive # extern/openvr headers ship in the bundle
+
+      - name: Set up xmake
+        uses: xmake-io/github-action-setup-xmake@v1
+        with:
+          xmake-version: latest
+          package-cache: true
+          build-cache: true
+          project-path: .
+
+      - name: Update xmake package repo
+        run: xmake repo --update
+
+      - name: Build commonlibsse-ng (all + rex_ini + skse_xbyak, releasedbg)
+        run: |
+          xmake config -m releasedbg -a x64 --skyrim_se=y --skyrim_ae=y --skyrim_vr=y --rex_ini=y --skse_xbyak=y --yes
+          xmake build --yes commonlibsse-ng
+
+      - name: Assemble bundle + stage into self-test consumer
+        id: bundle
+        shell: pwsh
+        run: |
+          $stage = "commonlibsse-ng-prebuilt-all-msvc"
+          New-Item -ItemType Directory -Force -Path "$stage/lib","$stage/extern/openvr" | Out-Null
+          # Drop-in replacement for the lib/commonlibsse-ng source tree: same xmake.lua
+          # (auto-detects the shipped lib), headers, plugin-rule templates, VR headers.
+          Copy-Item xmake.lua, PREBUILT.md "$stage/"
+          Copy-Item -Recurse include "$stage/include"
+          Copy-Item -Recurse res "$stage/res"
+          Copy-Item -Recurse extern/openvr/headers "$stage/extern/openvr/headers"
+          $lib = "build/windows/x64/releasedbg/commonlibsse-ng.lib"
+          if (-not (Test-Path $lib)) { Write-Error "lib not found at $lib"; exit 1 }
+          Copy-Item $lib "$stage/lib/"
+          7z a -t7z -mx=9 "$stage.7z" "$stage" | Out-Null
+          "bundle=$stage.7z" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          # Stage the same tree as the self-test consumer's lib/commonlibsse-ng.
+          $dst = "tests/prebuilt-consumer/lib/commonlibsse-ng"
+          New-Item -ItemType Directory -Force -Path $dst | Out-Null
+          Copy-Item -Recurse "$stage/*" $dst
+
+      - name: Self-test — build a plugin against the prebuilt
+        working-directory: tests/prebuilt-consumer
+        run: |
+          xmake f -P . -m releasedbg -a x64 --yes
+          xmake b -P . --yes --rebuild
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: prebuilt-bundle-xmake
+          path: ${{ steps.bundle.outputs.bundle }}
+          if-no-files-found: error
+
+      - name: Attach bundle to release
+        if: inputs.attach_tag != ''
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view "${{ inputs.attach_tag }}" *> $null
+          if ($LASTEXITCODE -ne 0) {
+            gh release create "${{ inputs.attach_tag }}" --title "CommonLibSSE-NG ${{ inputs.attach_tag }}" `
+              --notes "Prebuilt CommonLib bundle for downstream xmake consumers (config: skyrim all + rex_ini + skse_xbyak). See PREBUILT.md."
+          }
+          gh release upload "${{ inputs.attach_tag }}" "${{ steps.bundle.outputs.bundle }}" --clobber

--- a/.github/workflows/prebuilt.yml
+++ b/.github/workflows/prebuilt.yml
@@ -71,10 +71,12 @@ jobs:
       - name: Assemble bundle + stage into self-test consumer
         id: bundle
         shell: pwsh
+        env:
+          ATTACH_TAG: ${{ inputs.attach_tag }} # via env, not template interpolation (injection-safe)
         run: |
           # Version the asset name with the release tag when publishing (matches the
           # name documented in PREBUILT.md); fall back to an unversioned name for PR runs.
-          $tag = "${{ inputs.attach_tag }}"
+          $tag = $env:ATTACH_TAG
           $stage = if ($tag) { "commonlibsse-ng-prebuilt-$tag-all-msvc" } else { "commonlibsse-ng-prebuilt-all-msvc" }
           New-Item -ItemType Directory -Force -Path "$stage/lib","$stage/extern/openvr" | Out-Null
           # Drop-in replacement for the lib/commonlibsse-ng source tree: same xmake.lua
@@ -111,10 +113,11 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ATTACH_TAG: ${{ inputs.attach_tag }} # via env, not template interpolation (injection-safe)
         run: |
-          gh release view "${{ inputs.attach_tag }}" *> $null
+          gh release view "$env:ATTACH_TAG" *> $null
           if ($LASTEXITCODE -ne 0) {
-            gh release create "${{ inputs.attach_tag }}" --title "CommonLibSSE-NG ${{ inputs.attach_tag }}" `
+            gh release create "$env:ATTACH_TAG" --title "CommonLibSSE-NG $env:ATTACH_TAG" `
               --notes "Prebuilt CommonLib bundle for downstream xmake consumers (config: skyrim all + rex_ini + skse_xbyak). See PREBUILT.md."
           }
-          gh release upload "${{ inputs.attach_tag }}" "${{ steps.bundle.outputs.bundle }}" --clobber
+          gh release upload "$env:ATTACH_TAG" "${{ steps.bundle.outputs.bundle }}" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,10 @@ jobs:
     concurrency:
       group: semantic-release-publish
       cancel-in-progress: false
+    outputs:
+      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
+      new_release_version: ${{ steps.semantic.outputs.new_release_version }}
+      new_release_git_tag: ${{ steps.semantic.outputs.new_release_git_tag }}
 
     steps:
       - name: Checkout
@@ -49,6 +53,7 @@ jobs:
           persist-credentials: true
 
       - name: Semantic Release
+        id: semantic
         uses: cycjimmy/semantic-release-action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -58,3 +63,127 @@ jobs:
             @semantic-release/changelog
             @semantic-release/git
             conventional-changelog-conventionalcommits
+
+  # Build a prebuilt static-library bundle for the canonical "all" config and attach
+  # it to the release so downstream xmake projects can consume CommonLib without
+  # recompiling it. Config baked into the lib: skyrim all (SE+AE+VR) + rex_ini +
+  # skse_xbyak (the superset our xmake consumers use — see PREBUILT.md). Runs only
+  # when semantic-release actually published a new version.
+  build-prebuilt:
+    name: Build prebuilt (all · msvc · releasedbg)
+    needs: release
+    if: needs.release.outputs.new_release_published == 'true'
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    env:
+      TAG: ${{ needs.release.outputs.new_release_git_tag }}
+    steps:
+      - name: Checkout released tag
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.release.outputs.new_release_git_tag }}
+          submodules: recursive # extern/openvr headers are part of the bundle
+
+      - name: Set up xmake
+        uses: xmake-io/github-action-setup-xmake@v1
+        with:
+          xmake-version: latest
+          package-cache: true
+          build-cache: true
+          project-path: .
+
+      - name: Update xmake package repo
+        run: xmake repo --update
+
+      - name: Configure (all + rex_ini + skse_xbyak, releasedbg)
+        run: xmake config -m releasedbg -a x64 --skyrim_se=y --skyrim_ae=y --skyrim_vr=y --rex_ini=y --skse_xbyak=y --yes --verbose
+
+      - name: Build commonlibsse-ng
+        run: xmake build --yes commonlibsse-ng
+
+      - name: Assemble prebuilt bundle
+        id: bundle
+        shell: pwsh
+        run: |
+          $stage = "commonlibsse-ng-prebuilt-$env:TAG-all-msvc"
+          New-Item -ItemType Directory -Force -Path "$stage/lib", "$stage/extern/openvr" | Out-Null
+          # The bundle is a drop-in replacement for the lib/commonlibsse-ng source
+          # tree: same xmake.lua (auto-detects the shipped lib), headers, plugin-rule
+          # templates, VR headers, plus the prebuilt static library.
+          Copy-Item xmake.lua, PREBUILT.md "$stage/"
+          Copy-Item -Recurse include "$stage/include"
+          Copy-Item -Recurse res "$stage/res"
+          Copy-Item -Recurse extern/openvr/headers "$stage/extern/openvr/headers"
+          $lib = "build/windows/x64/releasedbg/commonlibsse-ng.lib"
+          if (-not (Test-Path $lib)) { Write-Error "Prebuilt lib not found at $lib"; exit 1 }
+          Copy-Item $lib "$stage/lib/"
+          7z a -t7z -mx=9 "$stage.7z" "$stage" | Out-Null
+          "bundle=$stage.7z" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          Write-Host "Assembled $stage.7z"
+
+      - name: Upload bundle as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: prebuilt-bundle
+          path: ${{ steps.bundle.outputs.bundle }}
+          if-no-files-found: error
+
+      - name: Attach bundle to release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # semantic-release tags but does not create a GitHub Release; create one on
+          # the tag if missing, then attach the prebuilt bundle.
+          gh release view "$env:TAG" *> $null
+          if ($LASTEXITCODE -ne 0) {
+            gh release create "$env:TAG" --title "CommonLibSSE-NG $env:TAG" `
+              --notes "Prebuilt CommonLib static library for downstream xmake consumers (config: skyrim all + rex_ini + skse_xbyak). See PREBUILT.md for how to consume."
+          }
+          gh release upload "$env:TAG" "${{ steps.bundle.outputs.bundle }}" --clobber
+
+  # Prove the bundle is actually consumable: extract it into a minimal xmake SKSE
+  # plugin and build+link against the prebuilt library (no CommonLib recompile).
+  test-prebuilt:
+    name: Test prebuilt consumer
+    needs: [release, build-prebuilt]
+    if: needs.release.outputs.new_release_published == 'true'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Download prebuilt bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: prebuilt-bundle
+          path: bundle
+
+      - name: Stage bundle as the consumer's lib/commonlibsse-ng
+        shell: pwsh
+        run: |
+          $archive = Get-ChildItem bundle/*.7z | Select-Object -First 1
+          $dest = "tests/prebuilt-consumer/lib"
+          New-Item -ItemType Directory -Force -Path $dest | Out-Null
+          7z x "$($archive.FullName)" "-o$dest" -y | Out-Null
+          # The archive contains a single top-level folder; rename it to commonlibsse-ng.
+          $extracted = Get-ChildItem $dest -Directory | Select-Object -First 1
+          Rename-Item $extracted.FullName "commonlibsse-ng"
+          Get-ChildItem "$dest/commonlibsse-ng"
+
+      - name: Set up xmake
+        uses: xmake-io/github-action-setup-xmake@v1
+        with:
+          xmake-version: latest
+          package-cache: true
+          project-path: tests/prebuilt-consumer
+
+      - name: Update xmake package repo
+        run: xmake repo --update
+
+      - name: Build consumer against prebuilt
+        working-directory: tests/prebuilt-consumer
+        run: |
+          xmake config -m releasedbg -a x64 --yes --verbose
+          xmake build --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,126 +64,16 @@ jobs:
             @semantic-release/git
             conventional-changelog-conventionalcommits
 
-  # Build a prebuilt static-library bundle for the canonical "all" config and attach
-  # it to the release so downstream xmake projects can consume CommonLib without
-  # recompiling it. Config baked into the lib: skyrim all (SE+AE+VR) + rex_ini +
-  # skse_xbyak (the superset our xmake consumers use — see PREBUILT.md). Runs only
-  # when semantic-release actually published a new version.
-  build-prebuilt:
-    name: Build prebuilt (all · msvc · releasedbg)
+  # On a published release, build the prebuilt CommonLib bundle and attach it to the
+  # GitHub release. The same build + consumer self-test also run on every PR to ng
+  # (see prebuilt.yml), so the bundle is validated before it ever ships.
+  prebuilt:
+    name: Prebuilt bundle
     needs: release
     if: needs.release.outputs.new_release_published == 'true'
-    runs-on: windows-latest
     permissions:
       contents: write
-    env:
-      TAG: ${{ needs.release.outputs.new_release_git_tag }}
-    steps:
-      - name: Checkout released tag
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ needs.release.outputs.new_release_git_tag }}
-          submodules: recursive # extern/openvr headers are part of the bundle
-
-      - name: Set up xmake
-        uses: xmake-io/github-action-setup-xmake@v1
-        with:
-          xmake-version: latest
-          package-cache: true
-          build-cache: true
-          project-path: .
-
-      - name: Update xmake package repo
-        run: xmake repo --update
-
-      - name: Configure (all + rex_ini + skse_xbyak, releasedbg)
-        run: xmake config -m releasedbg -a x64 --skyrim_se=y --skyrim_ae=y --skyrim_vr=y --rex_ini=y --skse_xbyak=y --yes --verbose
-
-      - name: Build commonlibsse-ng
-        run: xmake build --yes commonlibsse-ng
-
-      - name: Assemble prebuilt bundle
-        id: bundle
-        shell: pwsh
-        run: |
-          $stage = "commonlibsse-ng-prebuilt-$env:TAG-all-msvc"
-          New-Item -ItemType Directory -Force -Path "$stage/lib", "$stage/extern/openvr" | Out-Null
-          # The bundle is a drop-in replacement for the lib/commonlibsse-ng source
-          # tree: same xmake.lua (auto-detects the shipped lib), headers, plugin-rule
-          # templates, VR headers, plus the prebuilt static library.
-          Copy-Item xmake.lua, PREBUILT.md "$stage/"
-          Copy-Item -Recurse include "$stage/include"
-          Copy-Item -Recurse res "$stage/res"
-          Copy-Item -Recurse extern/openvr/headers "$stage/extern/openvr/headers"
-          $lib = "build/windows/x64/releasedbg/commonlibsse-ng.lib"
-          if (-not (Test-Path $lib)) { Write-Error "Prebuilt lib not found at $lib"; exit 1 }
-          Copy-Item $lib "$stage/lib/"
-          7z a -t7z -mx=9 "$stage.7z" "$stage" | Out-Null
-          "bundle=$stage.7z" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          Write-Host "Assembled $stage.7z"
-
-      - name: Upload bundle as workflow artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: prebuilt-bundle
-          path: ${{ steps.bundle.outputs.bundle }}
-          if-no-files-found: error
-
-      - name: Attach bundle to release
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # semantic-release tags but does not create a GitHub Release; create one on
-          # the tag if missing, then attach the prebuilt bundle.
-          gh release view "$env:TAG" *> $null
-          if ($LASTEXITCODE -ne 0) {
-            gh release create "$env:TAG" --title "CommonLibSSE-NG $env:TAG" `
-              --notes "Prebuilt CommonLib static library for downstream xmake consumers (config: skyrim all + rex_ini + skse_xbyak). See PREBUILT.md for how to consume."
-          }
-          gh release upload "$env:TAG" "${{ steps.bundle.outputs.bundle }}" --clobber
-
-  # Prove the bundle is actually consumable: extract it into a minimal xmake SKSE
-  # plugin and build+link against the prebuilt library (no CommonLib recompile).
-  test-prebuilt:
-    name: Test prebuilt consumer
-    needs: [release, build-prebuilt]
-    if: needs.release.outputs.new_release_published == 'true'
-    runs-on: windows-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Download prebuilt bundle
-        uses: actions/download-artifact@v4
-        with:
-          name: prebuilt-bundle
-          path: bundle
-
-      - name: Stage bundle as the consumer's lib/commonlibsse-ng
-        shell: pwsh
-        run: |
-          $archive = Get-ChildItem bundle/*.7z | Select-Object -First 1
-          $dest = "tests/prebuilt-consumer/lib"
-          New-Item -ItemType Directory -Force -Path $dest | Out-Null
-          7z x "$($archive.FullName)" "-o$dest" -y | Out-Null
-          # The archive contains a single top-level folder; rename it to commonlibsse-ng.
-          $extracted = Get-ChildItem $dest -Directory | Select-Object -First 1
-          Rename-Item $extracted.FullName "commonlibsse-ng"
-          Get-ChildItem "$dest/commonlibsse-ng"
-
-      - name: Set up xmake
-        uses: xmake-io/github-action-setup-xmake@v1
-        with:
-          xmake-version: latest
-          package-cache: true
-          project-path: tests/prebuilt-consumer
-
-      - name: Update xmake package repo
-        run: xmake repo --update
-
-      - name: Build consumer against prebuilt
-        working-directory: tests/prebuilt-consumer
-        run: |
-          xmake config -m releasedbg -a x64 --yes --verbose
-          xmake build --yes
+    uses: ./.github/workflows/prebuilt.yml
+    with:
+      ref: ${{ needs.release.outputs.new_release_git_tag }}
+      attach_tag: ${{ needs.release.outputs.new_release_git_tag }}

--- a/PREBUILT.md
+++ b/PREBUILT.md
@@ -1,0 +1,68 @@
+# Prebuilt CommonLib bundles
+
+Each release attaches a prebuilt **static-library bundle** so downstream **xmake**
+projects can consume CommonLib without recompiling it (CommonLib is the bulk of a
+plugin's build time). The bundle is produced by `.github/workflows/release.yml` and
+validated by the `test-prebuilt` job before publish.
+
+## What's in the bundle
+
+`commonlibsse-ng-prebuilt-<tag>-all-msvc.7z` is a drop-in replacement for the
+`lib/commonlibsse-ng` source tree:
+
+```
+xmake.lua            # the same build script, which auto-detects lib/commonlibsse-ng.lib
+                     #   and links it instead of compiling src/ ("prebuilt mode")
+include/             # public headers (RE/ REL/ REX/ SKSE/)
+res/                 # commonlibsse-ng.plugin rule templates
+extern/openvr/headers/   # VR headers (the "all" config enables VR)
+lib/commonlibsse-ng.lib  # the prebuilt static library
+PREBUILT.md
+```
+
+## Baked configuration (must match in the consumer)
+
+The library is compiled **once**, for the config our xmake consumers use:
+
+| Axis | Value |
+|------|-------|
+| Runtime | **all** — `skyrim_se` + `skyrim_ae` + `skyrim_vr` |
+| REX | **`rex_ini`** on |
+| Trampoline | **`skse_xbyak`** on |
+| Build | `releasedbg`, x64, **MSVC** |
+| C++ | C++23 |
+
+A prebuilt static library bakes its config and toolchain in. To link it safely a
+consumer **must** build with a compatible setup:
+
+- Same options: set `rex_ini = true` and `skse_xbyak = true` **before** `includes()`
+  (the `skyrim_*` runtimes default on). Different options (e.g. `rex_json`, or
+  disabling a runtime) are **not** served by this bundle — build from source for those.
+- Same mode/ABI: xmake `releasedbg` (release CRT `/MD`, `NDEBUG`). No `debug` bundle
+  is published. A true `debug` build must compile from source.
+- Same compiler family (**MSVC**) and a compatible MSVC toolset version. Toolset drift
+  between this bundle and the consumer is the most common cause of link/ABI errors.
+
+## How to consume (xmake)
+
+Replace the `lib/commonlibsse-ng` **source submodule** with the **extracted bundle**
+(same path). Your existing build is otherwise unchanged:
+
+```lua
+set_config("rex_ini", true)      -- match the bundle
+set_config("skse_xbyak", true)
+includes("lib/commonlibsse-ng")  -- now a prebuilt bundle, not source
+
+target("my-plugin")
+    add_deps("commonlibsse-ng")
+    add_rules("commonlibsse-ng.plugin", { name = "my-plugin", author = "you" })
+    add_files("src/**.cpp")
+```
+
+`includes()` runs the bundled `xmake.lua`, which sees `lib/commonlibsse-ng.lib` and
+switches to prebuilt mode — same target, same `commonlibsse-ng.plugin` rule, same
+transitive deps (`directxmath`, `directxtk`, `spdlog`, `simpleini`, `xbyak`,
+`rapidcsv`), just no CommonLib recompile.
+
+> CMake / vcpkg consumers should keep using the `commonlibsse-ng` vcpkg port (with
+> vcpkg binary caching) rather than this bundle.

--- a/PREBUILT.md
+++ b/PREBUILT.md
@@ -64,5 +64,23 @@ switches to prebuilt mode — same target, same `commonlibsse-ng.plugin` rule, s
 transitive deps (`directxmath`, `directxtk`, `spdlog`, `simpleini`, `xbyak`,
 `rapidcsv`), just no CommonLib recompile.
 
-> CMake / vcpkg consumers should keep using the `commonlibsse-ng` vcpkg port (with
-> vcpkg binary caching) rather than this bundle.
+## Size & cost
+
+The `releasedbg` "all" library carries full debug info for three runtimes, so it is
+**~1.2 GB extracted** — but compresses ~24× to a **~52 MB** download. A consumer build
+against it is **seconds** (e.g. ~6 s for the self-test plugin) versus a full source
+build (minutes cold). The large on-disk size is the trade for keeping CommonLib frames
+symbolicatable in crash logs; the extra link cost is negligible.
+
+## CMake consumers
+
+This bundle is **xmake-only**. CMake consumers are better served by their own
+toolchain:
+
+- **vcpkg-port consumers** (`"commonlibsse-ng"` in `vcpkg.json`): use **vcpkg binary
+  caching** (a shared NuGet/GHA/S3 backend) so the port builds once and is reused
+  across CI — idiomatic, no custom artifact.
+- **`add_subdirectory`/extern-path consumers**: keep building from the source
+  submodule, or open an issue if a `find_package(CommonLibSSE CONFIG)` prebuilt is
+  wanted (it needs `cmake/config.cmake.in` to `find_dependency` the full transitive
+  set, not just `spdlog`).

--- a/tests/prebuilt-consumer/.gitignore
+++ b/tests/prebuilt-consumer/.gitignore
@@ -1,0 +1,4 @@
+# CI stages the prebuilt bundle here at runtime (the ~1.2 GB lib must never be committed).
+/lib/
+/build/
+/.xmake/

--- a/tests/prebuilt-consumer/src/main.cpp
+++ b/tests/prebuilt-consumer/src/main.cpp
@@ -1,0 +1,12 @@
+#include <cstdint>
+
+#include <SKSE/SKSE.h>
+
+// The commonlibsse-ng.plugin rule adds the generated SKSE plugin declaration; this
+// translation unit additionally forces the linker to resolve an out-of-line symbol
+// from the prebuilt static library, so a successful build proves real linkage (not
+// merely that the headers parse). Never executed.
+extern "C" __declspec(dllexport) std::uint32_t commonlib_link_probe()
+{
+	return static_cast<std::uint32_t>(SKSE::GetPluginHandle());
+}

--- a/tests/prebuilt-consumer/xmake.lua
+++ b/tests/prebuilt-consumer/xmake.lua
@@ -10,7 +10,12 @@ add_rules("mode.debug", "mode.releasedbg")
 set_defaultmode("releasedbg")
 
 -- Match the options the prebuilt library was built with (see
--- lib/commonlibsse-ng/PREBUILT.md). These must be set before includes().
+-- lib/commonlibsse-ng/PREBUILT.md). These must be set before includes(). Set the
+-- runtime flags explicitly rather than relying on defaults so the test always
+-- matches the published "all" contract even if the upstream defaults drift.
+set_config("skyrim_se", true)
+set_config("skyrim_ae", true)
+set_config("skyrim_vr", true)
 set_config("rex_ini", true)
 set_config("skse_xbyak", true)
 

--- a/tests/prebuilt-consumer/xmake.lua
+++ b/tests/prebuilt-consumer/xmake.lua
@@ -1,0 +1,27 @@
+-- Minimal SKSE plugin that consumes CommonLib from a PREBUILT bundle (staged by CI
+-- into lib/commonlibsse-ng) rather than from source. Building this proves the bundle
+-- is consumable: the commonlibsse-ng.plugin rule + transitive deps resolve and the
+-- plugin links against the prebuilt static library with no CommonLib recompile.
+set_xmakever("3.0.0")
+set_project("prebuilt-consumer")
+set_arch("x64")
+set_languages("c++23")
+add_rules("mode.debug", "mode.releasedbg")
+set_defaultmode("releasedbg")
+
+-- Match the options the prebuilt library was built with (see
+-- lib/commonlibsse-ng/PREBUILT.md). These must be set before includes().
+set_config("rex_ini", true)
+set_config("skse_xbyak", true)
+
+includes("lib/commonlibsse-ng")
+
+target("prebuilt-consumer", function()
+    add_deps("commonlibsse-ng")
+    add_rules("commonlibsse-ng.plugin", {
+        name = "prebuilt-consumer",
+        author = "ci",
+        description = "CommonLib prebuilt-bundle consumption self-test",
+    })
+    add_files("src/main.cpp")
+end)

--- a/xmake.lua
+++ b/xmake.lua
@@ -101,6 +101,28 @@ target("commonlibsse-ng", function()
         add_linkdirs("lib", { public = true })
         add_links("commonlibsse-ng", { public = true })
         add_syslinks("advapi32", "bcrypt", "d3d11", "d3dcompiler", "dbghelp", "dxgi", "ole32", "shell32", "user32", "version", { public = true })
+
+        -- The shipped library baked a fixed option set. Linking it while the consumer
+        -- compiles CommonLib headers with different option-derived defines (REX_OPTION_*,
+        -- ENABLE_SKYRIM_*, SKSE_SUPPORT_XBYAK) is a silent ABI mismatch, so refuse unless
+        -- the consumer's options match what the lib was built with (see PREBUILT.md).
+        -- Checked in on_config so consumer options are fully resolved (not the defaults
+        -- seen during initial option discovery).
+        on_config(function(target)
+            local baked = {
+                skyrim_se = true, skyrim_ae = true, skyrim_vr = true,
+                rex_ini = true, skse_xbyak = true,
+                rex_json = false, rex_toml = false,
+            }
+            for opt, want in pairs(baked) do
+                local got = has_config(opt) and true or false
+                if got ~= want then
+                    raise("prebuilt commonlibsse-ng.lib was built with %s=%s, but the consumer has %s=%s. "
+                        .. "Match the baked config (skyrim all + rex_ini + skse_xbyak; see PREBUILT.md) "
+                        .. "or build from source.", opt, want and "y" or "n", opt, got and "y" or "n")
+                end
+            end
+        end)
     end
 
     -- set build by default

--- a/xmake.lua
+++ b/xmake.lua
@@ -86,8 +86,22 @@ if has_config("skyrim_vr") then
 end
 
 target("commonlibsse-ng", function()
+    -- Prebuilt mode: when a `lib/commonlibsse-ng.lib` is shipped alongside this
+    -- xmake.lua (i.e. consumed from a prebuilt release bundle rather than source),
+    -- link that static library instead of compiling src/. Consumers keep using
+    -- `includes(...)` + the `commonlibsse-ng.plugin` rule unchanged — the only
+    -- difference is zero recompile. They MUST set the same options the lib was built
+    -- with (see PREBUILT.md: skyrim all + rex_ini + skse_xbyak).
+    local prebuilt = os.isfile(path.join(os.scriptdir(), "lib", "commonlibsse-ng.lib"))
+
     -- set target kind
-    set_kind("static")
+    set_kind(prebuilt and "phony" or "static")
+
+    if prebuilt then
+        add_linkdirs("lib", { public = true })
+        add_links("commonlibsse-ng", { public = true })
+        add_syslinks("advapi32", "bcrypt", "d3d11", "d3dcompiler", "dbghelp", "dxgi", "ole32", "shell32", "user32", "version", { public = true })
+    end
 
     -- set build by default
     set_default(os.scriptdir() == os.projectdir())
@@ -120,11 +134,15 @@ target("commonlibsse-ng", function()
     -- add options
     add_options("rex_ini", "rex_json", "rex_toml", "skyrim_se", "skyrim_ae", "skyrim_vr", "skse_xbyak", "tests", { public = true })
 
-    -- add system links
-    add_syslinks("advapi32", "bcrypt", "d3d11", "d3dcompiler", "dbghelp", "dxgi", "ole32", "shell32", "user32", "version")
+    -- compile-only configuration (skipped in prebuilt mode, where the shipped
+    -- library already contains these and dependents link it directly)
+    if not prebuilt then
+        -- add system links
+        add_syslinks("advapi32", "bcrypt", "d3d11", "d3dcompiler", "dbghelp", "dxgi", "ole32", "shell32", "user32", "version")
 
-    -- add source files
-    add_files("src/**.cpp")
+        -- add source files
+        add_files("src/**.cpp")
+    end
 
     -- add header files
     add_includedirs("include", { public = true })
@@ -135,8 +153,10 @@ target("commonlibsse-ng", function()
         "include/(SKSE/**.h)"
     )
 
-    -- set precompiled header
-    set_pcxxheader("include/SKSE/Impl/PCH.h")
+    -- set precompiled header (only meaningful when compiling sources)
+    if not prebuilt then
+        set_pcxxheader("include/SKSE/Impl/PCH.h")
+    end
 
     -- add flags
     add_cxxflags("/EHsc", "/permissive-", "/Zc:preprocessor", { public = true })


### PR DESCRIPTION
**Draft — needs CI validation** (heavy Windows/xmake build; I can't run it locally). Opening so the release CI exercises it.

## Why

CommonLib is the bulk of a downstream plugin's build time (~16 min in devbench). Your xmake consumers (`devbench`, `Intellightent`, `Seamless-Saving-SKSE`, `imgui-vr-helper`) all build CommonLib **in-tree from source** every CI run. This publishes a **prebuilt static-library bundle per release** so they can link it instead — zero CommonLib recompile.

(Canvassed ~200 sibling repos: the xmake consumers are 100% consistent — `includes("lib/commonlibsse-ng")`, C++23, `releasedbg`, runtime **all**, `rex_ini` near-universal, `skse_xbyak` on devbench. CMake/vcpkg consumers (~31 repos) use the `commonlibsse-ng` vcpkg port and are intentionally **out of scope** here.)

## What

- **`xmake.lua`** — the `commonlibsse-ng` target auto-detects a shipped `lib/commonlibsse-ng.lib` and links it (`phony` mode) instead of compiling `src/`. **Source builds are byte-identical**; only prebuilt consumption is new.
- **`release.yml`** — after a release publishes, a `build-prebuilt` job builds the canonical **all** config (SE+AE+VR + `rex_ini` + `skse_xbyak`, `releasedbg`, MSVC), assembles a **drop-in bundle** (`xmake.lua` + `include/` + `res/` + VR headers + the `.lib`), and attaches it to the GitHub release. A `test-prebuilt` job then **builds a real SKSE plugin against the bundle** to prove it links.
- **`tests/prebuilt-consumer/`** — that self-test plugin (link probe forces resolving an out-of-line symbol from the prebuilt).
- **`PREBUILT.md`** — bundle layout, baked config, and the ABI-match rules.

## Consumer change (follow-up, once green)

Replace the `lib/commonlibsse-ng` **source submodule** with the **extracted bundle** at the same path. Existing `set_config(rex_ini/skse_xbyak)` + `includes()` + `commonlibsse-ng.plugin` rule work unchanged.

## Heads-up / open questions for review

- **Starts creating GitHub Releases.** `release.yml` currently only tags + commits the changelog (no `@semantic-release/github`). To host the asset, `build-prebuilt` now creates a Release on the tag. Intended — but flagging since it's new behavior for this repo.
- **Merging this is a `feat`** → cuts a minor CommonLib release, which then produces the first bundle (self-bootstrapping).
- **No PDB shipped** for the static lib yet (CommonLib frames won't symbolicate in consumer crashlogs). Easy follow-up (`/Z7` embed or ship the lib PDB) if you want it.
- **Things CI will shake out:** xmake `phony`-target public link/syslink propagation to dependents; whether the self-test's link probe symbol (`SKSE::GetPluginHandle`) resolves as expected; bundle path/rename in the test job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic build, test, and publish of prebuilt library bundles on releases, plus manual/reusable workflow invocation.

* **Build**
  * Build system now consumes a shipped prebuilt bundle when present and enforces matching configuration for consumers.

* **Documentation**
  * Added guide detailing how to download and use the prebuilt bundles.

* **Tests**
  * Added a small consumer test project that validates linking against the prebuilt bundle.

* **Chores**
  * CI ignore rules updated to exclude generated prebuilt artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->