### PR TITLE
fix: allocate correct size in Create()

### DIFF
--- a/include/RE/B/ButtonEvent.h
+++ b/include/RE/B/ButtonEvent.h
@@ -35,18 +35,16 @@ namespace RE
 		static ButtonEvent* Create(INPUT_DEVICE a_inputDevice, const BSFixedString& a_userEvent, uint32_t a_idCode, float a_value, float a_heldDownSecs)
 		{
 			{
-				// In SKYRIM_CROSS_VR, sizeof(ButtonEvent) == sizeof(InputEvent) == 0x18
-				// because ButtonEvent only inherits from InputEvent at compile time.
-				// At runtime the object is larger: VRWandEvent + RUNTIME_DATA (0x38)
-				// or IDEvent + RUNTIME_DATA (0x30) for SE/AE.
-				const auto size = REL::Module::IsVR() ?
-				                      sizeof(VRWandEvent) + sizeof(RUNTIME_DATA) :
-				                      sizeof(IDEvent) + sizeof(RUNTIME_DATA);
-				auto       buttonEvent = malloc<ButtonEvent>(size);
+				// sizeof(ButtonEvent) == sizeof(InputEvent) == 0x18 under SKYRIM_CROSS_VR
+				// (ButtonEvent only inherits from InputEvent at compile time). At runtime
+				// the object is larger: IDEvent + RUNTIME_DATA (0x30) for SE/AE, or
+				// VRWandEvent + RUNTIME_DATA (0x38) for VR. See malloc_runtime.
+				auto buttonEvent = malloc_runtime<ButtonEvent>(
+					sizeof(IDEvent) + sizeof(RUNTIME_DATA),
+					sizeof(VRWandEvent) + sizeof(RUNTIME_DATA));
 				if (!buttonEvent) {
 					return nullptr;
 				}
-				std::memset(reinterpret_cast<void*>(buttonEvent), 0, size);
 				{
 					stl::emplace_vtable<ButtonEvent>(buttonEvent);
 					buttonEvent->device = a_inputDevice;

--- a/include/RE/M/MemoryManager.h
+++ b/include/RE/M/MemoryManager.h
@@ -115,6 +115,28 @@ namespace RE
 		return malloc<T>(sizeof(T));
 	}
 
+	// Allocate and zero-initialize a runtime-correctly-sized object.
+	//
+	// For types whose runtime-data members are stripped under SKYRIM_CROSS_VR
+	// (the RUNTIME_DATA_ACCESSOR pattern), sizeof(T) collapses to the small
+	// cross-VR layout while the engine constructor still builds the full object.
+	// A plain malloc<T>() therefore under-allocates and the ctor overflows the
+	// heap. Pass the flat (SE/AE) and VR sizes from the type's STATIC_ASSERT_SIZE
+	// so the allocation matches the running runtime instead.
+	//
+	// Prefer this over malloc<T>() + memset for any self-allocating Create().
+	// See ButtonEvent/NiPointLight::Create(); guards against alandtse/CommonLibVR#120.
+	template <class T>
+	inline T* malloc_runtime(std::size_t a_flatSize, std::size_t a_vrSize)
+	{
+		const auto size = REL::Module::IsVR() ? a_vrSize : a_flatSize;
+		auto       mem = malloc<T>(size);
+		if (mem) {
+			std::memset(reinterpret_cast<void*>(mem), 0, size);
+		}
+		return mem;
+	}
+
 	inline void* aligned_alloc(std::size_t a_alignment, std::size_t a_size)
 	{
 		auto heap = MemoryManager::GetSingleton();

--- a/include/RE/N/NiDirectionalLight.h
+++ b/include/RE/N/NiDirectionalLight.h
@@ -35,9 +35,15 @@ namespace RE
 
 		static NiDirectionalLight* Create()
 		{
-			auto light = malloc<NiDirectionalLight>();
-			std::memset((void*)light, 0, sizeof(NiDirectionalLight));
+			// In SKYRIM_CROSS_VR, sizeof(NiDirectionalLight) collapses to 0x110 because the
+			// NiLight/NiDirectionalLight runtime-data members are stripped at compile time
+			// (#ifndef SKYRIM_CROSS_VR). The engine ctor still builds the full runtime
+			// object (0x158 SE/AE, 0x180 VR), so allocating sizeof(NiDirectionalLight) would
+			// overflow the heap. Allocate the real per-runtime size instead.
+			const auto size = REL::Module::IsVR() ? 0x180 : 0x158;
+			auto       light = malloc<NiDirectionalLight>(size);
 			if (light) {
+				std::memset((void*)light, 0, size);
 				light->Ctor();
 			}
 			return light;

--- a/include/RE/N/NiDirectionalLight.h
+++ b/include/RE/N/NiDirectionalLight.h
@@ -35,15 +35,10 @@ namespace RE
 
 		static NiDirectionalLight* Create()
 		{
-			// In SKYRIM_CROSS_VR, sizeof(NiDirectionalLight) collapses to 0x110 because the
-			// NiLight/NiDirectionalLight runtime-data members are stripped at compile time
-			// (#ifndef SKYRIM_CROSS_VR). The engine ctor still builds the full runtime
-			// object (0x158 SE/AE, 0x180 VR), so allocating sizeof(NiDirectionalLight) would
-			// overflow the heap. Allocate the real per-runtime size instead.
-			const auto size = REL::Module::IsVR() ? 0x180 : 0x158;
-			auto       light = malloc<NiDirectionalLight>(size);
+			// sizeof(NiDirectionalLight) is wrong under SKYRIM_CROSS_VR (runtime-data
+			// members stripped); allocate the real per-runtime size. See malloc_runtime.
+			auto light = malloc_runtime<NiDirectionalLight>(0x158, 0x180);
 			if (light) {
-				std::memset((void*)light, 0, size);
 				light->Ctor();
 			}
 			return light;

--- a/include/RE/N/NiPointLight.h
+++ b/include/RE/N/NiPointLight.h
@@ -35,9 +35,15 @@ namespace RE
 		bool                 IsEqual(NiObject* a_object) override;               // 1C
 		static NiPointLight* Create()
 		{
-			auto light = malloc<NiPointLight>();
-			std::memset((void*)light, 0, sizeof(NiPointLight));
+			// In SKYRIM_CROSS_VR, sizeof(NiPointLight) collapses to 0x110 because the
+			// NiLight/NiPointLight runtime-data members are stripped at compile time
+			// (#ifndef SKYRIM_CROSS_VR). The engine ctor still builds the full runtime
+			// object (0x150 SE/AE, 0x178 VR), so allocating sizeof(NiPointLight) would
+			// overflow the heap. Allocate the real per-runtime size instead.
+			const auto size = REL::Module::IsVR() ? 0x178 : 0x150;
+			auto       light = malloc<NiPointLight>(size);
 			if (light) {
+				std::memset((void*)light, 0, size);
 				light->Ctor();
 			}
 			return light;

--- a/include/RE/N/NiPointLight.h
+++ b/include/RE/N/NiPointLight.h
@@ -35,15 +35,10 @@ namespace RE
 		bool                 IsEqual(NiObject* a_object) override;               // 1C
 		static NiPointLight* Create()
 		{
-			// In SKYRIM_CROSS_VR, sizeof(NiPointLight) collapses to 0x110 because the
-			// NiLight/NiPointLight runtime-data members are stripped at compile time
-			// (#ifndef SKYRIM_CROSS_VR). The engine ctor still builds the full runtime
-			// object (0x150 SE/AE, 0x178 VR), so allocating sizeof(NiPointLight) would
-			// overflow the heap. Allocate the real per-runtime size instead.
-			const auto size = REL::Module::IsVR() ? 0x178 : 0x150;
-			auto       light = malloc<NiPointLight>(size);
+			// sizeof(NiPointLight) is wrong under SKYRIM_CROSS_VR (runtime-data members
+			// stripped); allocate the real per-runtime size. See malloc_runtime.
+			auto light = malloc_runtime<NiPointLight>(0x150, 0x178);
 			if (light) {
-				std::memset((void*)light, 0, size);
 				light->Ctor();
 			}
 			return light;


### PR DESCRIPTION
## Summary

Fixes #120 — a `SKYRIM_CROSS_VR` heap-buffer overflow in `NiPointLight::Create()` and `NiDirectionalLight::Create()`. The reporter (and the QTR modding team) hit a crash on return-to-menu / load-save that only occurs when the VR build is enabled; turning VR off makes it disappear.

## Root cause

`Create()` did:

```cpp
auto light = malloc<NiPointLight>();              // allocates sizeof(NiPointLight)
std::memset((void*)light, 0, sizeof(NiPointLight));
light->Ctor();                                    // engine ctor builds the FULL object
```

Both lights strip their `NiLight`-derived runtime-data members under `#ifndef SKYRIM_CROSS_VR`, so in a multi-runtime build `sizeof(T)` collapses:

| type | SE | AE | VR | **cross-VR (`sizeof`)** |
|---|---|---|---|---|
| `NiPointLight` | 0x150 | 0x150 | 0x178 | **0x110** |
| `NiDirectionalLight` | 0x158 | 0x158 | 0x180 | **0x110** |

So `Create()` allocated only `0x110`, then the engine constructor initialized a full `0x150`/`0x178` object — writing 0x40–0x70 bytes past the allocation. The overflowed region is all floats (`NiColor ambient/diffuse`, `NiPoint3 radius`, `float fade`), which is why the corrupted neighbor's pointer later reads as a `1.0f` bit pattern: the crashlog in #120 faults on `lock xadd [rcx+0x08]` (an `NiRefObject` refcount op) with `RCX = 0x3F80000000000000` — and `0x3F800000` is IEEE-754 `1.0f`. Heap corruption manifests later, during `QueuedFile` teardown driven by the main-thread message pump, hence "on return to menu / load save."

Flat (VR-off) builds were unaffected because the members are present there, so `sizeof` already matched the runtime object.

## Fix

Allocate the real per-runtime size via `REL::Module::IsVR()`, matching the existing `ButtonEvent::Create()` idiom in this repo.

## Sweep

Audited every self-allocating `Create()` (`malloc<T>()` + engine `Ctor()`) for the same defect:

- `NiPointLight`, `NiDirectionalLight` — **fixed here**.
- `ButtonEvent::Create()` — already correct (the `REL::Module::IsVR()` template this fix follows).
- `BSImagespaceShader::Create()` — strips only *virtuals* under cross-VR; data members are unconditional, `sizeof` is a single `0x1A8` for all runtimes → safe.
- `BGSAttackData`, `HitData`, `TESActionData`, `LooseFileLocation` — single uniform `static_assert(sizeof ...)`, no cross-VR member stripping → safe.

No other types were affected.
