### PR TITLE
fix(prebuilt): auto-fetch in CI; relax options gate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,23 +63,26 @@ if(COMMONLIB_PREBUILT_RESOLVED)
 		"${COMMONLIB_PREBUILT_RESOLVED}/include"
 		"${COMMONLIB_PREBUILT_RESOLVED}/extern/openvr/headers"
 	)
-	# Baked config: skyrim all (SE+AE+VR) + skse_xbyak (these change public-header layout, so
-	# the resolver requires the consumer to match them); rex_json/toml off.
+	# Skyrim runtime set is layout-critical and required by the resolver, so define it
+	# unconditionally to match the lib.
 	target_compile_definitions(
 		"${PROJECT_NAME}" INTERFACE
 		WINVER=0x0601
 		_WIN32_WINNT=0x0601
-		SKSE_SUPPORT_XBYAK=1
 		ENABLE_SKYRIM_SE=1
 		ENABLE_SKYRIM_AE=1
 		ENABLE_SKYRIM_VR=1
 		HAS_SKYRIM_MULTI_TARGETING=1
 	)
-	# The lib bakes rex_ini, so REX::INI is available to link, but it is a self-contained
-	# additive namespace — only expose it (define REX_OPTION_INI) when the consumer opts in,
-	# so a rex_ini-OFF consumer sees exactly the API it asked for.
+	# rex_ini and skse_xbyak are additive — the lib bakes them (so the symbols are present to
+	# link) but they don't change layout, so only expose each (define it) when the consumer
+	# opts in. That way a consumer sees exactly the API it asked for and doesn't drag in the
+	# xbyak headers it isn't using.
 	if(REX_OPTION_INI)
 		target_compile_definitions("${PROJECT_NAME}" INTERFACE REX_OPTION_INI=1)
+	endif()
+	if(SKSE_SUPPORT_XBYAK)
+		target_compile_definitions("${PROJECT_NAME}" INTERFACE SKSE_SUPPORT_XBYAK=1)
 	endif()
 	if(MSVC)
 		target_compile_options(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,18 +63,24 @@ if(COMMONLIB_PREBUILT_RESOLVED)
 		"${COMMONLIB_PREBUILT_RESOLVED}/include"
 		"${COMMONLIB_PREBUILT_RESOLVED}/extern/openvr/headers"
 	)
-	# Baked config: skyrim all (SE+AE+VR) + rex_ini + skse_xbyak; rex_json/toml off.
+	# Baked config: skyrim all (SE+AE+VR) + skse_xbyak (these change public-header layout, so
+	# the resolver requires the consumer to match them); rex_json/toml off.
 	target_compile_definitions(
 		"${PROJECT_NAME}" INTERFACE
 		WINVER=0x0601
 		_WIN32_WINNT=0x0601
-		REX_OPTION_INI=1
 		SKSE_SUPPORT_XBYAK=1
 		ENABLE_SKYRIM_SE=1
 		ENABLE_SKYRIM_AE=1
 		ENABLE_SKYRIM_VR=1
 		HAS_SKYRIM_MULTI_TARGETING=1
 	)
+	# The lib bakes rex_ini, so REX::INI is available to link, but it is a self-contained
+	# additive namespace — only expose it (define REX_OPTION_INI) when the consumer opts in,
+	# so a rex_ini-OFF consumer sees exactly the API it asked for.
+	if(REX_OPTION_INI)
+		target_compile_definitions("${PROJECT_NAME}" INTERFACE REX_OPTION_INI=1)
+	endif()
 	if(MSVC)
 		target_compile_options(
 			"${PROJECT_NAME}" INTERFACE

--- a/PREBUILT.md
+++ b/PREBUILT.md
@@ -113,12 +113,15 @@ sidesteps `find_package`/`install(EXPORT)` relocatability entirely — the paths
 just-extracted bundle's own.
 
 The bundle is baked the same as the xmake one (skyrim all + `skse_xbyak` + `rex_ini`,
-MSVC, **`Release`** `/MD NDEBUG`, C++23), but the consumer does **not** have to match every
-option. The runtime set (`ENABLE_SKYRIM_SE/AE/VR=ON`) and `SKSE_SUPPORT_XBYAK=ON` change
-public-header layout, so a consumer must enable those. `REX_OPTION_INI` only adds the
-self-contained `REX::INI` namespace, so the baked lib is a **superset**: a consumer with
-`REX_OPTION_INI=OFF` simply doesn't see `REX::INI` and links fine — it is **not** required.
-`REX_OPTION_JSON/TOML` must stay **OFF** (the lib lacks those symbols).
+MSVC, **`Release`** `/MD NDEBUG`, C++23), but the consumer only has to match the part that
+is ABI-critical. The **runtime set** (`ENABLE_SKYRIM_SE/AE/VR=ON`) changes the layout of
+dozens of public headers, so a consumer **must** build for all three. `REX_OPTION_INI` and
+`SKSE_SUPPORT_XBYAK` are **additive** — ini adds a self-contained `REX::INI` namespace, and
+xbyak adds an `#if`'d `ContextHook` block plus one non-virtual `Trampoline` method (no data
+member, so the class layout is identical) — so the baked lib is a **superset**: a consumer
+may leave either off and still link cleanly (it just doesn't see that API, and the IMPORTED
+target only defines the matching option). `REX_OPTION_JSON/TOML` must stay **OFF** (the lib
+lacks those symbols).
 
 ### Automatic fetch on a clean release tag (CMake)
 

--- a/PREBUILT.md
+++ b/PREBUILT.md
@@ -39,9 +39,11 @@ The library is compiled **once**, for the config our xmake consumers use:
 A prebuilt static library bakes its config and toolchain in. To link it safely a
 consumer **must** build with a compatible setup:
 
-- Same options: set `rex_ini = true` and `skse_xbyak = true` **before** `includes()`
-  (the `skyrim_*` runtimes default on). Different options (e.g. `rex_json`, or
-  disabling a runtime) are **not** served by this bundle — build from source for those.
+- Compatible options: keep the `skyrim_*` runtimes **all on** (they default on and are the
+  one layout-critical axis). `rex_ini` and `skse_xbyak` are additive — the lib bakes them, so
+  it is a superset and a consumer may set them either way. `rex_json`/`rex_toml` must stay
+  **off** (the lib lacks those symbols), and disabling a runtime is **not** served — build
+  from source for those.
 - Same mode/ABI: xmake `releasedbg` (release CRT `/MD`, `NDEBUG`). No `debug` bundle
   is published. A true `debug` build must compile from source.
 - Same compiler family (**MSVC**) and a compatible MSVC toolset version. Toolset drift
@@ -78,11 +80,12 @@ plugin whose `lib/commonlibsse-ng` submodule sits on `vX.Y.Z` gets the prebuilt 
 on CI, with zero changes to its repo.
 
 It falls back to a normal **source build** whenever the prebuilt can't be used safely:
-not on an exact tag, a dirty submodule, options that don't match the baked config, a
-missing/unverified asset, or no network. The download is cached under
-`build/.prebuilt/<tag>` and attempted at most once per tag. Local dev builds stay
-source-by-default (set `COMMONLIB_PREBUILT=1` to opt in). The consumer must still set the
-options the lib was baked with (`rex_ini`, `skse_xbyak`; runtimes default on).
+not on an exact tag, a dirty submodule, a missing/unverified asset, or no network. Once
+fetched, an ABI-incompatible config (a disabled runtime, or `rex_json`/`rex_toml` on) is
+refused so it can't silently mislink. The download is cached under `build/.prebuilt/<tag>`
+and attempted at most once per tag. Local dev builds stay source-by-default (set
+`COMMONLIB_PREBUILT=1` to opt in). The consumer only needs the `skyrim_*` runtimes on (the
+default); `rex_ini`/`skse_xbyak` are optional (the lib is a superset).
 
 ## Size & cost
 

--- a/PREBUILT.md
+++ b/PREBUILT.md
@@ -145,12 +145,14 @@ a missing/unverified asset. The download is cached under
 stay source-by-default (`-DCOMMONLIB_PREBUILT=ON` to opt in), or point
 `-DCOMMONLIB_PREBUILT_DIR=<extracted bundle>` at a bundle to skip the download.
 
-Because the headers are baked with `skse_xbyak` and link `spdlog`/`DirectXTK` PUBLIC, the
-consumer must provide those header deps from **its own `vcpkg.json`** (`spdlog`, `fmt`,
-`directxtk`, `directxmath`, `xbyak`) — exactly as a source build already requires. As with
-any CommonLibSSE-NG plugin, the consumer also supplies a **PCH** that includes
-`<SKSE/Impl/PCH.h>` and `using namespace std::literals;` (the headers are PCH-dependent).
-See `tests/prebuilt-consumer-cmake/` for a minimal working consumer.
+The headers link `spdlog`/`DirectXTK` PUBLIC, so the consumer provides those header deps
+from **its own `vcpkg.json`** (`spdlog`, `fmt`, `directxtk`, `directxmath`) — exactly as a
+source build already requires. Only add `xbyak` if the consumer enables `SKSE_SUPPORT_XBYAK`,
+and `simpleini` if it enables `REX_OPTION_INI`; a consumer that leaves those off needs
+neither (the baked lib still provides those symbols, unused). As with any CommonLibSSE-NG
+plugin, the consumer also supplies a **PCH** that includes `<SKSE/Impl/PCH.h>` and
+`using namespace std::literals;` (the headers are PCH-dependent). See
+`tests/prebuilt-consumer-cmake/` for a minimal working consumer.
 
 ### vcpkg-port consumers
 

--- a/PREBUILT.md
+++ b/PREBUILT.md
@@ -112,9 +112,13 @@ and defines `CommonLibSSE` as an **IMPORTED** target pointing at these local pat
 sidesteps `find_package`/`install(EXPORT)` relocatability entirely — the paths are the
 just-extracted bundle's own.
 
-The baked configuration is the same as the xmake bundle, with the CMake spelling:
-`ENABLE_SKYRIM_SE/AE/VR=ON`, `REX_OPTION_INI=ON`, `SKSE_SUPPORT_XBYAK=ON`
-(`REX_OPTION_JSON/TOML=OFF`), MSVC, **`Release`** (`/MD`, `NDEBUG`), C++23.
+The bundle is baked the same as the xmake one (skyrim all + `skse_xbyak` + `rex_ini`,
+MSVC, **`Release`** `/MD NDEBUG`, C++23), but the consumer does **not** have to match every
+option. The runtime set (`ENABLE_SKYRIM_SE/AE/VR=ON`) and `SKSE_SUPPORT_XBYAK=ON` change
+public-header layout, so a consumer must enable those. `REX_OPTION_INI` only adds the
+self-contained `REX::INI` namespace, so the baked lib is a **superset**: a consumer with
+`REX_OPTION_INI=OFF` simply doesn't see `REX::INI` and links fine — it is **not** required.
+`REX_OPTION_JSON/TOML` must stay **OFF** (the lib lacks those symbols).
 
 ### Automatic fetch on a clean release tag (CMake)
 

--- a/cmake/Prebuilt.cmake
+++ b/cmake/Prebuilt.cmake
@@ -53,10 +53,13 @@ function(commonlib_resolve_prebuilt out_dir)
         return()
     endif()
 
-    # options must match the config the bundle was baked with (skyrim all + rex_ini +
-    # skse_xbyak; rex_json/toml off) — otherwise the headers/lib would mismatch ABI.
-    if(NOT (ENABLE_SKYRIM_SE AND ENABLE_SKYRIM_AE AND ENABLE_SKYRIM_VR
-            AND REX_OPTION_INI AND SKSE_SUPPORT_XBYAK)
+    # options must be compatible with the baked config (skyrim all + skse_xbyak + rex_ini;
+    # rex_json/toml off). The runtime set and skse_xbyak change public-header layout, so they
+    # must match exactly. rex_ini/json/toml each only add a self-contained REX::{INI,JSON,TOML}
+    # namespace: the lib bakes rex_ini, so it is a superset for ini (a rex_ini-OFF consumer
+    # just never sees REX::INI) and rex_ini is not required here — but it LACKS json/toml, so a
+    # consumer enabling those would reference missing symbols and must keep them off.
+    if(NOT (ENABLE_SKYRIM_SE AND ENABLE_SKYRIM_AE AND ENABLE_SKYRIM_VR AND SKSE_SUPPORT_XBYAK)
        OR REX_OPTION_JSON OR REX_OPTION_TOML)
         return()
     endif()

--- a/cmake/Prebuilt.cmake
+++ b/cmake/Prebuilt.cmake
@@ -53,13 +53,16 @@ function(commonlib_resolve_prebuilt out_dir)
         return()
     endif()
 
-    # options must be compatible with the baked config (skyrim all + skse_xbyak + rex_ini;
-    # rex_json/toml off). The runtime set and skse_xbyak change public-header layout, so they
-    # must match exactly. rex_ini/json/toml each only add a self-contained REX::{INI,JSON,TOML}
-    # namespace: the lib bakes rex_ini, so it is a superset for ini (a rex_ini-OFF consumer
-    # just never sees REX::INI) and rex_ini is not required here — but it LACKS json/toml, so a
-    # consumer enabling those would reference missing symbols and must keep them off.
-    if(NOT (ENABLE_SKYRIM_SE AND ENABLE_SKYRIM_AE AND ENABLE_SKYRIM_VR AND SKSE_SUPPORT_XBYAK)
+    # Only the skyrim runtime set is truly ABI-critical: ENABLE_SKYRIM_SE/AE/VR change the
+    # layout of dozens of public headers, so a consumer must build for all three (as the lib
+    # does). The baked extras are additive and the lib is a superset of them:
+    #   * rex_ini  — adds a self-contained REX::INI namespace (one header)
+    #   * skse_xbyak — adds an #if'd ContextHook block + one non-virtual Trampoline method
+    #                  declaration (no data member → class layout is identical either way)
+    # so a consumer may leave either off and still link cleanly. rex_json/toml are additive
+    # too but baked OFF, so the lib LACKS those symbols — a consumer enabling them would fail
+    # to link and must keep them off.
+    if(NOT (ENABLE_SKYRIM_SE AND ENABLE_SKYRIM_AE AND ENABLE_SKYRIM_VR)
        OR REX_OPTION_JSON OR REX_OPTION_TOML)
         return()
     endif()

--- a/cmake/Prebuilt.cmake
+++ b/cmake/Prebuilt.cmake
@@ -71,6 +71,12 @@ function(commonlib_resolve_prebuilt out_dir)
     if(NOT Git_FOUND)
         return()
     endif()
+    # actions/checkout fetches submodules shallow and without tags, so describe can't see the
+    # release tag in CI; pull tags best-effort first (depth 1, ~fast). Still uses --exact-match,
+    # so a non-tag commit safely falls back to a source build.
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" -C "${CMAKE_CURRENT_SOURCE_DIR}" fetch --tags --depth=1 origin
+        RESULT_VARIABLE _ignore ERROR_QUIET OUTPUT_QUIET)
     execute_process(
         COMMAND "${GIT_EXECUTABLE}" -C "${CMAKE_CURRENT_SOURCE_DIR}" describe --tags --exact-match --dirty
         OUTPUT_VARIABLE _tag OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/tests/prebuilt-consumer-cmake/vcpkg.json
+++ b/tests/prebuilt-consumer-cmake/vcpkg.json
@@ -3,13 +3,12 @@
   "name": "prebuilt-consumer-cmake",
   "version": "0.0.1",
   "builtin-baseline": "ee12231b20c95013c6638d845d04c91559a1d1ff",
-  "description": "Self-test consumer for the CommonLibSSE CMake prebuilt auto-fetch. The baked bundle (skyrim all + rex_ini + skse_xbyak) pulls these header deps from the consumer's own vcpkg, same as a real consumer.",
+  "description": "Self-test consumer for the CommonLibSSE CMake prebuilt auto-fetch. This consumer leaves rex_ini and skse_xbyak OFF (the common case), so it does NOT need simpleini or xbyak — proving the baked lib is a usable superset for those options.",
   "supports": "windows & x64",
   "dependencies": [
     "spdlog",
     "fmt",
     "directxtk",
-    "directxmath",
-    "xbyak"
+    "directxmath"
   ]
 }

--- a/xmake.lua
+++ b/xmake.lua
@@ -161,22 +161,24 @@ target("commonlibsse-ng", function()
         end
     end)
 
-    -- Once options are resolved: if we're on a prebuilt, refuse a baked-option mismatch
-    -- (linking the fixed lib while compiling headers with different REX_OPTION_*/
-    -- ENABLE_SKYRIM_*/SKSE_SUPPORT_XBYAK defines is a silent ABI break), and supply openvr
-    -- headers from the bundle when the nested openvr submodule isn't checked out.
+    -- Once options are resolved: if we're on a prebuilt, refuse an ABI-incompatible config,
+    -- and supply openvr headers from the bundle when the nested openvr submodule isn't
+    -- checked out. Only the skyrim runtime set is layout-critical (linking the fixed lib while
+    -- compiling ENABLE_SKYRIM_* headers differently is a silent ABI break). rex_ini and
+    -- skse_xbyak are additive — the baked lib is a superset, and this target only adds their
+    -- defines/packages when the consumer enables them — so a consumer may leave them off.
+    -- rex_json/toml are baked off, so the lib lacks those symbols and they must stay off.
     on_config(function(target)
         if target:kind() ~= "phony" then return end
-        local baked = {
+        local required = {
             skyrim_se = true, skyrim_ae = true, skyrim_vr = true,
-            rex_ini = true, skse_xbyak = true,
             rex_json = false, rex_toml = false,
         }
-        for opt, want in pairs(baked) do
+        for opt, want in pairs(required) do
             local got = has_config(opt) and true or false
             if got ~= want then
-                raise("prebuilt commonlibsse-ng.lib was built with %s=%s, but the consumer has %s=%s. "
-                    .. "Match the baked config (skyrim all + rex_ini + skse_xbyak; see PREBUILT.md) "
+                raise("prebuilt commonlibsse-ng.lib requires %s=%s, but the consumer has %s=%s. "
+                    .. "Match the baked config (skyrim all; rex_json/toml off; see PREBUILT.md) "
                     .. "or build from source.", opt, want and "y" or "n", opt, got and "y" or "n")
             end
         end

--- a/xmake.lua
+++ b/xmake.lua
@@ -113,6 +113,10 @@ target("commonlibsse-ng", function()
             if not (os.getenv("GITHUB_ACTIONS") or os.getenv("COMMONLIB_PREBUILT")) then
                 return nil
             end
+            -- actions/checkout fetches submodules shallow and without tags, so describe can't
+            -- see the release tag in CI; pull tags best-effort first (depth 1, ~fast). Still
+            -- uses --exact-match, so a non-tag commit safely falls back to a source build.
+            try { function() os.iorunv("git", { "-C", scriptdir, "fetch", "--tags", "--depth=1", "origin" }) end }
             local tag = try { function()
                 return os.iorunv("git", { "-C", scriptdir, "describe", "--tags", "--exact-match", "--dirty" })
             end }


### PR DESCRIPTION
Two fixes that together make the prebuilt auto-fetch (#169/#170) actually usable by real consumers.

## 1. Make clean-tag detection work in CI (the blocker)

`actions/checkout` fetches submodules **shallow and without tags**, so
`git describe --tags --exact-match` found nothing in CI — the resolver always fell back to a
source build and the auto-fetch **never engaged for anyone**. Verified end-to-end: devbench on
the v4.24.0 tag with matching options still compiled CommonLib from source for ~16 min.

Both resolvers now do a best-effort `git fetch --tags --depth=1 origin` before `describe`
(~40 refs, fast). Still `--exact-match`, so a non-tag / dirty commit safely falls back to source.
Proven by simulating a shallow fetch-by-SHA checkout: `describe` finds nothing before the tag
fetch and resolves to the exact tag after.

## 2. Only require the skyrim runtime set (broaden eligibility)

The options gate required consumers to also set `rex_ini` + `skse_xbyak`, which excluded almost
the entire surveyed ecosystem. Only the **skyrim runtime set** is ABI-critical
(`ENABLE_SKYRIM_SE/AE/VR` change the layout of dozens of headers). `rex_ini` and `skse_xbyak`
are **additive** — ini adds a self-contained `REX::INI` namespace; xbyak adds an `#if`'d
`ContextHook` block plus one non-virtual `Trampoline` method declaration (no data member → same
layout, no ODR hazard) — so the baked lib is a **superset** and a consumer may leave either off.
`REX_OPTION_JSON/TOML` stay must-be-off (the lib lacks those symbols).

- `cmake/Prebuilt.cmake` / `xmake.lua`: tag fetch + relaxed gate.
- `CMakeLists.txt`: the IMPORTED target defines `REX_OPTION_INI`/`SKSE_SUPPORT_XBYAK` only when
  the consumer enables them, instead of forcing them.
- `tests/prebuilt-consumer-cmake`: drops `xbyak` from its manifest to exercise the no-xbyak path.
- `PREBUILT.md`: documents must-match vs superset-optional.

## Validation

- Tag detection: simulated a CI-style shallow `fetch --depth=1 <sha>` checkout — `describe` fails
  before the tag fetch, returns the exact tag after.
- Gate: self-test consumer with **both** `rex_ini` and `skse_xbyak` OFF and **neither** xbyak nor
  simpleini in its manifest links the prebuilt → `prebuilt_consumer_cmake.dll`. #170's CI self-test
  runs this consumer against the fully-baked bundle, exercising the superset link end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Prebuilt library requirements are more flexible; optional build features no longer need to match those in the prebuilt binary for successful linking.
  * Enhanced version detection for prebuilt libraries in continuous integration environments.

* **Documentation**
  * Updated prebuilt library compatibility guidance to clarify which runtime selections are mandatory versus which remain optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->