### PR TITLE
feat(re): add ShadowSceneNode::ResetScene

### DIFF
--- a/include/RE/S/ShadowSceneNode.h
+++ b/include/RE/S/ShadowSceneNode.h
@@ -127,7 +127,9 @@ namespace RE
 		BSLight*           GetShadowLight(NiLight* a_light);
 		void               RemoveLight(NiLight* a_light);
 		void               RemoveLight(const NiPointer<BSLight>& a_light);
+		void               ClearLightArrays();  // bulk teardown: queues every active light into lightQueueRemove
 		BSCompoundFrustum* BuildSharedCompoundFrustum(BSCullingProcess* a_cullingProcess, BSPortal* a_portal);
+		void               ResetScene(BSPortalGraph* a_graph);  // portalGraph setter; called from ResetCellGrid on cell transition
 
 		// members
 #ifndef SKYRIM_CROSS_VR

--- a/src/RE/S/ShadowSceneNode.cpp
+++ b/src/RE/S/ShadowSceneNode.cpp
@@ -61,10 +61,24 @@ namespace RE
 		return func(this, a_light);
 	}
 
+	void ShadowSceneNode::ClearLightArrays()
+	{
+		using func_t = void (*)(ShadowSceneNode*);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(99704, 106338) };
+		return func(this);
+	}
+
 	BSCompoundFrustum* ShadowSceneNode::BuildSharedCompoundFrustum(BSCullingProcess* a_cullingProcess, BSPortal* a_portal)
 	{
 		using func_t = decltype(&ShadowSceneNode::BuildSharedCompoundFrustum);
 		static REL::Relocation<func_t> func{ RELOCATION_ID(99735, 106379) };
 		return func(this, a_cullingProcess, a_portal);
+	}
+
+	void ShadowSceneNode::ResetScene(BSPortalGraph* a_graph)
+	{
+		using func_t = void (*)(ShadowSceneNode*, BSPortalGraph*);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(99741, 106385) };
+		return func(this, a_graph);
 	}
 }


### PR DESCRIPTION
Adds `ShadowSceneNode::ResetScene(BSPortalGraph*)` — the engine's `portalGraph`
setter (`this->portalGraph = a_graph`), called from `ResetCellGrid` on cell
transitions.

- `RELOCATION_ID(99741, 106385)`; VR addr `0x1412fb9e0`.
- Named in the SE/AE/VR Ghidra DBs.
- Follows the existing `ShadowSceneNode` method pattern (`AddLight`,
  `ClearLightArrays`, `BuildSharedCompoundFrustum`).

RE'd while fixing an interior cell-transition shadow CTD in Open Shaders, where
`ResetScene` (main thread) swaps `portalGraph` while the engine's `AccumulateLight`
reads it on the render thread. Documenting the function here for reuse.

Note: `AccumulateLight` (the read side) has two engine overloads (`99752`/`99753`)
with the same `(BSLight*, BSTArray<NiAVObject*>*, bool)` signature, so they can't
be distinguished as C++ methods — left out intentionally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scene light array clearing capability for efficient memory management
  * Added scene reset functionality to support portal graph transitions during scene changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->