### PR TITLE
fix: MenuEventHandler VR vtable shift

### DIFF
--- a/include/RE/C/ClickHandler.h
+++ b/include/RE/C/ClickHandler.h
@@ -13,8 +13,10 @@ namespace RE
 		~ClickHandler() override;
 
 		// override (MenuEventHandler)
-		bool CanProcess(InputEvent* a_event) override;      // 01
-		bool ProcessButton(ButtonEvent* a_event) override;  // 05
+		bool CanProcess(InputEvent* a_event) override;  // 01
+#ifndef SKYRIM_CROSS_VR
+		bool ProcessButton(ButtonEvent* a_event) override;  // 05 (VR 08)
+#endif
 	};
 	static_assert(sizeof(ClickHandler) == 0x10);
 }

--- a/include/RE/C/ConsoleOpenHandler.h
+++ b/include/RE/C/ConsoleOpenHandler.h
@@ -13,8 +13,10 @@ namespace RE
 		~ConsoleOpenHandler() override;  // 00
 
 		// override (MenuEventHandler)
-		bool CanProcess(InputEvent* a_event) override;      // 01
-		bool ProcessButton(ButtonEvent* a_event) override;  // 05
+		bool CanProcess(InputEvent* a_event) override;  // 01
+#ifndef SKYRIM_CROSS_VR
+		bool ProcessButton(ButtonEvent* a_event) override;  // 05 (VR 08)
+#endif
 	};
 	static_assert(sizeof(ConsoleOpenHandler) == 0x10);
 }

--- a/include/RE/D/DirectionHandler.h
+++ b/include/RE/D/DirectionHandler.h
@@ -13,9 +13,11 @@ namespace RE
 		~DirectionHandler() override;  // 00
 
 		// override (MenuEventHandler)
-		bool CanProcess(InputEvent* a_event) override;              // 01
-		bool ProcessThumbstick(ThumbstickEvent* a_event) override;  // 03
-		bool ProcessButton(ButtonEvent* a_event) override;          // 05
+		bool CanProcess(InputEvent* a_event) override;  // 01
+#ifndef SKYRIM_CROSS_VR
+		bool ProcessThumbstick(ThumbstickEvent* a_event) override;  // 03 (VR 06)
+		bool ProcessButton(ButtonEvent* a_event) override;          // 05 (VR 08)
+#endif
 
 		// members
 		float         nextRepeat;                // 10

--- a/include/RE/F/FavoritesHandler.h
+++ b/include/RE/F/FavoritesHandler.h
@@ -13,9 +13,11 @@ namespace RE
 		~FavoritesHandler() override;  // 00
 
 		// override
-		bool CanProcess(InputEvent* a_event) override;      // 01
-		bool ProcessKinect(KinectEvent* a_event) override;  // 02
-		bool ProcessButton(ButtonEvent* a_event) override;  // 05
+		bool CanProcess(InputEvent* a_event) override;  // 01
+#ifndef SKYRIM_CROSS_VR
+		bool ProcessKinect(KinectEvent* a_event) override;  // 02 (VR 05)
+		bool ProcessButton(ButtonEvent* a_event) override;  // 05 (VR 08)
+#endif
 	};
 	static_assert(sizeof(FavoritesHandler) == 0x10);
 }

--- a/include/RE/I/InputEvent.h
+++ b/include/RE/I/InputEvent.h
@@ -12,7 +12,10 @@ namespace RE
 		kChar,
 		kThumbstick,
 		kDeviceConnect,
-		kKinect
+		kKinect,
+		// VR only (SkyrimVR): the VR runtime emits two extra wand-touchpad event types.
+		kVrTouchpadPosition,  // 6 - VrWandTouchpadPositionEvent
+		kVrTouchpadSwipe      // 7 - VrWandTouchpadSwipeEvent
 	};
 
 	class ButtonEvent;

--- a/include/RE/L/LocalMapMenu.h
+++ b/include/RE/L/LocalMapMenu.h
@@ -137,10 +137,12 @@ namespace RE
 			~InputHandler() override;  // 00
 
 			// override (MenuEventHandler)
-			bool CanProcess(InputEvent* a_event) override;              // 01
-			bool ProcessThumbstick(ThumbstickEvent* a_event) override;  // 03
-			bool ProcessMouseMove(MouseMoveEvent* a_event) override;    // 04
-			bool ProcessButton(ButtonEvent* a_event) override;          // 05
+			bool CanProcess(InputEvent* a_event) override;  // 01
+#ifndef SKYRIM_CROSS_VR
+			bool ProcessThumbstick(ThumbstickEvent* a_event) override;  // 03 (VR 06)
+			bool ProcessMouseMove(MouseMoveEvent* a_event) override;    // 04 (VR 07)
+			bool ProcessButton(ButtonEvent* a_event) override;          // 05 (VR 08)
+#endif
 
 			// members
 			LocalMapMenu* localMapMenu;  // 10

--- a/include/RE/M/MapLookHandler.h
+++ b/include/RE/M/MapLookHandler.h
@@ -13,9 +13,11 @@ namespace RE
 		~MapLookHandler() override;  // 00
 
 		// override (MapInputHandler)
-		bool ProcessThumbstick(ThumbstickEvent* a_event) override;  // 03
-		bool ProcessMouseMove(MouseMoveEvent* a_event) override;    // 04
-		bool ProcessButton(ButtonEvent* a_event) override;          // 05
+#ifndef SKYRIM_CROSS_VR
+		bool ProcessThumbstick(ThumbstickEvent* a_event) override;  // 03 (VR 06)
+		bool ProcessMouseMove(MouseMoveEvent* a_event) override;    // 04 (VR 07)
+		bool ProcessButton(ButtonEvent* a_event) override;          // 05 (VR 08)
+#endif
 
 		// members
 		std::uint64_t unk18;  // 18

--- a/include/RE/M/MapMoveHandler.h
+++ b/include/RE/M/MapMoveHandler.h
@@ -14,8 +14,10 @@ namespace RE
 		~MapMoveHandler() override;  // 00
 
 		// override (MapInputHandler)
-		bool CanProcess(InputEvent* a_event) override;              // 01
-		bool ProcessThumbstick(ThumbstickEvent* a_event) override;  // 03
+		bool CanProcess(InputEvent* a_event) override;  // 01
+#ifndef SKYRIM_CROSS_VR
+		bool ProcessThumbstick(ThumbstickEvent* a_event) override;  // 03 (VR 06)
+#endif
 
 		// members
 		BSTPoint2<float> unk18;  // 18

--- a/include/RE/M/MapZoomHandler.h
+++ b/include/RE/M/MapZoomHandler.h
@@ -13,8 +13,10 @@ namespace RE
 		~MapZoomHandler() override;  // 00
 
 		// override (MapInputHandler)
-		bool CanProcess(InputEvent* a_event) override;      // 01
-		bool ProcessButton(ButtonEvent* a_event) override;  // 05
+		bool CanProcess(InputEvent* a_event) override;  // 01
+#ifndef SKYRIM_CROSS_VR
+		bool ProcessButton(ButtonEvent* a_event) override;  // 05 (VR 08)
+#endif
 	};
 	static_assert(sizeof(MapZoomHandler) == 0x18);
 }

--- a/include/RE/M/MenuEventHandler.h
+++ b/include/RE/M/MenuEventHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "RE/B/BSIntrusiveRefCounted.h"
+#include "REL/Relocation.h"
 
 namespace RE
 {
@@ -9,6 +10,8 @@ namespace RE
 	class KinectEvent;
 	class MouseMoveEvent;
 	class ThumbstickEvent;
+	class VrWandTouchpadPositionEvent;
+	class VrWandTouchpadSwipeEvent;
 
 	class MenuEventHandler : public BSIntrusiveRefCounted
 	{
@@ -20,22 +23,45 @@ namespace RE
 		virtual ~MenuEventHandler() = default;  // 00
 
 		virtual bool CanProcess(InputEvent* a_event) = 0;  // 01
+
+		// VR's vtable inserts three wand-touchpad input virtuals after CanProcess, shifting
+		// ProcessKinect/Thumbstick/MouseMove/Button from slots 02-05 down to 05-08. The
+		// MenuControls dispatcher routes INPUT_EVENT_TYPE::kVrTouchpadSwipe (7) -> slot 02 and
+		// kVrTouchpadPosition (6) -> slot 03; slot 04 is not routed by MenuControls.
 #if defined(EXCLUSIVE_SKYRIM_VR)
-		// VR's MenuEventHandler vtable has three extra controller-input virtuals inserted
-		// here, which shifts ProcessKinect/Thumbstick/MouseMove/Button down by +3 (to VR
-		// slots 05-08). Declaring them in EXCLUSIVE_SKYRIM_VR makes the compiler place those
-		// methods at the correct VR slots, so derived overrides bind correctly.
-		// Per the MenuControls input dispatcher these route VR-only INPUT_EVENT_TYPE values
-		// (type 7 -> Unk_02, type 6 -> Unk_03; Unk_04 is not routed by MenuControls). The
-		// exact VR event classes are not yet identified, hence the Unk_ names.
-		virtual bool Unk_02(void* a_event);  // VR 02 - { return false; }
-		virtual bool Unk_03(void* a_event);  // VR 03 - { return false; }
-		virtual bool Unk_04(void* a_event);  // VR 04 - { return false; }
+		virtual bool ProcessVrWandTouchpadSwipe(VrWandTouchpadSwipeEvent* a_event);        // VR 02 - { return false; }
+		virtual bool ProcessVrWandTouchpadPosition(VrWandTouchpadPositionEvent* a_event);  // VR 03 - { return false; }
+		virtual bool Unk_04(void* a_event);                                                // VR 04 - { return false; }
+		virtual bool ProcessKinect(KinectEvent* a_event);                                  // VR 05 - { return false; }
+		virtual bool ProcessThumbstick(ThumbstickEvent* a_event);                          // VR 06 - { return false; }
+		virtual bool ProcessMouseMove(MouseMoveEvent* a_event);                            // VR 07 - { return false; }
+		virtual bool ProcessButton(ButtonEvent* a_event);                                  // VR 08 - { return false; }
+#elif !defined(SKYRIM_CROSS_VR)
+		// EXCLUSIVE_SKYRIM_FLAT (SE/AE)
+		virtual bool ProcessKinect(KinectEvent* a_event);          // 02 - { return false; }
+		virtual bool ProcessThumbstick(ThumbstickEvent* a_event);  // 03 - { return false; }
+		virtual bool ProcessMouseMove(MouseMoveEvent* a_event);    // 04 - { return false; }
+		virtual bool ProcessButton(ButtonEvent* a_event);          // 05 - { return false; }
+#else
+		// SKYRIM_CROSS_VR (multi-runtime): non-virtual wrappers dispatch to the correct
+		// per-runtime vtable slot, so a single binary works on both flat and VR.
+		bool ProcessKinect(KinectEvent* a_event)
+		{
+			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessKinect)>(0x02, 0x05, this, a_event);
+		}
+		bool ProcessThumbstick(ThumbstickEvent* a_event)
+		{
+			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessThumbstick)>(0x03, 0x06, this, a_event);
+		}
+		bool ProcessMouseMove(MouseMoveEvent* a_event)
+		{
+			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessMouseMove)>(0x04, 0x07, this, a_event);
+		}
+		bool ProcessButton(ButtonEvent* a_event)
+		{
+			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessButton)>(0x05, 0x08, this, a_event);
+		}
 #endif
-		virtual bool ProcessKinect(KinectEvent* a_event);          // 02, VR 05 - { return false; }
-		virtual bool ProcessThumbstick(ThumbstickEvent* a_event);  // 03, VR 06 - { return false; }
-		virtual bool ProcessMouseMove(MouseMoveEvent* a_event);    // 04, VR 07 - { return false; }
-		virtual bool ProcessButton(ButtonEvent* a_event);          // 05, VR 08 - { return false; }
 
 		// members
 		bool          registered;  // 0C

--- a/include/RE/M/MenuEventHandler.h
+++ b/include/RE/M/MenuEventHandler.h
@@ -19,11 +19,23 @@ namespace RE
 		MenuEventHandler() = default;
 		virtual ~MenuEventHandler() = default;  // 00
 
-		virtual bool CanProcess(InputEvent* a_event) = 0;          // 01
-		virtual bool ProcessKinect(KinectEvent* a_event);          // 02 - { return false; }
-		virtual bool ProcessThumbstick(ThumbstickEvent* a_event);  // 03 - { return false; }
-		virtual bool ProcessMouseMove(MouseMoveEvent* a_event);    // 04 - { return false; }
-		virtual bool ProcessButton(ButtonEvent* a_event);          // 05 - { return false; }
+		virtual bool CanProcess(InputEvent* a_event) = 0;  // 01
+#if defined(EXCLUSIVE_SKYRIM_VR)
+		// VR's MenuEventHandler vtable has three extra controller-input virtuals inserted
+		// here, which shifts ProcessKinect/Thumbstick/MouseMove/Button down by +3 (to VR
+		// slots 05-08). Declaring them in EXCLUSIVE_SKYRIM_VR makes the compiler place those
+		// methods at the correct VR slots, so derived overrides bind correctly.
+		// Per the MenuControls input dispatcher these route VR-only INPUT_EVENT_TYPE values
+		// (type 7 -> Unk_02, type 6 -> Unk_03; Unk_04 is not routed by MenuControls). The
+		// exact VR event classes are not yet identified, hence the Unk_ names.
+		virtual bool Unk_02(void* a_event);  // VR 02 - { return false; }
+		virtual bool Unk_03(void* a_event);  // VR 03 - { return false; }
+		virtual bool Unk_04(void* a_event);  // VR 04 - { return false; }
+#endif
+		virtual bool ProcessKinect(KinectEvent* a_event);          // 02, VR 05 - { return false; }
+		virtual bool ProcessThumbstick(ThumbstickEvent* a_event);  // 03, VR 06 - { return false; }
+		virtual bool ProcessMouseMove(MouseMoveEvent* a_event);    // 04, VR 07 - { return false; }
+		virtual bool ProcessButton(ButtonEvent* a_event);          // 05, VR 08 - { return false; }
 
 		// members
 		bool          registered;  // 0C

--- a/include/RE/M/MenuOpenHandler.h
+++ b/include/RE/M/MenuOpenHandler.h
@@ -13,9 +13,11 @@ namespace RE
 		~MenuOpenHandler() override;  // 00
 
 		// override (MenuEventHandler)
-		bool CanProcess(InputEvent* a_event) override;      // 01
-		bool ProcessKinect(KinectEvent* a_event) override;  // 02
-		bool ProcessButton(ButtonEvent* a_event) override;  // 05
+		bool CanProcess(InputEvent* a_event) override;  // 01
+#ifndef SKYRIM_CROSS_VR
+		bool ProcessKinect(KinectEvent* a_event) override;  // 02 (VR 05)
+		bool ProcessButton(ButtonEvent* a_event) override;  // 05 (VR 08)
+#endif
 
 		// members
 		bool          unk10;  // 10

--- a/include/RE/Q/QuickSaveLoadHandler.h
+++ b/include/RE/Q/QuickSaveLoadHandler.h
@@ -13,9 +13,11 @@ namespace RE
 		~QuickSaveLoadHandler() override;  // 00
 
 		// override (MenuEventHandler)
-		bool CanProcess(InputEvent* a_event) override;      // 01
-		bool ProcessKinect(KinectEvent* a_event) override;  // 02
-		bool ProcessButton(ButtonEvent* a_event) override;  // 05
+		bool CanProcess(InputEvent* a_event) override;  // 01
+#ifndef SKYRIM_CROSS_VR
+		bool ProcessKinect(KinectEvent* a_event) override;  // 02 (VR 05)
+		bool ProcessButton(ButtonEvent* a_event) override;  // 05 (VR 08)
+#endif
 	};
 	static_assert(sizeof(QuickSaveLoadHandler) == 0x10);
 }

--- a/include/RE/S/ScreenshotHandler.h
+++ b/include/RE/S/ScreenshotHandler.h
@@ -13,8 +13,10 @@ namespace RE
 		~ScreenshotHandler() override;  // 00
 
 		// override (MenuEventHandler)
-		bool CanProcess(InputEvent* a_event) override;      // 01
-		bool ProcessButton(ButtonEvent* a_event) override;  // 05
+		bool CanProcess(InputEvent* a_event) override;  // 01
+#ifndef SKYRIM_CROSS_VR
+		bool ProcessButton(ButtonEvent* a_event) override;  // 05 (VR 08)
+#endif
 
 		// members
 		bool          screenshotQueued;       // 10

--- a/src/RE/M/MenuEventHandler.cpp
+++ b/src/RE/M/MenuEventHandler.cpp
@@ -1,5 +1,8 @@
 #include "RE/M/MenuEventHandler.h"
 
+// In SKYRIM_CROSS_VR these are non-virtual RelocateVirtual wrappers defined inline in the
+// header (the VR vtable shifts these slots), so they must not be redefined here.
+#ifndef SKYRIM_CROSS_VR
 namespace RE
 {
 	bool MenuEventHandler::ProcessKinect(KinectEvent*)
@@ -22,3 +25,4 @@ namespace RE
 		return false;
 	}
 }
+#endif


### PR DESCRIPTION
## Bug
VR's `MenuEventHandler` vtable has **9 slots vs flat's 6** — VR inserts three wand-touchpad input virtuals after `CanProcess`, shifting `ProcessKinect`/`ProcessThumbstick`/`ProcessMouseMove`/`ProcessButton` from slots **02-05 → 05-08**. The header declared only the flat layout, so every `MenuEventHandler` subclass (MistMenu + ~dozens of menus/handlers) mis-bound those overrides on VR.

## RE (SkyrimVR.exe, verified)
- Base vtable `0x16a8b30` = 9 slots (flat `0x1632660` = 6).
- `MenuControls` dispatcher (`0x1408d5640`) eventType→slot: 0→8 Button, 1→7 MouseMove, 3→6 Thumbstick, 5→5 Kinect, **6→3, 7→2**.
- VR event types identified from ctors: **`VrWandTouchpadPositionEvent` → type 6**, **`VrWandTouchpadSwipeEvent` → type 7**. Added as `INPUT_EVENT_TYPE::kVrTouchpadPosition`/`kVrTouchpadSwipe`.

## Fix (all three build modes)
- **`MenuEventHandler.h`**: `EXCLUSIVE_SKYRIM_VR` declares the 3 VR-only virtuals (`ProcessVrWandTouchpadSwipe`/`Position` + `Unk_04`) and the four shifted methods at slots 05-08; `EXCLUSIVE_SKYRIM_FLAT` keeps the flat layout; `SKYRIM_CROSS_VR` uses non-virtual `RelocateVirtual(flat, vr)` wrappers that dispatch to the correct per-runtime slot.
- **Guarded** the four shifting overrides with `#ifndef SKYRIM_CROSS_VR` in every subclass that inherits `MenuEventHandler` *unconditionally* and overrides them: ClickHandler, ConsoleOpenHandler, DirectionHandler, FavoritesHandler, MenuOpenHandler, MapLookHandler, MapMoveHandler, MapZoomHandler, QuickSaveLoadHandler, ScreenshotHandler, LocalMapMenu::InputHandler. `CanProcess` (slot 01, identical both runtimes) stays. Menus that inherit conditionally are unaffected.

`sizeof` unchanged (0x10); flat layout unchanged. Multi-runtime builds now dispatch VR menu input to the correct slot instead of mis-binding.

## Notes
- `Unk_04` (VR slot 04) is a real virtual but isn't routed by `MenuControls`; left as documented `Unk_`.
- `PlayerInputHandler` subclasses (two-param `Process*(evt, PlayerControlsData*)`) are a separate base and are not affected.