### PR TITLE
feat: add BSImagespaceShaderReflectionsRayTracing (VR-aware vtable)

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -280,6 +280,7 @@ set(SOURCES
 	include/RE/B/BSImagespaceShader.h
 	include/RE/B/BSImagespaceShaderBlur3.h
 	include/RE/B/BSImagespaceShaderISTemporalAA.h
+	include/RE/B/BSImagespaceShaderReflectionsRayTracing.h
 	include/RE/B/BSInputDevice.h
 	include/RE/B/BSInputDeviceFactory.h
 	include/RE/B/BSInputDeviceManager.h

--- a/include/RE/B/BSImagespaceShaderReflectionsRayTracing.h
+++ b/include/RE/B/BSImagespaceShaderReflectionsRayTracing.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "RE/B/BSImagespaceShader.h"
+
+namespace RE
+{
+	class BSImagespaceShaderReflectionsRayTracing : public BSImagespaceShader
+	{
+	public:
+		inline static constexpr auto RTTI = RTTI_BSImagespaceShaderReflectionsRayTracing;
+		inline static constexpr auto VTABLE = VTABLE_BSImagespaceShaderReflectionsRayTracing;
+
+		~BSImagespaceShaderReflectionsRayTracing() override;  // 00
+
+		// override (BSImagespaceShader)
+		// GetShaderMacros is shifted by VR's FakeDispatchComputeShader insertion in the
+		// BSImagespaceShader base (flat 0x0D -> VR 0x0E), mirroring BSImagespaceShader's
+		// own handling. The class adds no new virtuals of its own.
+#if defined(EXCLUSIVE_SKYRIM_VR) || defined(EXCLUSIVE_SKYRIM_FLAT)
+		void GetShaderMacros(ShaderMacro* a_macros) override;  // 0D, VR 0E
+#endif
+
+#ifdef SKYRIM_CROSS_VR
+		void GetShaderMacros(ShaderMacro* a_macros)
+		{
+			REL::RelocateVirtual<decltype(&BSImagespaceShaderReflectionsRayTracing::GetShaderMacros)>(0x0D, 0x0E, this, a_macros);
+		}
+#endif
+	};
+	static_assert(sizeof(BSImagespaceShaderReflectionsRayTracing) == 0x1A8);
+}

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -282,6 +282,7 @@
 #include "RE/B/BSImagespaceShader.h"
 #include "RE/B/BSImagespaceShaderBlur3.h"
 #include "RE/B/BSImagespaceShaderISTemporalAA.h"
+#include "RE/B/BSImagespaceShaderReflectionsRayTracing.h"
 #include "RE/B/BSInputDevice.h"
 #include "RE/B/BSInputDeviceFactory.h"
 #include "RE/B/BSInputDeviceManager.h"


### PR DESCRIPTION
Adds the missing `BSImagespaceShaderReflectionsRayTracing` class type (ISReflectionsRayTracing / SSR). RTTI + VTABLE offsets already existed in `Offsets_*`, but there was no class.

## RE (verified SE/AE/VR in Ghidra)
- Base hierarchy is **identical to `BSImagespaceShader`** (`BSShader`→`NiRefObject`, + `NiBoneMatrixSetterI`@0x10, `BSReloadShaderI`@0x18, `ImageSpaceEffect`@0x90), so `: public BSImagespaceShader` covers every base.
- `sizeof == 0x1A8` (allocation `MOV ECX,0x1A8` at the ctor call site) — **no new members**.
- Primary vtable adds **no new virtuals**; RTRT overrides only **dtor** (0x00) and **GetShaderMacros** (flat 0x0D).

## The VR difference
The differing VR vtable is the `FakeDispatchComputeShader` insertion **inherited from `BSImagespaceShader`** (VR slot 0x0D), which shifts `GetShaderMacros` to **VR 0x0E**. Handled with the same `EXCLUSIVE_SKYRIM_VR`/`EXCLUSIVE_SKYRIM_FLAT` + `SKYRIM_CROSS_VR` `RelocateVirtual(0x0D, 0x0E)` idiom as the base, so the override resolves correctly in flat, VR, and multi-runtime builds.

Functions named in Ghidra across SE/AE/VR: Ctor, dtor, GetShaderMacros.