### PR TITLE
fix(prebuilt): support multi-config generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,15 +46,18 @@ commonlib_resolve_prebuilt(COMMONLIB_PREBUILT_RESOLVED)
 if(COMMONLIB_PREBUILT_RESOLVED)
 	message(STATUS "CommonLibSSE: linking prebuilt binary from ${COMMONLIB_PREBUILT_RESOLVED}")
 	add_library("${PROJECT_NAME}" STATIC IMPORTED GLOBAL)
-	# Pin the lib to Release and map the other release-like configs onto it. Map Debug to nothing
-	# so a stray Debug build (multi-config) fails loudly instead of silently linking the Release lib.
+	# Pin the lib to Release and map the other release-like configs onto it. Point Debug at a
+	# non-existent sentinel rather than nothing: a multi-config generator validates every config
+	# at generate time, so an empty Debug map fails the whole configure — the sentinel keeps
+	# generate happy while making a Debug *build* fail loudly with a self-documenting name (the
+	# Release-only bundle can't serve Debug; build it from source).
 	set_target_properties(
 		"${PROJECT_NAME}" PROPERTIES
-		IMPORTED_CONFIGURATIONS RELEASE
+		IMPORTED_CONFIGURATIONS "RELEASE;DEBUG"
 		IMPORTED_LOCATION_RELEASE "${COMMONLIB_PREBUILT_RESOLVED}/lib/CommonLibSSE.lib"
+		IMPORTED_LOCATION_DEBUG "${COMMONLIB_PREBUILT_RESOLVED}/lib/CommonLibSSE-debug-build-from-source.lib"
 		MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release
 		MAP_IMPORTED_CONFIG_MINSIZEREL Release
-		MAP_IMPORTED_CONFIG_DEBUG ""
 	)
 	add_library("${PROJECT_NAME}::${PROJECT_NAME}" ALIAS "${PROJECT_NAME}")
 


### PR DESCRIPTION
Fixes a bug in #174 found when bumping EngineFixes ([#10](https://github.com/alandtse/EngineFixesSkyrim64/pull/10)) to v4.26.0: the prebuilt **grabbed fine** (`linking prebuilt binary from …/.prebuilt/v4.26.0`), but configure then failed:

```
CMake Error: IMPORTED_LOCATION not set for imported target "CommonLibSSE" configuration "Debug".
```

`MAP_IMPORTED_CONFIG_DEBUG ""` was meant to make a Debug *build* fail loudly, but a multi-config generator validates the IMPORTED target for **every** config at **generate** time — so any consumer with `Debug` in `CMAKE_CONFIGURATION_TYPES` (e.g. EngineFixes' `Debug;Release`) fails the whole configure, not just Debug builds.

**Fix:** point Debug at a non-existent **sentinel** lib instead of an empty map. Generate succeeds; Release links the prebuilt; a Debug build fails with a self-documenting `LNK1104: cannot open 'CommonLibSSE-debug-build-from-source.lib'`.

## Validation (VS 17 2022, EF's exact setup)
- `CMAKE_CONFIGURATION_TYPES=Debug;Release` + `COMMONLIB_PREBUILT_MULTICONFIG=ON` → **configure/generate now succeeds** (exit 0, was 1).
- Release build → links the prebuilt (`.dll`).
- Debug build → `LNK1104` on the sentinel (loud, self-documenting).

Unblocks the EngineFixes / CS multi-config bumps. (Single-config consumers are unaffected — the Debug sentinel is only consulted for a Debug config, which they don't have.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for debug builds with proper debug library configuration mapping.
  * Improved build configuration mappings for optimized release variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->