### PR TITLE
fix: remove phantom ISGraphicsTextureFilterMode IS effect

### DIFF
--- a/include/RE/I/ImageSpaceManager.h
+++ b/include/RE/I/ImageSpaceManager.h
@@ -181,10 +181,10 @@ namespace RE
 	X2(ISWaterFlow, 157, 172)                            /* BSImagespaceShaderWaterFlow */                                      \
 	/* SE 158 missing */                                                                                                        \
 	/* VR only */                                                                                                               \
-	X2(ISCopyDepthBuffer, INVALID_INDEX, 98)                      /* BSImagespaceShaderCopyDepthBuffer */                       \
-	X2(ISCopyDepthBuffer_DR, INVALID_INDEX, 99)                   /* BSImagespaceShaderCopyDepthBuffer_DR */                    \
-	X2(ISCopyDepthBufferTargetSize, INVALID_INDEX, 100)           /* BSImagespaceShaderCopyDepthBuffer_TargetSize */            \
-	X2(ISGraphicsTextureFilterMode, INVALID_INDEX, 111)           /* ISGraphicsTextureFilterMode */                             \
+	X2(ISCopyDepthBuffer, INVALID_INDEX, 98)            /* BSImagespaceShaderCopyDepthBuffer */                                 \
+	X2(ISCopyDepthBuffer_DR, INVALID_INDEX, 99)         /* BSImagespaceShaderCopyDepthBuffer_DR */                              \
+	X2(ISCopyDepthBufferTargetSize, INVALID_INDEX, 100) /* BSImagespaceShaderCopyDepthBuffer_TargetSize */                      \
+	/* VR 111 = ISReflectionBlurHCS; ISGraphicsTextureFilterMode was a phantom (removed) */                                     \
 	X2(ISDownsampleHierarchicalDepthBufferCS, INVALID_INDEX, 126) /* BSImagespaceShaderISDownsampleHierarchicalDepthBufferCS */ \
 	X2(ISDiffScaleDownsampleDepthBufferCS, INVALID_INDEX, 127)    /* BSImagespaceShaderISDiffScaleDownsampleDepthBufferCS */    \
 	X2(ISFullScreenVR, INVALID_INDEX, 129)                        /* BSImagespaceShaderISFullScreenVR */                        \


### PR DESCRIPTION
While verifying the VR `ImageSpaceEffectEnum` against the binary, found that VR index **111** was assigned to two effects: `ISReflectionBlurHCS` (se 108 / vr 111) and the VR-only `ISGraphicsTextureFilterMode` (INVALID / 111).

Ground truth from the engine effect-init dispatcher (`SkyrimVR.exe` `ImageSpaceManager` init → register helper `0x1412d1af0`, index in EDX): **VR 111 = `BSImagespaceShaderReflectionBlurHCS`**. `GraphicsTextureFilterMode` is **not** a registered IS effect anywhere, so its entry was a phantom that collided with the real one. Removed it.

I extracted and verified the **full VR effect map (indices 98–172)** against the binary — every other entry (including the VR-only depth-buffer copy/downsample, FullScreenVR, and the PreTest culling chain) matches; no further discrepancies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VR rendering effects configuration for improved depth buffer operation handling in virtual reality environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->