### PR TITLE
feat(build): auto-fetch prebuilt CommonLib on clean release tags (cmake)

### DIFF
--- a/.github/workflows/prebuilt.yml
+++ b/.github/workflows/prebuilt.yml
@@ -20,6 +20,7 @@ on:
     paths:
       - xmake.lua
       - CMakeLists.txt
+      - CMakePresets.json
       - cmake/**
       - include/**
       - src/**
@@ -53,6 +54,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false # don't leave the repo token in the workspace; we run PR code
           submodules: recursive # extern/openvr headers ship in the bundle
 
       - name: Set up xmake
@@ -140,6 +142,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false # don't leave the repo token in the workspace; we run PR code
           submodules: recursive # extern/openvr (headers + win64/openvr_api.lib) ship in the bundle
 
       - name: Extract vcpkg baseline from vcpkg.json

--- a/.github/workflows/prebuilt.yml
+++ b/.github/workflows/prebuilt.yml
@@ -2,13 +2,16 @@
 # consumable. Runs on every PR to ng (validation only) and is called by release.yml on
 # a published release (with attach_tag set) to attach the bundle to the GitHub release.
 #
-# xmake consumers only: the bundle ships the same xmake.lua (auto-detects the prebuilt),
-# headers, plugin-rule templates and VR headers, so a consumer's includes()/the
-# commonlibsse-ng.plugin rule work unchanged with zero CommonLib recompile. Baked
-# config: skyrim all (SE+AE+VR) + rex_ini + skse_xbyak, releasedbg, MSVC.
+# Two bundles, one per build system, both baked with the same config (skyrim all
+# (SE+AE+VR) + rex_ini + skse_xbyak, MSVC) so the clean-tag auto-fetch in each build
+# file can download + link them with zero CommonLib recompile — see PREBUILT.md.
 #
-# CMake consumers are intentionally not served here — see PREBUILT.md (use vcpkg
-# binary caching for the vcpkg-port consumers).
+# xmake bundle: ships the same xmake.lua (auto-detects the prebuilt), headers, plugin-rule
+#   templates and VR headers, so a consumer's includes()/the commonlibsse-ng.plugin rule
+#   work unchanged (releasedbg).
+# cmake bundle: ships lib/ (CommonLibSSE.lib + openvr_api.lib), include/ and VR headers;
+#   an add_subdirectory consumer's cmake/Prebuilt.cmake resolves it into an IMPORTED
+#   target (Release). Each job self-tests by building a plugin against its own bundle.
 name: Prebuilt bundles
 
 on:
@@ -122,5 +125,113 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             gh release create "$env:ATTACH_TAG" --title "CommonLibSSE-NG $env:ATTACH_TAG" `
               --notes "Prebuilt CommonLib bundle for downstream xmake consumers (config: skyrim all + rex_ini + skse_xbyak). See PREBUILT.md."
+          }
+          gh release upload "$env:ATTACH_TAG" "${{ steps.bundle.outputs.bundle }}" "${{ steps.bundle.outputs.sha }}" --clobber
+
+  cmake:
+    name: cmake bundle + self-test
+    runs-on: windows-latest
+    permissions:
+      contents: write # only used when attach_tag is set
+    env:
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+          submodules: recursive # extern/openvr (headers + win64/openvr_api.lib) ship in the bundle
+
+      - name: Extract vcpkg baseline from vcpkg.json
+        id: baseline
+        shell: pwsh
+        run: |
+          $baseline = (Get-Content vcpkg.json | ConvertFrom-Json).'builtin-baseline'
+          "baseline=$baseline" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Setup MSVC Environment
+        uses: TheMrMilchmann/setup-msvc-dev@v4.0.0
+        with:
+          arch: x64
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitCommitId: ${{ steps.baseline.outputs.baseline }}
+
+      # x-gha reads the Actions cache endpoint from these two variables, which GitHub only
+      # exposes to the github-script runtime — re-export them so vcpkg sees them.
+      - name: Enable vcpkg GitHub Actions binary cache
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Build CommonLibSSE (all + rex_ini + skse_xbyak, release)
+        uses: lukka/run-cmake@v10
+        with:
+          cmakeListsTxtPath: ${{ github.workspace }}/CMakeLists.txt
+          configurePreset: build-release-msvc-vcpkg-all
+          configurePresetAdditionalArgs: "['-DREX_OPTION_INI=ON', '-DSKSE_SUPPORT_XBYAK=ON', '-DBUILD_TESTS=OFF']"
+          buildPreset: release-msvc-vcpkg-all
+
+      - name: Assemble bundle
+        id: bundle
+        shell: pwsh
+        env:
+          ATTACH_TAG: ${{ inputs.attach_tag }} # via env, not template interpolation (injection-safe)
+        run: |
+          $tag = $env:ATTACH_TAG
+          $stage = if ($tag) { "commonlibsse-ng-prebuilt-$tag-all-msvc-cmake" } else { "commonlibsse-ng-prebuilt-all-msvc-cmake" }
+          New-Item -ItemType Directory -Force -Path "$stage/lib","$stage/extern/openvr" | Out-Null
+          $lib = "build/release-msvc-vcpkg-all/CommonLibSSE.lib"
+          if (-not (Test-Path $lib)) { Write-Error "lib not found at $lib"; exit 1 }
+          Copy-Item $lib "$stage/lib/"
+          # openvr_api.lib is linked PUBLIC by the IMPORTED target, so it ships in the bundle.
+          Copy-Item extern/openvr/lib/win64/openvr_api.lib "$stage/lib/"
+          Copy-Item PREBUILT.md "$stage/"
+          Copy-Item -Recurse include "$stage/include"
+          Copy-Item -Recurse extern/openvr/headers "$stage/extern/openvr/headers"
+          # .zip so the consumer's file(ARCHIVE_EXTRACT) (libarchive) unpacks it reliably.
+          Compress-Archive -Path "$stage" -DestinationPath "$stage.zip" -Force
+          ((Get-FileHash "$stage.zip" -Algorithm SHA256).Hash.ToLower() + "  $stage.zip") | Out-File "$stage.zip.sha256" -Encoding ascii -NoNewline
+          "stage=$stage" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "bundle=$stage.zip" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "sha=$stage.zip.sha256" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Self-test — build a plugin against the prebuilt
+        shell: pwsh
+        env:
+          PREBUILT_DIR: ${{ github.workspace }}/${{ steps.bundle.outputs.stage }}
+        run: |
+          cmake -S tests/prebuilt-consumer-cmake -B build/cmake-selftest -G Ninja `
+            --toolchain "$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
+            -DVCPKG_TARGET_TRIPLET=x64-windows-static-md `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL `
+            -DCOMMONLIB_PREBUILT_DIR="$env:PREBUILT_DIR"
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+          cmake --build build/cmake-selftest
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: prebuilt-bundle-cmake
+          path: ${{ steps.bundle.outputs.bundle }}
+          if-no-files-found: error
+
+      - name: Attach bundle to release
+        if: inputs.attach_tag != ''
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ATTACH_TAG: ${{ inputs.attach_tag }} # via env, not template interpolation (injection-safe)
+        run: |
+          gh release view "$env:ATTACH_TAG" *> $null
+          if ($LASTEXITCODE -ne 0) {
+            gh release create "$env:ATTACH_TAG" --title "CommonLibSSE-NG $env:ATTACH_TAG" `
+              --notes "Prebuilt CommonLib bundles for downstream consumers (config: skyrim all + rex_ini + skse_xbyak). See PREBUILT.md."
           }
           gh release upload "$env:ATTACH_TAG" "${{ steps.bundle.outputs.bundle }}" "${{ steps.bundle.outputs.sha }}" --clobber

--- a/.github/workflows/test-consumer.yml
+++ b/.github/workflows/test-consumer.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgJsonGlob: '**/vcpkg.json'
+          # Only the root manifest — tests/ ship their own vcpkg.json (self-test consumers),
+          # and a '**/' glob would match multiple and fail baseline detection.
+          vcpkgJsonGlob: 'vcpkg.json'
       
       - name: Install vcpkg dependencies
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,9 +46,14 @@ commonlib_resolve_prebuilt(COMMONLIB_PREBUILT_RESOLVED)
 if(COMMONLIB_PREBUILT_RESOLVED)
 	message(STATUS "CommonLibSSE: linking prebuilt binary from ${COMMONLIB_PREBUILT_RESOLVED}")
 	add_library("${PROJECT_NAME}" STATIC IMPORTED GLOBAL)
+	# The bundle is Release; the resolver only resolves for non-Debug single-config builds.
+	# Pin the lib to the Release config and map the other release-like configs onto it.
 	set_target_properties(
 		"${PROJECT_NAME}" PROPERTIES
-		IMPORTED_LOCATION "${COMMONLIB_PREBUILT_RESOLVED}/lib/CommonLibSSE.lib"
+		IMPORTED_CONFIGURATIONS RELEASE
+		IMPORTED_LOCATION_RELEASE "${COMMONLIB_PREBUILT_RESOLVED}/lib/CommonLibSSE.lib"
+		MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release
+		MAP_IMPORTED_CONFIG_MINSIZEREL Release
 	)
 	add_library("${PROJECT_NAME}::${PROJECT_NAME}" ALIAS "${PROJECT_NAME}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,67 @@ find_package(spdlog CONFIG REQUIRED)
 find_path(RAPIDCSV_INCLUDE_DIRS "rapidcsv.h")
 find_package(directxtk CONFIG REQUIRED)
 
+# Prefer a published prebuilt binary over a ~16-min source compile (clean release tag,
+# in CI or with COMMONLIB_PREBUILT / COMMONLIB_PREBUILT_DIR) — see cmake/Prebuilt.cmake.
+# Runs inside the consumer's add_subdirectory build, so the IMPORTED target points at the
+# bundle's local paths — no install/export and none of the relocatability that find_package
+# would require. Falls through to the source build on anything unsafe.
+include(cmake/Prebuilt.cmake)
+commonlib_resolve_prebuilt(COMMONLIB_PREBUILT_RESOLVED)
+if(COMMONLIB_PREBUILT_RESOLVED)
+	message(STATUS "CommonLibSSE: linking prebuilt binary from ${COMMONLIB_PREBUILT_RESOLVED}")
+	add_library("${PROJECT_NAME}" STATIC IMPORTED GLOBAL)
+	set_target_properties(
+		"${PROJECT_NAME}" PROPERTIES
+		IMPORTED_LOCATION "${COMMONLIB_PREBUILT_RESOLVED}/lib/CommonLibSSE.lib"
+	)
+	add_library("${PROJECT_NAME}::${PROJECT_NAME}" ALIAS "${PROJECT_NAME}")
+
+	target_compile_features("${PROJECT_NAME}" INTERFACE cxx_std_23)
+	target_include_directories(
+		"${PROJECT_NAME}" INTERFACE
+		"${COMMONLIB_PREBUILT_RESOLVED}/include"
+		"${COMMONLIB_PREBUILT_RESOLVED}/extern/openvr/headers"
+	)
+	# Baked config: skyrim all (SE+AE+VR) + rex_ini + skse_xbyak; rex_json/toml off.
+	target_compile_definitions(
+		"${PROJECT_NAME}" INTERFACE
+		WINVER=0x0601
+		_WIN32_WINNT=0x0601
+		REX_OPTION_INI=1
+		SKSE_SUPPORT_XBYAK=1
+		ENABLE_SKYRIM_SE=1
+		ENABLE_SKYRIM_AE=1
+		ENABLE_SKYRIM_VR=1
+		HAS_SKYRIM_MULTI_TARGETING=1
+	)
+	if(MSVC)
+		target_compile_options(
+			"${PROJECT_NAME}" INTERFACE
+			/Zc:preprocessor
+			/wd4005 /wd4061 /wd4068 /wd4200 /wd4201 /wd4265 /wd4266 /wd4371
+			/wd4514 /wd4582 /wd4583 /wd4623 /wd4625 /wd4626 /wd4702 /wd4710
+			/wd4711 /wd4820 /wd4996 /wd5026 /wd5027 /wd5045 /wd5053 /wd5204 /wd5220
+		)
+	endif()
+	target_link_libraries(
+		"${PROJECT_NAME}" INTERFACE
+		spdlog::spdlog
+		Microsoft::DirectXTK
+		Advapi32.lib
+		bcrypt.lib
+		D3D11.lib
+		d3dcompiler.lib
+		Dbghelp.lib
+		DXGI.lib
+		Ole32.lib
+		Version.lib
+		"${COMMONLIB_PREBUILT_RESOLVED}/lib/openvr_api.lib"
+	)
+	include(cmake/CommonLibSSE.cmake)  # add_commonlibsse_plugin() helper for consumers
+	return()
+endif()
+
 include(cmake/sourcelist.cmake)
 include(cmake/testlist.cmake)
 

--- a/PREBUILT.md
+++ b/PREBUILT.md
@@ -125,11 +125,15 @@ extract it, and expose the IMPORTED target instead of compiling `src/`. A plugin
 submodule sits on `vX.Y.Z` gets the prebuilt for free on CI, unchanged.
 
 It falls back to a normal **source build** whenever the prebuilt can't be used safely: the
-top-level project is CommonLib itself (you only auto-fetch when *consumed*), not on an
-exact tag, a dirty tree, options that don't match the baked config, or a missing/unverified
-asset. The download is cached under `<build>/.prebuilt/<tag>` and attempted at most once
-per tag. Local dev builds stay source-by-default (`-DCOMMONLIB_PREBUILT=ON` to opt in), or
-point `-DCOMMONLIB_PREBUILT_DIR=<extracted bundle>` at a bundle to skip the download.
+top-level project is CommonLib itself (you only auto-fetch when *consumed*), a Debug or
+multi-config build (the bundle is Release `/MD`; a Debug `/MDd` link would be an ABI
+mismatch), not on an exact tag, a dirty tree, options that don't match the baked config, or
+a missing/unverified asset. The download is cached under
+`${CMAKE_CURRENT_BINARY_DIR}/.prebuilt/<tag>` — with the advertised
+`add_subdirectory(… commonlib)` layout that is the CommonLib sub-build dir, e.g.
+`<build>/commonlib/.prebuilt/<tag>` — and attempted at most once per tag. Local dev builds
+stay source-by-default (`-DCOMMONLIB_PREBUILT=ON` to opt in), or point
+`-DCOMMONLIB_PREBUILT_DIR=<extracted bundle>` at a bundle to skip the download.
 
 Because the headers are baked with `skse_xbyak` and link `spdlog`/`DirectXTK` PUBLIC, the
 consumer must provide those header deps from **its own `vcpkg.json`** (`spdlog`, `fmt`,

--- a/PREBUILT.md
+++ b/PREBUILT.md
@@ -1,11 +1,15 @@
 # Prebuilt CommonLib bundles
 
-Each release attaches a prebuilt **static-library bundle** so downstream **xmake**
-projects can consume CommonLib without recompiling it (CommonLib is the bulk of a
-plugin's build time). The bundle is produced by `.github/workflows/release.yml` and
-validated by the `test-prebuilt` job before publish.
+Each release attaches prebuilt **static-library bundles** so downstream projects can
+consume CommonLib without recompiling it (CommonLib is the bulk of a plugin's build
+time). There is one bundle per build system — **xmake** and **CMake** — both baked with
+the same config below. They are produced and self-tested by
+`.github/workflows/prebuilt.yml` and attached to the release.
 
-## What's in the bundle
+Both build systems **auto-fetch** their bundle on a clean release tag (see the auto-fetch
+sections), so in the common case you change nothing in your repo.
+
+## What's in the xmake bundle
 
 `commonlibsse-ng-prebuilt-<tag>-all-msvc.7z` is a drop-in replacement for the
 `lib/commonlibsse-ng` source tree:
@@ -88,15 +92,54 @@ against it is **seconds** (e.g. ~6 s for the self-test plugin) versus a full sou
 build (minutes cold). The large on-disk size is the trade for keeping CommonLib frames
 symbolicatable in crash logs; the extra link cost is negligible.
 
-## CMake consumers
+## CMake bundle
 
-This bundle is **xmake-only**. CMake consumers are better served by their own
-toolchain:
+`commonlibsse-ng-prebuilt-<tag>-all-msvc-cmake.zip` serves **`add_subdirectory`**
+consumers (the common extern-path setup). It carries just the build outputs the consumer
+links against:
 
-- **vcpkg-port consumers** (`"commonlibsse-ng"` in `vcpkg.json`): use **vcpkg binary
-  caching** (a shared NuGet/GHA/S3 backend) so the port builds once and is reused
-  across CI — idiomatic, no custom artifact.
-- **`add_subdirectory`/extern-path consumers**: keep building from the source
-  submodule, or open an issue if a `find_package(CommonLibSSE CONFIG)` prebuilt is
-  wanted (it needs `cmake/config.cmake.in` to `find_dependency` the full transitive
-  set, not just `spdlog`).
+```
+lib/CommonLibSSE.lib     # the prebuilt static library (Release)
+lib/openvr_api.lib       # linked PUBLIC by the target (the "all" config enables VR)
+include/                 # public headers (RE/ REL/ REX/ SKSE/)
+extern/openvr/headers/   # VR headers
+PREBUILT.md
+```
+
+It is **not** a `find_package` install tree: instead the consumer's
+`add_subdirectory(<commonlib>)` runs `cmake/Prebuilt.cmake`, which resolves the bundle
+and defines `CommonLibSSE` as an **IMPORTED** target pointing at these local paths. This
+sidesteps `find_package`/`install(EXPORT)` relocatability entirely — the paths are the
+just-extracted bundle's own.
+
+The baked configuration is the same as the xmake bundle, with the CMake spelling:
+`ENABLE_SKYRIM_SE/AE/VR=ON`, `REX_OPTION_INI=ON`, `SKSE_SUPPORT_XBYAK=ON`
+(`REX_OPTION_JSON/TOML=OFF`), MSVC, **`Release`** (`/MD`, `NDEBUG`), C++23.
+
+### Automatic fetch on a clean release tag (CMake)
+
+When CommonLib is consumed via `add_subdirectory` from a source submodule pinned to a
+clean release **tag**, `cmake/Prebuilt.cmake` will — in CI (`GITHUB_ACTIONS`), or anywhere
+with `-DCOMMONLIB_PREBUILT=ON` — download that tag's `…-cmake.zip`, verify its `.sha256`,
+extract it, and expose the IMPORTED target instead of compiling `src/`. A plugin whose
+submodule sits on `vX.Y.Z` gets the prebuilt for free on CI, unchanged.
+
+It falls back to a normal **source build** whenever the prebuilt can't be used safely: the
+top-level project is CommonLib itself (you only auto-fetch when *consumed*), not on an
+exact tag, a dirty tree, options that don't match the baked config, or a missing/unverified
+asset. The download is cached under `<build>/.prebuilt/<tag>` and attempted at most once
+per tag. Local dev builds stay source-by-default (`-DCOMMONLIB_PREBUILT=ON` to opt in), or
+point `-DCOMMONLIB_PREBUILT_DIR=<extracted bundle>` at a bundle to skip the download.
+
+Because the headers are baked with `skse_xbyak` and link `spdlog`/`DirectXTK` PUBLIC, the
+consumer must provide those header deps from **its own `vcpkg.json`** (`spdlog`, `fmt`,
+`directxtk`, `directxmath`, `xbyak`) — exactly as a source build already requires. As with
+any CommonLibSSE-NG plugin, the consumer also supplies a **PCH** that includes
+`<SKSE/Impl/PCH.h>` and `using namespace std::literals;` (the headers are PCH-dependent).
+See `tests/prebuilt-consumer-cmake/` for a minimal working consumer.
+
+### vcpkg-port consumers
+
+Consumers that pull `"commonlibsse-ng"` through `vcpkg.json` (rather than
+`add_subdirectory`) are served by **vcpkg binary caching** (a shared GHA/NuGet/S3 backend)
+so the port builds once and is restored across CI — idiomatic, no custom artifact.

--- a/cmake/Prebuilt.cmake
+++ b/cmake/Prebuilt.cmake
@@ -9,6 +9,20 @@
 # Anything else (no exact tag, dirty tree, options that don't match the baked config,
 # missing/unverified asset, offline) leaves the output empty so the caller builds from
 # source. The download is cached under the build tree and attempted at most once per tag.
+# A bundle is only usable if all four pieces the IMPORTED target consumes are present
+# (include/, the lib, openvr lib + headers); otherwise a partial extraction or stale cache
+# would resolve and fail deep in configure/build instead of falling back to source.
+function(_commonlib_prebuilt_complete dir out_var)
+    if(IS_DIRECTORY "${dir}/include"
+       AND EXISTS "${dir}/lib/CommonLibSSE.lib"
+       AND EXISTS "${dir}/lib/openvr_api.lib"
+       AND IS_DIRECTORY "${dir}/extern/openvr/headers")
+        set(${out_var} TRUE PARENT_SCOPE)
+    else()
+        set(${out_var} FALSE PARENT_SCOPE)
+    endif()
+endfunction()
+
 function(commonlib_resolve_prebuilt out_dir)
     set(${out_dir} "" PARENT_SCOPE)
 
@@ -27,12 +41,12 @@ function(commonlib_resolve_prebuilt out_dir)
     endif()
 
     # explicit override: a consumer (or this repo's self-test) points at an extracted bundle
-    if(COMMONLIB_PREBUILT_DIR
-       AND EXISTS "${COMMONLIB_PREBUILT_DIR}/lib/CommonLibSSE.lib"
-       AND EXISTS "${COMMONLIB_PREBUILT_DIR}/lib/openvr_api.lib"
-       AND IS_DIRECTORY "${COMMONLIB_PREBUILT_DIR}/extern/openvr/headers")
-        set(${out_dir} "${COMMONLIB_PREBUILT_DIR}" PARENT_SCOPE)
-        return()
+    if(COMMONLIB_PREBUILT_DIR)
+        _commonlib_prebuilt_complete("${COMMONLIB_PREBUILT_DIR}" _ok)
+        if(_ok)
+            set(${out_dir} "${COMMONLIB_PREBUILT_DIR}" PARENT_SCOPE)
+            return()
+        endif()
     endif()
 
     if(NOT (DEFINED ENV{GITHUB_ACTIONS} OR COMMONLIB_PREBUILT))
@@ -60,7 +74,8 @@ function(commonlib_resolve_prebuilt out_dir)
     endif()
 
     set(_cache "${CMAKE_CURRENT_BINARY_DIR}/.prebuilt/${_tag}")
-    if(EXISTS "${_cache}/lib/CommonLibSSE.lib")
+    _commonlib_prebuilt_complete("${_cache}" _ok)
+    if(_ok)
         set(${out_dir} "${_cache}" PARENT_SCOPE)
         return()
     endif()
@@ -97,5 +112,11 @@ function(commonlib_resolve_prebuilt out_dir)
     get_filename_component(_root "${_found}" DIRECTORY)        # .../lib
     get_filename_component(_root "${_root}" DIRECTORY)         # bundle root
     file(RENAME "${_root}" "${_cache}")
+    _commonlib_prebuilt_complete("${_cache}" _ok)
+    if(NOT _ok)
+        file(MAKE_DIRECTORY "${_cache}")
+        file(TOUCH "${_cache}/.failed")
+        return()
+    endif()
     set(${out_dir} "${_cache}" PARENT_SCOPE)
 endfunction()

--- a/cmake/Prebuilt.cmake
+++ b/cmake/Prebuilt.cmake
@@ -1,0 +1,84 @@
+# Resolve a directory containing a prebuilt CommonLibSSE.lib (+ include/, openvr) so
+# add_subdirectory consumers can link the published binary instead of compiling ~16 min
+# of source. Mirrors the xmake clean-tag auto-fetch.
+#
+# A directory is resolved from, in order:
+#   1. COMMONLIB_PREBUILT_DIR, if it points at an already-extracted bundle, else
+#   2. on a CLEAN release tag, in CI (GITHUB_ACTIONS) or with COMMONLIB_PREBUILT set, the
+#      matching cmake bundle downloaded from the GitHub release and SHA256-verified.
+# Anything else (no exact tag, dirty tree, options that don't match the baked config,
+# missing/unverified asset, offline) leaves the output empty so the caller builds from
+# source. The download is cached under the build tree and attempted at most once per tag.
+function(commonlib_resolve_prebuilt out_dir)
+    set(${out_dir} "" PARENT_SCOPE)
+
+    # explicit override: a consumer (or this repo's self-test) points at an extracted bundle
+    if(COMMONLIB_PREBUILT_DIR AND EXISTS "${COMMONLIB_PREBUILT_DIR}/lib/CommonLibSSE.lib")
+        set(${out_dir} "${COMMONLIB_PREBUILT_DIR}" PARENT_SCOPE)
+        return()
+    endif()
+
+    if(NOT (DEFINED ENV{GITHUB_ACTIONS} OR COMMONLIB_PREBUILT))
+        return()
+    endif()
+
+    # options must match the config the bundle was baked with (skyrim all + rex_ini +
+    # skse_xbyak; rex_json/toml off) — otherwise the headers/lib would mismatch ABI.
+    if(NOT (ENABLE_SKYRIM_SE AND ENABLE_SKYRIM_AE AND ENABLE_SKYRIM_VR
+            AND REX_OPTION_INI AND SKSE_SUPPORT_XBYAK)
+       OR REX_OPTION_JSON OR REX_OPTION_TOML)
+        return()
+    endif()
+
+    find_package(Git QUIET)
+    if(NOT Git_FOUND)
+        return()
+    endif()
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" -C "${CMAKE_CURRENT_SOURCE_DIR}" describe --tags --exact-match --dirty
+        OUTPUT_VARIABLE _tag OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE _rc ERROR_QUIET)
+    if(NOT _rc EQUAL 0 OR _tag MATCHES "dirty" OR NOT _tag MATCHES "^v[0-9]")
+        return()
+    endif()
+
+    set(_cache "${CMAKE_CURRENT_BINARY_DIR}/.prebuilt/${_tag}")
+    if(EXISTS "${_cache}/lib/CommonLibSSE.lib")
+        set(${out_dir} "${_cache}" PARENT_SCOPE)
+        return()
+    endif()
+    if(EXISTS "${_cache}/.failed")
+        return()
+    endif()
+
+    set(_base "https://github.com/alandtse/CommonLibVR/releases/download/${_tag}")
+    set(_asset "commonlibsse-ng-prebuilt-${_tag}-all-msvc-cmake.zip")
+    set(_zip "${_cache}.zip")
+    file(DOWNLOAD "${_base}/${_asset}.sha256" "${_cache}.sha256" STATUS _s1)
+    list(GET _s1 0 _s1code)
+    if(NOT _s1code EQUAL 0)
+        file(MAKE_DIRECTORY "${_cache}")
+        file(TOUCH "${_cache}/.failed")
+        return()
+    endif()
+    file(READ "${_cache}.sha256" _shaline)
+    string(REGEX MATCH "[0-9a-fA-F]+" _want "${_shaline}")
+    file(DOWNLOAD "${_base}/${_asset}" "${_zip}" EXPECTED_HASH "SHA256=${_want}" STATUS _s2)
+    list(GET _s2 0 _s2code)
+    if(NOT _s2code EQUAL 0)
+        file(MAKE_DIRECTORY "${_cache}")
+        file(TOUCH "${_cache}/.failed")
+        return()
+    endif()
+    file(ARCHIVE_EXTRACT INPUT "${_zip}" DESTINATION "${_cache}.x")
+    file(GLOB_RECURSE _found "${_cache}.x/*/lib/CommonLibSSE.lib")
+    if(NOT _found)
+        file(MAKE_DIRECTORY "${_cache}")
+        file(TOUCH "${_cache}/.failed")
+        return()
+    endif()
+    get_filename_component(_root "${_found}" DIRECTORY)        # .../lib
+    get_filename_component(_root "${_root}" DIRECTORY)         # bundle root
+    file(RENAME "${_root}" "${_cache}")
+    set(${out_dir} "${_cache}" PARENT_SCOPE)
+endfunction()

--- a/cmake/Prebuilt.cmake
+++ b/cmake/Prebuilt.cmake
@@ -12,6 +12,13 @@
 function(commonlib_resolve_prebuilt out_dir)
     set(${out_dir} "" PARENT_SCOPE)
 
+    # Auto-fetch only makes sense for add_subdirectory consumers. When CommonLibSSE is the
+    # top-level project (developing or releasing CommonLib itself, including the bundle
+    # producer building at a release tag) always build from source.
+    if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+        return()
+    endif()
+
     # explicit override: a consumer (or this repo's self-test) points at an extracted bundle
     if(COMMONLIB_PREBUILT_DIR AND EXISTS "${COMMONLIB_PREBUILT_DIR}/lib/CommonLibSSE.lib")
         set(${out_dir} "${COMMONLIB_PREBUILT_DIR}" PARENT_SCOPE)

--- a/cmake/Prebuilt.cmake
+++ b/cmake/Prebuilt.cmake
@@ -19,8 +19,18 @@ function(commonlib_resolve_prebuilt out_dir)
         return()
     endif()
 
+    # The bundle is baked Release (/MD, NDEBUG). Linking it from a Debug config (/MDd) is a
+    # CRT/ABI mismatch, and a multi-config generator can't promise the chosen config at
+    # configure time — so only use the prebuilt for a single-config, non-Debug build.
+    if(CMAKE_CONFIGURATION_TYPES OR NOT CMAKE_BUILD_TYPE MATCHES "^(Release|RelWithDebInfo|MinSizeRel)$")
+        return()
+    endif()
+
     # explicit override: a consumer (or this repo's self-test) points at an extracted bundle
-    if(COMMONLIB_PREBUILT_DIR AND EXISTS "${COMMONLIB_PREBUILT_DIR}/lib/CommonLibSSE.lib")
+    if(COMMONLIB_PREBUILT_DIR
+       AND EXISTS "${COMMONLIB_PREBUILT_DIR}/lib/CommonLibSSE.lib"
+       AND EXISTS "${COMMONLIB_PREBUILT_DIR}/lib/openvr_api.lib"
+       AND IS_DIRECTORY "${COMMONLIB_PREBUILT_DIR}/extern/openvr/headers")
         set(${out_dir} "${COMMONLIB_PREBUILT_DIR}" PARENT_SCOPE)
         return()
     endif()

--- a/tests/prebuilt-consumer-cmake/CMakeLists.txt
+++ b/tests/prebuilt-consumer-cmake/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Self-test for the CMake clean-tag auto-fetch: add_subdirectory the CommonLibVR repo
+# with COMMONLIB_PREBUILT_DIR pointing at the just-assembled bundle, so the resolver in
+# cmake/Prebuilt.cmake exposes CommonLibSSE as an IMPORTED target. add_commonlibsse_plugin
+# then compiles a generated plugin TU against the prebuilt headers and links the prebuilt
+# lib — proving the bundle is consumable with zero CommonLib recompile. Driven by
+# prebuilt.yml; locally: configure with -DCOMMONLIB_PREBUILT_DIR=<extracted bundle>.
+cmake_minimum_required(VERSION 3.19)
+project(prebuilt_consumer_cmake LANGUAGES CXX)
+
+# The repo root is two levels up; give add_subdirectory an explicit binary dir.
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../.." commonlib)
+
+add_commonlibsse_plugin(prebuilt_consumer_cmake
+	AUTHOR "CommonLibVR"
+	NAME "prebuilt_consumer_cmake"
+	VERSION 1.0.0)
+
+# CommonLibSSE-NG headers are PCH-dependent; consumers force-include a PCH.
+target_precompile_headers(prebuilt_consumer_cmake PRIVATE
+	"${CMAKE_CURRENT_SOURCE_DIR}/pch.h")

--- a/tests/prebuilt-consumer-cmake/pch.h
+++ b/tests/prebuilt-consumer-cmake/pch.h
@@ -1,0 +1,3 @@
+#pragma once
+#include <SKSE/Impl/PCH.h>
+using namespace std::literals;  // CommonLibSSE-NG consumer convention (global sv/s suffixes)

--- a/tests/prebuilt-consumer-cmake/vcpkg.json
+++ b/tests/prebuilt-consumer-cmake/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "name": "prebuilt-consumer-cmake",
+  "version": "0.0.1",
+  "builtin-baseline": "ee12231b20c95013c6638d845d04c91559a1d1ff",
+  "description": "Self-test consumer for the CommonLibSSE CMake prebuilt auto-fetch. The baked bundle (skyrim all + rex_ini + skse_xbyak) pulls these header deps from the consumer's own vcpkg, same as a real consumer.",
+  "supports": "windows & x64",
+  "dependencies": [
+    "spdlog",
+    "fmt",
+    "directxtk",
+    "directxmath",
+    "xbyak"
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -30,6 +30,10 @@
       "version>=": "8.90"
     },
     {
+      "name": "simpleini",
+      "version>=": "4.25"
+    },
+    {
       "name": "spdlog",
       "version>=": "1.16.0"
     },


### PR DESCRIPTION
Completes prebuilt parity with the xmake half (#169): `add_subdirectory` **CMake**
consumers now auto-fetch and link the published prebuilt CommonLib on a clean release
tag, instead of recompiling it (~16 min of build → seconds).

## How it works

- `cmake/Prebuilt.cmake` resolves a prebuilt directory: an explicit
  `-DCOMMONLIB_PREBUILT_DIR=<dir>` override, else — on a clean release tag, in CI
  (`GITHUB_ACTIONS`) or with `-DCOMMONLIB_PREBUILT=ON`, when the options match the baked
  config — it downloads that tag's `…-cmake.zip`, SHA256-verifies it, and extracts it
  (cached under `<build>/.prebuilt/<tag>`, attempted once per tag).
- `CMakeLists.txt`, when a prebuilt is resolved, defines `CommonLibSSE` as an **IMPORTED**
  target pointing at the bundle's **local** paths (lib, headers, openvr) with the baked
  interface (defines, `cxx_std_23`, warning suppressions, `spdlog`/`DirectXTK`/windows
  libs/`openvr_api.lib`), includes the `add_commonlibsse_plugin` helper, and `return()`s
  before the source build. Running inside the consumer's build with local paths sidesteps
  `find_package`/`install(EXPORT)` relocatability entirely.
- Auto-fetch only applies when CommonLib is **consumed** (`add_subdirectory`); as the
  top-level project (dev, or the bundle producer at a release tag) it always builds from
  source, so the producer can't try to fetch the bundle it's producing.

## Producer + self-test

`prebuilt.yml` gains a `cmake` job mirroring the xmake one: build the
`all + rex_ini + skse_xbyak` config via the release preset, assemble
`lib/CommonLibSSE.lib` + `openvr_api.lib` + headers into a `.zip` + `.sha256`, **build a
plugin against the bundle** (`tests/prebuilt-consumer-cmake/`), and attach to the release.

## Validation (local, MSVC + vcpkg)

Built the in-repo self-test consumer against an assembled bundle: the resolver fired
(`linking prebuilt binary from …`), the generated plugin TU compiled against the prebuilt
headers and **linked the 616 MB prebuilt `CommonLibSSE.lib` + `openvr_api.lib`** →
`prebuilt_consumer_cmake.dll`. Confirmed the consumer must supply the header deps
(`spdlog`/`fmt`/`directxtk`/`directxmath`/`xbyak`) and a PCH from its own side — same as a
source build — now documented in `PREBUILT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CMake consumers can use prebuilt CommonLibSSE bundles for faster builds with automatic download, SHA256 verification, caching, and baked-configuration checks; CI also self-tests the CMake bundle.

* **Documentation**
  * PREBUILT.md expanded with CMake bundle guidance, contents, verification, caching, and fallback-to-source behavior.

* **CI**
  * Release workflow now produces both xmake and CMake prebuilt bundles, uploads ZIP+SHA artifacts, and supports optional release-asset attachment; PR filters and secure checkout improved.

* **Tests**
  * Added a CMake self-test consumer and vcpkg manifest to validate prebuilt consumption; added PCH helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->