### PR TITLE
feat(prebuilt): opt-in prebuilt for Release-only multi-config consumers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,14 +46,17 @@ commonlib_resolve_prebuilt(COMMONLIB_PREBUILT_RESOLVED)
 if(COMMONLIB_PREBUILT_RESOLVED)
 	message(STATUS "CommonLibSSE: linking prebuilt binary from ${COMMONLIB_PREBUILT_RESOLVED}")
 	add_library("${PROJECT_NAME}" STATIC IMPORTED GLOBAL)
-	# The bundle is Release; the resolver only resolves for non-Debug single-config builds.
-	# Pin the lib to the Release config and map the other release-like configs onto it.
+	# The bundle is Release. Pin the lib to the Release config and map the other release-like
+	# configs onto it. Map Debug to nothing (empty) so that under a multi-config generator
+	# (opted in via COMMONLIB_PREBUILT_MULTICONFIG) a Debug build fails to link loudly instead
+	# of silently picking the Release lib — a /MDd-vs-/MD CRT/ABI mismatch.
 	set_target_properties(
 		"${PROJECT_NAME}" PROPERTIES
 		IMPORTED_CONFIGURATIONS RELEASE
 		IMPORTED_LOCATION_RELEASE "${COMMONLIB_PREBUILT_RESOLVED}/lib/CommonLibSSE.lib"
 		MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release
 		MAP_IMPORTED_CONFIG_MINSIZEREL Release
+		MAP_IMPORTED_CONFIG_DEBUG ""
 	)
 	add_library("${PROJECT_NAME}::${PROJECT_NAME}" ALIAS "${PROJECT_NAME}")
 

--- a/PREBUILT.md
+++ b/PREBUILT.md
@@ -138,7 +138,16 @@ It falls back to a normal **source build** whenever the prebuilt can't be used s
 top-level project is CommonLib itself (you only auto-fetch when *consumed*), a Debug or
 multi-config build (the bundle is Release `/MD`; a Debug `/MDd` link would be an ABI
 mismatch), not on an exact tag, a dirty tree, options that don't match the baked config, or
-a missing/unverified asset. The download is cached under
+a missing/unverified asset.
+
+A **multi-config generator** (Visual Studio) is skipped by default because the config is
+chosen at build time, so Debug can't be ruled out. A consumer that only ever builds
+release-like configs can opt in with **`-DCOMMONLIB_PREBUILT_MULTICONFIG=ON`** (e.g. in its
+preset's `cacheVariables`): the IMPORTED target serves Release (RelWithDebInfo/MinSizeRel map
+onto it) and maps **Debug to nothing**, so a stray Debug build fails loudly rather than
+silently linking the Release lib into a `/MDd` target.
+
+The download is cached under
 `${CMAKE_CURRENT_BINARY_DIR}/.prebuilt/<tag>` — with the advertised
 `add_subdirectory(… commonlib)` layout that is the CommonLib sub-build dir, e.g.
 `<build>/commonlib/.prebuilt/<tag>` — and attempted at most once per tag. Local dev builds

--- a/cmake/Prebuilt.cmake
+++ b/cmake/Prebuilt.cmake
@@ -34,9 +34,17 @@ function(commonlib_resolve_prebuilt out_dir)
     endif()
 
     # The bundle is baked Release (/MD, NDEBUG). Linking it from a Debug config (/MDd) is a
-    # CRT/ABI mismatch, and a multi-config generator can't promise the chosen config at
-    # configure time — so only use the prebuilt for a single-config, non-Debug build.
-    if(CMAKE_CONFIGURATION_TYPES OR NOT CMAKE_BUILD_TYPE MATCHES "^(Release|RelWithDebInfo|MinSizeRel)$")
+    # CRT/ABI mismatch. A single-config build must therefore be a non-Debug config. A
+    # multi-config generator (Visual Studio) chooses the config at build time, so by default
+    # we can't promise Debug won't be built and skip it. A consumer that only ever builds
+    # release-like configs can opt in with COMMONLIB_PREBUILT_MULTICONFIG=ON: the IMPORTED
+    # target then serves Release (RelWithDebInfo/MinSizeRel map to it) and maps Debug to
+    # nothing, so a stray Debug build fails to link loudly instead of silently linking Release.
+    if(CMAKE_CONFIGURATION_TYPES)
+        if(NOT COMMONLIB_PREBUILT_MULTICONFIG)
+            return()
+        endif()
+    elseif(NOT CMAKE_BUILD_TYPE MATCHES "^(Release|RelWithDebInfo|MinSizeRel)$")
         return()
     endif()
 


### PR DESCRIPTION
Follow-up to #170/#171. The cmake prebuilt auto-fetch skipped **multi-config generators** (Visual Studio) unconditionally — the config is chosen at build time, so Debug can't be ruled out, and a multi-config IMPORTED target would let a Debug build silently link the Release-only bundle (`/MDd` vs `/MD` CRT/ABI mismatch). That excluded VS-generator consumers like **community-shaders**, which build **Release** but use the VS generator.

## Change
- `cmake/Prebuilt.cmake`: a consumer that only builds release-like configs opts in with **`-DCOMMONLIB_PREBUILT_MULTICONFIG=ON`**; the resolver then allows the multi-config generator. Single-config still requires a non-Debug `CMAKE_BUILD_TYPE`. **Default is unchanged** — multi-config without the flag still source-builds, so no regression for Debug-building consumers.
- `CMakeLists.txt`: the IMPORTED target already pins `IMPORTED_LOCATION_RELEASE` and maps RelWithDebInfo/MinSizeRel→Release; now also **maps Debug to nothing** (`MAP_IMPORTED_CONFIG_DEBUG ""`) so a stray Debug build under the opt-in fails loudly instead of silently mislinking Release.
- `PREBUILT.md`: documents the opt-in.

## Validation (VS 17 2022 generator, local)
- **Without** the flag: consumer correctly falls back to source (`linking prebuilt = 0`).
- **With** `COMMONLIB_PREBUILT_MULTICONFIG=ON`: `CommonLibSSE: linking prebuilt binary …`, **Release build OK → dll**.
- **Debug** build under the opt-in: **fails loudly** (Debug maps to nothing), so it can't silently link the Release lib.

Unlocks community-shaders (and similar VS-generator, Release-only `add_subdirectory` consumers) after a submodule bump to the release carrying this — a CS follow-up PR sets the flag in its `ALL` preset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)