### PR TITLE
feat(vr): add GetActiveCameraPosition and GetActiveTarget

### DIFF
--- a/include/RE/C/CrosshairPickData.h
+++ b/include/RE/C/CrosshairPickData.h
@@ -72,12 +72,12 @@ namespace RE
 		ObjectRefHandle                  grabPickRef[VR_DEVICE::kTotal];     // 1C
 		NiPoint3                         collisionPoint[VR_DEVICE::kTotal];  // 28
 		std::uint32_t                    pad4C;                              // 4C
-		std::uint64_t                    unk50[VR_DEVICE::kTotal];           // 50
+		bhkRigidBody*                    targetCollider[VR_DEVICE::kTotal];  // 50
 		float                            unk68;                              // 68
 		float                            unk6C;                              // 68
 		std::uint32_t                    unk70;                              // 70
 		std::uint32_t                    unk74;                              // 74
-		NiPointer<bhkSimpleShapePhantom> unk78;                              // 78
+		NiPointer<bhkSimpleShapePhantom> pickCollider;                       // 78
 		std::uint32_t                    unk80;                              // 80
 		std::uint16_t                    unk84;                              // 84
 		std::byte                        unk86;                              // 86

--- a/include/RE/C/CrosshairPickData.h
+++ b/include/RE/C/CrosshairPickData.h
@@ -3,6 +3,7 @@
 #include "RE/B/BSPointerHandle.h"
 #include "RE/N/NiPoint3.h"
 #include "RE/N/NiSmartPointer.h"
+#include "REL/Relocation.h"
 
 namespace RE
 {
@@ -30,6 +31,21 @@ namespace RE
 		{
 			static REL::Relocation<CrosshairPickData**> singleton{ RELOCATION_ID(515446, 401585) };
 			return *singleton;
+		}
+
+		[[nodiscard]] ObjectRefHandle GetActiveTarget() const
+		{
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+			return target;
+#else
+			if (REL::Module::IsVR()) {
+				if (target[VR_DEVICE::kLeftController]) return target[VR_DEVICE::kLeftController];
+				if (target[VR_DEVICE::kRightController]) return target[VR_DEVICE::kRightController];
+				if (target[VR_DEVICE::kHeadset]) return target[VR_DEVICE::kHeadset];
+				return ObjectRefHandle();
+			}
+			return target[0];
+#endif
 		}
 
 		// members

--- a/include/RE/C/CrosshairPickData.h
+++ b/include/RE/C/CrosshairPickData.h
@@ -39,9 +39,12 @@ namespace RE
 			return target;
 #else
 			if (REL::Module::IsVR()) {
-				if (target[VR_DEVICE::kLeftController]) return target[VR_DEVICE::kLeftController];
-				if (target[VR_DEVICE::kRightController]) return target[VR_DEVICE::kRightController];
-				if (target[VR_DEVICE::kHeadset]) return target[VR_DEVICE::kHeadset];
+				if (target[VR_DEVICE::kLeftController])
+					return target[VR_DEVICE::kLeftController];
+				if (target[VR_DEVICE::kRightController])
+					return target[VR_DEVICE::kRightController];
+				if (target[VR_DEVICE::kHeadset])
+					return target[VR_DEVICE::kHeadset];
 				return ObjectRefHandle();
 			}
 			return target[0];

--- a/include/RE/P/PlayerCamera.h
+++ b/include/RE/P/PlayerCamera.h
@@ -124,16 +124,16 @@ namespace RE
 
 		static PlayerCamera* GetSingleton();
 
-		bool ForceFirstPerson();
-		bool ForceThirdPerson();
-		bool IsInBleedoutMode() const;
-		bool IsInFirstPerson() const;
-		bool IsInFreeCameraMode() const;
-		bool IsInThirdPerson() const;
-		void PushCameraState(CameraState a_state);
-		void ToggleFreeCameraMode(bool a_freezeTime);
-		void Update();
-		void UpdateThirdPerson(bool a_weaponDrawn);
+		bool                          ForceFirstPerson();
+		bool                          ForceThirdPerson();
+		bool                          IsInBleedoutMode() const;
+		bool                          IsInFirstPerson() const;
+		bool                          IsInFreeCameraMode() const;
+		bool                          IsInThirdPerson() const;
+		void                          PushCameraState(CameraState a_state);
+		void                          ToggleFreeCameraMode(bool a_freezeTime);
+		void                          Update();
+		void                          UpdateThirdPerson(bool a_weaponDrawn);
 		[[nodiscard]] static NiPoint3 GetActiveCameraPosition();
 
 		RUNTIME_DATA_ACCESSOR(RUNTIME_DATA, 0x40, 0);

--- a/include/RE/P/PlayerCamera.h
+++ b/include/RE/P/PlayerCamera.h
@@ -126,6 +126,7 @@ namespace RE
 
 		bool                          ForceFirstPerson();
 		bool                          ForceThirdPerson();
+		[[nodiscard]] static NiPoint3 GetActiveCameraPosition();
 		bool                          IsInBleedoutMode() const;
 		bool                          IsInFirstPerson() const;
 		bool                          IsInFreeCameraMode() const;
@@ -134,7 +135,6 @@ namespace RE
 		void                          ToggleFreeCameraMode(bool a_freezeTime);
 		void                          Update();
 		void                          UpdateThirdPerson(bool a_weaponDrawn);
-		[[nodiscard]] static NiPoint3 GetActiveCameraPosition();
 
 		RUNTIME_DATA_ACCESSOR(RUNTIME_DATA, 0x40, 0);
 

--- a/include/RE/P/PlayerCamera.h
+++ b/include/RE/P/PlayerCamera.h
@@ -134,6 +134,7 @@ namespace RE
 		void ToggleFreeCameraMode(bool a_freezeTime);
 		void Update();
 		void UpdateThirdPerson(bool a_weaponDrawn);
+		[[nodiscard]] static NiPoint3 GetActiveCameraPosition();
 
 		RUNTIME_DATA_ACCESSOR(RUNTIME_DATA, 0x40, 0);
 

--- a/src/RE/P/PlayerCamera.cpp
+++ b/src/RE/P/PlayerCamera.cpp
@@ -92,7 +92,7 @@ namespace RE
 		if (REL::Module::IsVR()) {
 			if (auto worldRoot = RE::Main::WorldRootNode(); worldRoot && !worldRoot->GetChildren().empty()) {
 				if (auto frontNode = worldRoot->GetChildren().front()) {
-					return frontNode->local.translate;
+					return frontNode->world.translate;
 				}
 			}
 		}

--- a/src/RE/P/PlayerCamera.cpp
+++ b/src/RE/P/PlayerCamera.cpp
@@ -1,4 +1,8 @@
 #include "RE/P/PlayerCamera.h"
+#include "RE/M/Main.h"
+#include "RE/N/NiNode.h"
+#include "RE/N/NiAVObject.h"
+#include "RE/S/SceneGraph.h"
 
 namespace RE
 {
@@ -81,5 +85,20 @@ namespace RE
 		using func_t = decltype(&PlayerCamera::UpdateThirdPerson);
 		static REL::Relocation<func_t> func{ RELOCATION_ID(49908, 50841) };
 		return func(this, a_weaponDrawn);
+	}
+
+	NiPoint3 PlayerCamera::GetActiveCameraPosition()
+	{
+		if (REL::Module::IsVR()) {
+			if (auto worldRoot = RE::Main::WorldRootNode(); worldRoot && !worldRoot->GetChildren().empty()) {
+				if (auto frontNode = worldRoot->GetChildren().front()) {
+					return frontNode->local.translate;
+				}
+			}
+		}
+		if (auto pcCamera = PlayerCamera::GetSingleton(); pcCamera && pcCamera->cameraRoot) {
+			return pcCamera->cameraRoot->world.translate;
+		}
+		return NiPoint3::Zero();
 	}
 }

--- a/src/RE/P/PlayerCamera.cpp
+++ b/src/RE/P/PlayerCamera.cpp
@@ -1,7 +1,7 @@
 #include "RE/P/PlayerCamera.h"
 #include "RE/M/Main.h"
-#include "RE/N/NiNode.h"
 #include "RE/N/NiAVObject.h"
+#include "RE/N/NiNode.h"
 #include "RE/S/SceneGraph.h"
 
 namespace RE


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way to retrieve the currently active crosshair target in more situations, including VR and non-VR layouts.
  * Added a helper to get the active camera position, improving access to the camera’s current world location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->