### PR TITLE
feat(vr): type BSOpenVRControllerDevice controller state

### DIFF
--- a/include/RE/B/BSOpenVRControllerDevice.h
+++ b/include/RE/B/BSOpenVRControllerDevice.h
@@ -109,15 +109,21 @@ namespace RE
 
 	private:
 #	if defined(EXCLUSIVE_SKYRIM_VR)
-		std::uint64_t unk80[0x16];  // 080
+		// Per-frame controller state, maintained by Poll() via IVRSystem (see Poll RE).
+		// prevState is rolled from currentState at the top of Poll; currentState is filled by
+		// IVRSystem::GetControllerState(deviceIndex, &currentState, sizeof(currentState)).
+		vr::VRControllerState_t prevState;     // 080 - previous frame snapshot
+		vr::VRControllerState_t currentState;  // 0C0 - current frame (GetControllerState, 0x40)
+		std::uint64_t           unk100[6];     // 100 - unidentified (0x30; size of vr::HmdMatrix34_t, possibly a cached pose)
+		// Lighthouse/Vive trackpad swipe -> analog-stick emulation state (set by Poll's axis handlers).
 		std::uint32_t unk130;       // 130
-		std::uint32_t unk134;       // 134
-		std::uint32_t unk138;       // 138
-		std::uint32_t unk13C;       // 13C
-		std::uint32_t unk140;       // 140
-		std::uint32_t unk144;       // 144
-		std::uint32_t unk148;       // 148
-		std::uint32_t unk14C;       // 14C
+		float         swipeRefX;    // 134 - swipe reference point X
+		float         swipeRefY;    // 138 - swipe reference point Y
+		float         swipeLastX;   // 13C - last swipe sample X
+		float         swipeLastY;   // 140 - last swipe sample Y
+		std::uint32_t swipeAccum;   // 144
+		bool          swipeActive;  // 148 - trackpad swipe in progress
+		std::uint32_t swipeState;   // 14C - 4 = idle/armed
 #	endif
 	};
 	STATIC_ASSERT_SIZE(BSOpenVRControllerDevice, SIZE_UNDEFINED, SIZE_UNDEFINED, 0x158, SIZE_UNDEFINED, SIZE_UNDEFINED);

--- a/include/RE/B/BSOpenVRControllerDevice.h
+++ b/include/RE/B/BSOpenVRControllerDevice.h
@@ -114,7 +114,7 @@ namespace RE
 		// IVRSystem::GetControllerState(deviceIndex, &currentState, sizeof(currentState)).
 		vr::VRControllerState_t prevState;     // 080 - previous frame snapshot
 		vr::VRControllerState_t currentState;  // 0C0 - current frame (GetControllerState, 0x40)
-		std::uint64_t           unk100[6];     // 100 - unidentified (0x30; size of vr::HmdMatrix34_t, possibly a cached pose)
+		std::uint64_t           unk100[6];     // 100 - unused/reserved (0x30; stays zero in live capture while controller is actively polled)
 		// Lighthouse/Vive trackpad swipe -> analog-stick emulation state (set by Poll's axis handlers).
 		std::uint32_t unk130;       // 130
 		float         swipeRefX;    // 134 - swipe reference point X


### PR DESCRIPTION
## What
Types the opaque `unk80[0x16]` / `unk130` block in `BSOpenVRControllerDevice` from RE of `Poll()` (vtable slot 0x02).

## RE basis
`Poll()` drives the controller each frame via `IVRSystem`:
- `GetTrackedDeviceIndexForControllerRole(role)` → device index
- `GetControllerState(idx, &currentState, 0x40)` — **confirmed** `lea r8,[this+0xC0]; mov r9d,0x40; call [rax+0x110]`
- `GetUint64TrackedDeviceProperty(Prop_SupportedButtons_Uint64 = 3001)` → press/release edge loop (diffs prev vs current `ulButtonPressed`)
- `GetInt32TrackedDeviceProperty(Prop_Axis0Type_Int32 + n = 3002+n)` → per-axis trackpad(1)/joystick(2) handling

`ClearInputState()` is `memset(this+0x80, 0, 0x80)` + swipe-state init, which confirms the two back-to-back `0x40` state buffers.

## Layout
| offset | field | notes |
|---|---|---|
| 0x80 | `vr::VRControllerState_t prevState` | previous frame (rolled from current at top of Poll) |
| 0xC0 | `vr::VRControllerState_t currentState` | `GetControllerState` target |
| 0x100 | `std::uint64_t unk100[6]` | not written by any class method; size = `vr::HmdMatrix34_t` (possible cached pose), left opaque |
| 0x130 | swipe state | lighthouse/Vive trackpad → analog-stick emulation (`swipeRefX/Y`, `swipeLastX/Y`, `swipeAccum`, `swipeActive`, `swipeState`) |

## Safety
VR-only (`EXCLUSIVE_SKYRIM_VR`); `openvr.h` is already pulled in via the base class, so non-VR builds are unaffected. Struct size/layout unchanged (`0x158`).

## Verification
All 5 release presets build clean (SE/AE/VR/Flatrim/All). The `vr` preset compiles the `EXCLUSIVE_SKYRIM_VR` block, exercising the typed fields and the `0x158` size assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated VR controller per-frame state handling to use clearer, typed fields and documented swipe-tracking lifecycle, improving readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->