### PR TITLE
feat: add BSIStream with DecompressLipData

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -277,6 +277,7 @@ set(SOURCES
 	include/RE/B/BSISoundCategory.h
 	include/RE/B/BSISoundDescriptor.h
 	include/RE/B/BSISoundOutputModel.h
+	include/RE/B/BSIStream.h
 	include/RE/B/BSImagespaceShader.h
 	include/RE/B/BSImagespaceShaderBlur3.h
 	include/RE/B/BSImagespaceShaderISTemporalAA.h
@@ -2063,6 +2064,7 @@ set(SOURCES
 	src/RE/B/BSGamepadDevice.cpp
 	src/RE/B/BSGeometry.cpp
 	src/RE/B/BSHandleRefObject.cpp
+	src/RE/B/BSIStream.cpp
 	src/RE/B/BSInputDevice.cpp
 	src/RE/B/BSInputDeviceFactory.cpp
 	src/RE/B/BSInputDeviceManager.cpp

--- a/include/RE/B/BSIStream.h
+++ b/include/RE/B/BSIStream.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "RE/B/BSFixedString.h"
+#include "RE/B/BSTSmartPointer.h"
+
+namespace RE
+{
+	namespace BSResource
+	{
+		class Stream;
+	}
+
+	class BSIStream
+	{
+	public:
+		inline static constexpr auto RTTI = RTTI_BSIStream;
+		inline static constexpr auto VTABLE = VTABLE_BSIStream;
+
+		virtual ~BSIStream() = default;  // 00
+
+		[[nodiscard]] void* DecompressLipData();
+
+		// members
+		BSTSmartPointer<BSResource::Stream> stream;    // 08
+		bool                                eof;       // 10
+		std::uint8_t                        pad11[7];  // 11
+		BSFixedString                       name;      // 18
+	};
+	static_assert(sizeof(BSIStream) == 0x20);
+}

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -279,6 +279,7 @@
 #include "RE/B/BSISoundCategory.h"
 #include "RE/B/BSISoundDescriptor.h"
 #include "RE/B/BSISoundOutputModel.h"
+#include "RE/B/BSIStream.h"
 #include "RE/B/BSImagespaceShader.h"
 #include "RE/B/BSImagespaceShaderBlur3.h"
 #include "RE/B/BSImagespaceShaderISTemporalAA.h"

--- a/src/RE/B/BSIStream.cpp
+++ b/src/RE/B/BSIStream.cpp
@@ -1,0 +1,11 @@
+#include "RE/B/BSIStream.h"
+
+namespace RE
+{
+	void* BSIStream::DecompressLipData()
+	{
+		using func_t = decltype(&BSIStream::DecompressLipData);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(16021, 16263) };
+		return func(this);
+	}
+}


### PR DESCRIPTION
## What
Add `RE::BSIStream` — wraps a `BSResource::Stream` (plus an `eof` flag and a `name`) and exposes `DecompressLipData()`, which inflates FUZE/EZUF-compressed lip-sync data read from the stream.

## RE
- Real engine class: `RTTI_BSIStream` (690706 / 398561) and `VTABLE_BSIStream` (287988 / 238369).
- Single virtual (the destructor) — vtable has exactly one slot.
- `DecompressLipData` is non-virtual, bound via `RELOCATION_ID(16021, 16263)`. Both SE 16021 and AE 16263 decompile to `void* __thiscall DecompressLipData(this)` with identical FUZE/EZUF magic handling and `this+8` stream reads.
- VR-safe: id 16021 is present in the VR address library (status 4), so it resolves on all three runtimes.
- Layout matches the binary: `vfptr@0, stream@8, eof@10, name@18`, `sizeof == 0x20`.

## Build
Clean on all five presets (se / ae / vr / flatrim / all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)