### PR TITLE
refactor: type split RGB color fields as NiColor

### DIFF
--- a/include/RE/B/BSVolumetricLightingRenderData.h
+++ b/include/RE/B/BSVolumetricLightingRenderData.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "RE/N/NiColor.h"
+
 namespace RE
 {
 	class BSVolumetricLightingRenderData
@@ -44,9 +46,7 @@ namespace RE
 		// members
 		float               intensity;            // 00 - CNAM
 		CustomColor         customColor;          // 04
-		float               red;                  // 08 - ENAM
-		float               green;                // 0C - FNAM
-		float               blue;                 // 10 - GNAM
+		NiColor             color;                // 08 - ENAM (red) / FNAM (green) / GNAM (blue)
 		Density             density;              // 14
 		PhaseFunction       phaseFunction;        // 24
 		SamplingRepartition samplingRepartition;  // 2C

--- a/include/RE/I/ImageSpaceData.h
+++ b/include/RE/I/ImageSpaceData.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "RE/N/NiColor.h"
+
 namespace RE
 {
 	struct ImageSpaceBaseData
@@ -33,19 +35,9 @@ namespace RE
 		struct Tint  // TNAM
 		{
 		public:
-			struct ColorF
-			{
-			public:
-				// members
-				float red;    // 0
-				float green;  // 4
-				float blue;   // 8
-			};
-			static_assert(sizeof(ColorF) == 0xC);
-
 			// members
-			float  amount;  // 00
-			ColorF color;   // 04
+			float   amount;  // 00
+			NiColor color;   // 04 - red/green/blue
 		};
 		static_assert(sizeof(Tint) == 0x10);
 


### PR DESCRIPTION
## What
Replace split `red`/`green`/`blue` float members with the canonical `RE::NiColor`:
- `BSVolumetricLightingRenderData`: `red`/`green`/`blue` (0x08/0x0C/0x10) → `NiColor color` (ENAM/FNAM/GNAM).
- `ImageSpaceData::Tint`: drop the nested `ColorF { red, green, blue }` → `NiColor color` (TNAM).

## Why
These are the engine RGB triple. `NiColor` is the library convention (used by BGSMaterialType, the shader materials, Clouds, water, etc.); only these two structs still carried split floats. Using `NiColor` matches the binary, is self-documenting, and brings its operators.

## Safety
- **Layout-identical** — `NiColor` is `{ float red, green, blue }` (0xC). All `static_assert(sizeof(...))` are unchanged.
- No in-tree references to the removed `ImageSpaceData::Tint::ColorF`.
- Built clean on **all five presets** (se / ae / vr / flatrim / all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)