### PR TITLE
fix(VR): correct MistMenu

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -1321,6 +1321,7 @@ set(SOURCES
 	include/RE/I/IPathBuilder.h
 	include/RE/I/IPathBuilderTracker.h
 	include/RE/I/IPostAnimationChannelUpdateFunctor.h
+	include/RE/I/IProcedureTreeExecState.h
 	include/RE/I/IProcedureTreeItem.h
 	include/RE/I/IProfilePolicy.h
 	include/RE/I/ISavePatcherInterface.h

--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -24,6 +24,7 @@ set(SOURCES
 	include/RE/A/ActorMagicCaster.h
 	include/RE/A/ActorMover.h
 	include/RE/A/ActorPackage.h
+	include/RE/A/ActorPackageData.h
 	include/RE/A/ActorSpeedChannel.h
 	include/RE/A/ActorState.h
 	include/RE/A/ActorTargetCheck.h

--- a/include/RE/A/ActorPackageData.h
+++ b/include/RE/A/ActorPackageData.h
@@ -1,0 +1,29 @@
+#pragma once
+
+namespace RE
+{
+	// Base for the per-package-type runtime data hung off ActorPackage::data (e.g.
+	// EscortActorPackageData, GuardActorPackageData, PatrolActorPackageData, SandBoxActorPackageData,
+	// UseWeaponActorPackageData, CustomActorPackageData). Holds only the vtable pointer -- derived
+	// classes append their own fields starting immediately at offset 08.
+	class ActorPackageData
+	{
+	public:
+		inline static constexpr auto RTTI = RTTI_ActorPackageData;
+		inline static constexpr auto VTABLE = VTABLE_ActorPackageData;
+
+		virtual ~ActorPackageData();  // 00
+
+		// add
+		virtual void Unk_01(void) = 0;  // 01
+		virtual void Unk_02(void);      // 02
+		virtual void Unk_03(void);      // 03
+		virtual void Unk_04(void);      // 04
+		virtual void Unk_05(void) = 0;  // 05
+		virtual void Unk_06(void) = 0;  // 06
+		virtual void Unk_07(void);      // 07
+		virtual void Unk_08(void);      // 08
+		virtual void Unk_09(void);      // 09
+	};
+	static_assert(sizeof(ActorPackageData) == 0x8);
+}

--- a/include/RE/B/BGSProcedureTreeProcedure.h
+++ b/include/RE/B/BGSProcedureTreeProcedure.h
@@ -16,11 +16,11 @@ namespace RE
 		~BGSProcedureTreeProcedure() override;  // 00
 
 		// override (BGSProcedureTreeConditionalItem)
-		void Unk_01(void) override;                // 01
-		void Unk_02(void) override;                // 02
-		void Load(TESFile* a_mod) override;        // 03
-		void Execute(void* a_execState) override;  // 04
-		void Unk_05(void) override;                // 05
+		void Unk_01(void) override;                                                // 01
+		void Unk_02(void) override;                                                // 02
+		void Load(TESFile* a_mod) override;                                        // 03
+		void Execute(IProcedureTreeItem::ExecStateContext* a_execState) override;  // 04
+		void Unk_05(void) override;                                                // 05
 		// Unk_06 tail-calls procedure->vtable[6] (executes the procedure); AVs if procedure
 		// is null (record loaded without its BGSProcedureBase, e.g. broken record / load order)
 		void Unk_06(void) override;  // 06

--- a/include/RE/B/BGSProcedureTreeProcedure.h
+++ b/include/RE/B/BGSProcedureTreeProcedure.h
@@ -16,11 +16,11 @@ namespace RE
 		~BGSProcedureTreeProcedure() override;  // 00
 
 		// override (BGSProcedureTreeConditionalItem)
-		void Unk_01(void) override;          // 01
-		void Unk_02(void) override;          // 02
-		void Load(TESFile* a_mod) override;  // 03
-		void Unk_04(void) override;          // 04
-		void Unk_05(void) override;          // 05
+		void Unk_01(void) override;                // 01
+		void Unk_02(void) override;                // 02
+		void Load(TESFile* a_mod) override;        // 03
+		void Execute(void* a_execState) override;  // 04
+		void Unk_05(void) override;                // 05
 		// Unk_06 tail-calls procedure->vtable[6] (executes the procedure); AVs if procedure
 		// is null (record loaded without its BGSProcedureBase, e.g. broken record / load order)
 		void Unk_06(void) override;  // 06

--- a/include/RE/B/BGSProcedureTreeSequence.h
+++ b/include/RE/B/BGSProcedureTreeSequence.h
@@ -14,8 +14,8 @@ namespace RE
 		~BGSProcedureTreeSequence() override;  // 00
 
 		// override (BGSProcedureTreeBranch)
-		void Execute(void* a_execState) override;  // 04
-		void Unk_06(void) override;                // 06
+		void Execute(IProcedureTreeItem::ExecStateContext* a_execState) override;  // 04
+		void Unk_06(void) override;                                                // 06
 	};
 	static_assert(sizeof(BGSProcedureTreeSequence) == 0x30);
 }

--- a/include/RE/B/BGSProcedureTreeSequence.h
+++ b/include/RE/B/BGSProcedureTreeSequence.h
@@ -14,8 +14,8 @@ namespace RE
 		~BGSProcedureTreeSequence() override;  // 00
 
 		// override (BGSProcedureTreeBranch)
-		void Unk_04(void) override;  // 04
-		void Unk_06(void) override;  // 06
+		void Execute(void* a_execState) override;  // 04
+		void Unk_06(void) override;                // 06
 	};
 	static_assert(sizeof(BGSProcedureTreeSequence) == 0x30);
 }

--- a/include/RE/I/IProcedureTreeExecState.h
+++ b/include/RE/I/IProcedureTreeExecState.h
@@ -1,0 +1,27 @@
+#pragma once
+
+namespace RE
+{
+	// Base interface for per-node AI procedure execution state.
+	// Concrete subtypes: BGSProcedureTreeOneChildExecState (branch/sequence nodes),
+	// BGSProcedureXxxExecState (leaf procedures via BGSTypedItem<T, IProcedureTreeExecState>).
+	class IProcedureTreeExecState
+	{
+	public:
+		inline static constexpr auto RTTI = RTTI_IProcedureTreeExecState;
+		inline static constexpr auto VTABLE = VTABLE_IProcedureTreeExecState;
+
+		virtual ~IProcedureTreeExecState() = default;  // 00
+
+		// add
+		virtual void Unk_01(void) = 0;  // 01
+		virtual void Unk_02(void) = 0;  // 02
+		virtual void Unk_03(void) = 0;  // 03
+		virtual void Unk_04(void) = 0;  // 04
+		virtual void Unk_05(void) = 0;  // 05 - used by ValidateExecState
+		virtual void Unk_06(void) = 0;  // 06
+		virtual void Unk_07(void);      // 07
+		virtual void Unk_08(void);      // 08
+	};
+	static_assert(sizeof(IProcedureTreeExecState) == 0x8);
+}

--- a/include/RE/I/IProcedureTreeItem.h
+++ b/include/RE/I/IProcedureTreeItem.h
@@ -6,7 +6,6 @@ namespace RE
 {
 	class Actor;
 	class ActorPackage;
-	class ActorPackageData;
 	class TESFile;
 	class TESQuest;
 
@@ -20,17 +19,20 @@ namespace RE
 		// -> FUN_1406429D0) and passed down through Execute(). No RTTI (plain struct).
 		struct ProcedureExecContext
 		{
-			Actor*            actor;         // 00
-			TESQuest*         ownerQuest;    // 08 - TESPackage::ownerQuest of the running package
-			ActorPackageData* packageData;   // 10 - one past ActorPackage::data (caller does data+1)
-			ActorPackage*     package;       // 18 - the currently executing package
-			bool              unk20;         // 20
-			bool              unk21;         // 21
-			bool              continueFlag;  // 22 - cleared before each Execute call; caller checks it after
-			std::uint8_t      pad23[5];      // 23
-			void*             manager;       // 28 - stack-local closure; vtable[1] = SetActiveProcedure(BGSProcedureBase*)
-			std::uint32_t     unk30;         // 30
-			std::uint32_t     processType;   // 34 - RE::PROCESS_TYPE in the low byte (see Character::GetActorProcessType)
+			Actor*    actor;             // 00
+			TESQuest* ownerQuest;        // 08 - TESPackage::ownerQuest of the running package
+			void*     packageDataTail;   // 10 - ActorPackage::data cast past ActorPackageData's 8-byte vtable
+										 //      ptr; points to the concrete subclass's own fields (e.g.
+										 //      EscortActorPackageData, GuardActorPackageData) -- type depends
+										 //      on the running package's PACKAGE_PROCEDURE_TYPE
+			ActorPackage* package;       // 18 - the currently executing package
+			bool          unk20;         // 20
+			bool          unk21;         // 21
+			bool          continueFlag;  // 22 - cleared before each Execute call; caller checks it after
+			std::uint8_t  pad23[5];      // 23
+			void*         manager;       // 28 - stack-local closure; vtable[1] = SetActiveProcedure(BGSProcedureBase*)
+			std::uint32_t unk30;         // 30
+			std::uint32_t processType;   // 34 - RE::PROCESS_TYPE in the low byte (see Character::GetActorProcessType)
 		};
 		static_assert(sizeof(ProcedureExecContext) == 0x38);
 

--- a/include/RE/I/IProcedureTreeItem.h
+++ b/include/RE/I/IProcedureTreeItem.h
@@ -12,14 +12,11 @@ namespace RE
 		inline static constexpr auto RTTI = RTTI_IProcedureTreeItem;
 		inline static constexpr auto VTABLE = VTABLE_IProcedureTreeItem;
 
-		// Opaque context passed to Execute(). Binary layout (anonymous struct, no RTTI):
-		//   [0x00] void* context  — plain struct: Actor* at [0x00], bool interruptFlag at [0x21],
-		//                           exec-state manager object at [0x28] (vtable[1] = SetActiveProcedure)
-		//   [0x08] IProcedureTreeExecState* nodeState — node-specific state (e.g. BGSProcedureTreeOneChildExecState)
+		// Opaque context passed to Execute(). Anonymous struct, no RTTI.
 		struct ExecStateContext
 		{
-			void*                    context;    // [0x00]
-			IProcedureTreeExecState* nodeState;  // [0x08]
+			void*                    context;    // 00 - plain struct: Actor* at 00, bool interruptFlag at 21, exec-state manager at 28 (vtable[1] = SetActiveProcedure)
+			IProcedureTreeExecState* nodeState;  // 08 - node-specific state (e.g. BGSProcedureTreeOneChildExecState)
 		};
 		static_assert(sizeof(ExecStateContext) == 0x10);
 

--- a/include/RE/I/IProcedureTreeItem.h
+++ b/include/RE/I/IProcedureTreeItem.h
@@ -19,20 +19,22 @@ namespace RE
 		// -> FUN_1406429D0) and passed down through Execute(). No RTTI (plain struct).
 		struct ProcedureExecContext
 		{
-			Actor*    actor;             // 00
-			TESQuest* ownerQuest;        // 08 - TESPackage::ownerQuest of the running package
-			void*     packageDataTail;   // 10 - ActorPackage::data cast past ActorPackageData's 8-byte vtable
-										 //      ptr; points to the concrete subclass's own fields (e.g.
-										 //      EscortActorPackageData, GuardActorPackageData) -- type depends
-										 //      on the running package's PACKAGE_PROCEDURE_TYPE
-			ActorPackage* package;       // 18 - the currently executing package
-			bool          unk20;         // 20
-			bool          unk21;         // 21
-			bool          continueFlag;  // 22 - cleared before each Execute call; caller checks it after
-			std::uint8_t  pad23[5];      // 23
-			void*         manager;       // 28 - stack-local closure; vtable[1] = SetActiveProcedure(BGSProcedureBase*)
-			std::uint32_t unk30;         // 30
-			std::uint32_t processType;   // 34 - RE::PROCESS_TYPE in the low byte (see Character::GetActorProcessType)
+			Actor*    actor;                  // 00
+			TESQuest* ownerQuest;             // 08 - TESPackage::ownerQuest of the running package
+			void*     packageDataTail;        // 10 - ActorPackage::data cast past ActorPackageData's 8-byte vtable
+											  //      ptr; points to the concrete subclass's own fields (e.g.
+											  //      EscortActorPackageData, GuardActorPackageData) -- type depends
+											  //      on the running package's PACKAGE_PROCEDURE_TYPE
+			ActorPackage* package;            // 18 - the currently executing package
+			bool          unk20;              // 20 - usually 0; propagated from an outer bool param in one caller
+			bool          recheckConditions;  // 21 - constant true in normal AI-tick callers; computed from
+											  //      TESCustomPackageData::alwaysRecheckConditions in one caller;
+											  //      false in the query-only GameFunc::IsWarningAbout
+			bool          continueFlag;       // 22 - cleared before each Execute call; caller checks it after
+			std::uint8_t  pad23[5];           // 23
+			void*         manager;            // 28 - stack-local closure; vtable[1] = SetActiveProcedure(BGSProcedureBase*)
+			float         deltaTime;          // 30 - gSecondsSinceLastFrame_WorldTime at every observed call site
+			std::uint32_t processType;        // 34 - RE::PROCESS_TYPE in the low byte (see Character::GetActorProcessType)
 		};
 		static_assert(sizeof(ProcedureExecContext) == 0x38);
 

--- a/include/RE/I/IProcedureTreeItem.h
+++ b/include/RE/I/IProcedureTreeItem.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "RE/I/IProcedureTreeExecState.h"
+
 namespace RE
 {
 	class TESFile;
@@ -10,25 +12,36 @@ namespace RE
 		inline static constexpr auto RTTI = RTTI_IProcedureTreeItem;
 		inline static constexpr auto VTABLE = VTABLE_IProcedureTreeItem;
 
+		// Opaque context passed to Execute(). Binary layout (anonymous struct, no RTTI):
+		//   [0x00] void* context  — plain struct: Actor* at [0x00], bool interruptFlag at [0x21],
+		//                           exec-state manager object at [0x28] (vtable[1] = SetActiveProcedure)
+		//   [0x08] IProcedureTreeExecState* nodeState — node-specific state (e.g. BGSProcedureTreeOneChildExecState)
+		struct ExecStateContext
+		{
+			void*                    context;    // [0x00]
+			IProcedureTreeExecState* nodeState;  // [0x08]
+		};
+		static_assert(sizeof(ExecStateContext) == 0x10);
+
 		virtual ~IProcedureTreeItem();  // 00
 
 		// add
-		virtual void Unk_01(void) = 0;                // 01
-		virtual void Unk_02(void) = 0;                // 02
-		virtual void Load(TESFile* a_mod) = 0;        // 03
-		virtual void Execute(void* a_execState) = 0;  // 04
-		virtual void Unk_05(void) = 0;                // 05
-		virtual void Unk_06(void) = 0;                // 06
-		virtual void Unk_07(void) = 0;                // 07
-		virtual void Unk_08(void);                    // 08
-		virtual void Unk_09(void);                    // 09
-		virtual void Unk_0A(void) = 0;                // 0A
-		virtual void Unk_0B(void) = 0;                // 0B
-		virtual void Unk_0C(void) = 0;                // 0C
-		virtual void Unk_0D(void) = 0;                // 0D
-		virtual void Unk_0E(void) = 0;                // 0E
-		virtual void Unk_0F(void) = 0;                // 0F
-		virtual void Unk_10(void) = 0;                // 10
+		virtual void Unk_01(void) = 0;                            // 01
+		virtual void Unk_02(void) = 0;                            // 02
+		virtual void Load(TESFile* a_mod) = 0;                    // 03
+		virtual void Execute(ExecStateContext* a_execState) = 0;  // 04
+		virtual void Unk_05(void) = 0;                            // 05
+		virtual void Unk_06(void) = 0;                            // 06
+		virtual void Unk_07(void) = 0;                            // 07
+		virtual void Unk_08(void);                                // 08
+		virtual void Unk_09(void);                                // 09
+		virtual void Unk_0A(void) = 0;                            // 0A
+		virtual void Unk_0B(void) = 0;                            // 0B
+		virtual void Unk_0C(void) = 0;                            // 0C
+		virtual void Unk_0D(void) = 0;                            // 0D
+		virtual void Unk_0E(void) = 0;                            // 0E
+		virtual void Unk_0F(void) = 0;                            // 0F
+		virtual void Unk_10(void) = 0;                            // 10
 	};
 	static_assert(sizeof(IProcedureTreeItem) == 0x8);
 }

--- a/include/RE/I/IProcedureTreeItem.h
+++ b/include/RE/I/IProcedureTreeItem.h
@@ -4,7 +4,11 @@
 
 namespace RE
 {
+	class Actor;
+	class ActorPackage;
+	class ActorPackageData;
 	class TESFile;
+	class TESQuest;
 
 	class IProcedureTreeItem
 	{
@@ -12,10 +16,28 @@ namespace RE
 		inline static constexpr auto RTTI = RTTI_IProcedureTreeItem;
 		inline static constexpr auto VTABLE = VTABLE_IProcedureTreeItem;
 
-		// Opaque context passed to Execute(). Anonymous struct, no RTTI.
+		// Per-invocation execution context, built on the caller's stack (e.g. SE Character::sub_1405E20D0
+		// -> FUN_1406429D0) and passed down through Execute(). No RTTI (plain struct).
+		struct ProcedureExecContext
+		{
+			Actor*            actor;         // 00
+			TESQuest*         ownerQuest;    // 08 - TESPackage::ownerQuest of the running package
+			ActorPackageData* packageData;   // 10 - one past ActorPackage::data (caller does data+1)
+			ActorPackage*     package;       // 18 - the currently executing package
+			bool              unk20;         // 20
+			bool              unk21;         // 21
+			bool              continueFlag;  // 22 - cleared before each Execute call; caller checks it after
+			std::uint8_t      pad23[5];      // 23
+			void*             manager;       // 28 - stack-local closure; vtable[1] = SetActiveProcedure(BGSProcedureBase*)
+			std::uint32_t     unk30;         // 30
+			std::uint32_t     processType;   // 34 - RE::PROCESS_TYPE in the low byte (see Character::GetActorProcessType)
+		};
+		static_assert(sizeof(ProcedureExecContext) == 0x38);
+
+		// Opaque pair passed to Execute().
 		struct ExecStateContext
 		{
-			void*                    context;    // 00 - plain struct: Actor* at 00, bool interruptFlag at 21, exec-state manager at 28 (vtable[1] = SetActiveProcedure)
+			ProcedureExecContext*    context;    // 00
 			IProcedureTreeExecState* nodeState;  // 08 - node-specific state (e.g. BGSProcedureTreeOneChildExecState)
 		};
 		static_assert(sizeof(ExecStateContext) == 0x10);

--- a/include/RE/I/IProcedureTreeItem.h
+++ b/include/RE/I/IProcedureTreeItem.h
@@ -13,22 +13,22 @@ namespace RE
 		virtual ~IProcedureTreeItem();  // 00
 
 		// add
-		virtual void Unk_01(void) = 0;          // 01
-		virtual void Unk_02(void) = 0;          // 02
-		virtual void Load(TESFile* a_mod) = 0;  // 03
-		virtual void Unk_04(void) = 0;          // 04
-		virtual void Unk_05(void) = 0;          // 05
-		virtual void Unk_06(void) = 0;          // 06
-		virtual void Unk_07(void) = 0;          // 07
-		virtual void Unk_08(void);              // 08
-		virtual void Unk_09(void);              // 09
-		virtual void Unk_0A(void) = 0;          // 0A
-		virtual void Unk_0B(void) = 0;          // 0B
-		virtual void Unk_0C(void) = 0;          // 0C
-		virtual void Unk_0D(void) = 0;          // 0D
-		virtual void Unk_0E(void) = 0;          // 0E
-		virtual void Unk_0F(void) = 0;          // 0F
-		virtual void Unk_10(void) = 0;          // 10
+		virtual void Unk_01(void) = 0;                // 01
+		virtual void Unk_02(void) = 0;                // 02
+		virtual void Load(TESFile* a_mod) = 0;        // 03
+		virtual void Execute(void* a_execState) = 0;  // 04
+		virtual void Unk_05(void) = 0;                // 05
+		virtual void Unk_06(void) = 0;                // 06
+		virtual void Unk_07(void) = 0;                // 07
+		virtual void Unk_08(void);                    // 08
+		virtual void Unk_09(void);                    // 09
+		virtual void Unk_0A(void) = 0;                // 0A
+		virtual void Unk_0B(void) = 0;                // 0B
+		virtual void Unk_0C(void) = 0;                // 0C
+		virtual void Unk_0D(void) = 0;                // 0D
+		virtual void Unk_0E(void) = 0;                // 0E
+		virtual void Unk_0F(void) = 0;                // 0F
+		virtual void Unk_10(void) = 0;                // 10
 	};
 	static_assert(sizeof(IProcedureTreeItem) == 0x8);
 }

--- a/include/RE/M/MistMenu.h
+++ b/include/RE/M/MistMenu.h
@@ -58,13 +58,13 @@ namespace RE
 	std::uint32_t                   unk0A0;                        /* 0A0 */                            \
 	std::uint32_t                   unk0A4;                        /* 0A4 */                            \
 	std::uint64_t                   unk0A8;                        /* 0A8 */                            \
-	NiPointer<NiNode>               mistModel;                     /* 0B0 - smart ptr */                \
+	NiPointer<NiNode>               mistModel;                     /* 0B0 */                            \
 	ModelDBHandle                   mistModelDBHandle;             /* 0B8 */                            \
 	ModelDBHandle                   loadScreenModelHandle;         /* 0C0 */                            \
 	NiPointer<BSFadeNode>           cameraPath;                    /* 0C8 - parent of cameraPathNode */ \
-	NiPointer<NiNode>               cameraPathNode;                /* 0D0 - smart ptr */                \
-	NiPointer<NiControllerSequence> cameraPathSequence;            /* 0D8 - smart ptr */                \
-	NiPointer<NiControllerManager>  cameraPathController;          /* 0E0 - smart ptr */                \
+	NiPointer<NiNode>               cameraPathNode;                /* 0D0 */                            \
+	NiPointer<NiControllerSequence> cameraPathSequence;            /* 0D8 */                            \
+	NiPointer<NiControllerManager>  cameraPathController;          /* 0E0 */                            \
 	BSLightingShaderProperty*       logoShaderProperty;            /* 0E8 - default logo only */        \
 	NiPointer<BSFadeNode>           loadScreenModel;               /* 0F0 */                            \
 	ImageSpaceBaseData*             originalImageSpace;            /* 0F8 - imagespacedata? */          \
@@ -87,30 +87,27 @@ namespace RE
 		};
 		static_assert(sizeof(RUNTIME_DATA) == 0xE8);
 
-		// VR appends deferred load-screen-model setup state past the shared RUNTIME_DATA (at +0x150): the
-		// model NIF streams in asynchronously, so SetupLoadScreenModel3D stashes the InitLoadScreen3D
-		// transform here and AdvanceMovie replays setup once the model lands. Absent on SE/AE (which load
-		// the model synchronously). Reachable in any build via GetVRRuntimeData().
+		// VR-only tail: model loads async (SE/AE sync), so SetupLoadScreenModel3D stashes the transform here until AdvanceMovie can replay InitLoadScreen3D.
 		struct VR_RUNTIME_DATA
 		{
-#define VR_RUNTIME_DATA_CONTENT                                                                                              \
-	std::uint32_t     unk150;                  /* 150 */                                                                     \
-	std::uint32_t     pad154;                  /* 154 */                                                                     \
-	NiPointer<NiNode> unk158;                  /* 158 - NiPointer, released on camera-path teardown */                       \
-	NiPointer<NiNode> unk160;                  /* 160 - NiPointer, released on camera-path teardown */                       \
-	bool              deferredSetupNeeded;     /* 168 - set when the load-screen model NIF is not yet loaded */              \
-	std::uint8_t      pad169[0x3];             /* 169 */                                                                     \
-	float             stashedModelScale;       /* 16C */                                                                     \
-	NiPoint3          stashedRotateOffset;     /* 170 */                                                                     \
-	NiPoint3          stashedTranslateOffset;  /* 17C */                                                                     \
-	NiPoint3          unk188;                  /* 188 */                                                                     \
-	NiPoint3          unk194;                  /* 194 */                                                                     \
-	bool              cameraPathActive;        /* 1A0 - set once the camera path is initialized, guards teardown */          \
-	bool              loadScreenModelReady;    /* 1A1 - set once the model is loaded and set up */                           \
-	bool              loadScreen3DInitialized; /* 1A2 - set after InitLoadScreen3D runs on the model */                      \
-	bool              suppressPostDisplay;     /* 1A3 - when set, PostDisplay skips rendering if item menus are open */      \
-	bool              cameraSequenceEnabled;   /* 1A4 - enables camera path animation; default true */                       \
-	bool              resetCameraTimer;        /* 1A5 - cleared by AdvanceMovie after resetting the camera sequence timer */ \
+#define VR_RUNTIME_DATA_CONTENT                          \
+	std::uint32_t     unk150;                  /* 150 */ \
+	std::uint32_t     pad154;                  /* 154 */ \
+	NiPointer<NiNode> unk158;                  /* 158 */ \
+	NiPointer<NiNode> unk160;                  /* 160 */ \
+	bool              deferredSetupNeeded;     /* 168 */ \
+	std::uint8_t      pad169[0x3];             /* 169 */ \
+	float             stashedModelScale;       /* 16C */ \
+	NiPoint3          stashedRotateOffset;     /* 170 */ \
+	NiPoint3          stashedTranslateOffset;  /* 17C */ \
+	NiPoint3          unk188;                  /* 188 */ \
+	NiPoint3          unk194;                  /* 194 */ \
+	bool              cameraPathActive;        /* 1A0 */ \
+	bool              loadScreenModelReady;    /* 1A1 */ \
+	bool              loadScreen3DInitialized; /* 1A2 */ \
+	bool              suppressPostDisplay;     /* 1A3 */ \
+	bool              cameraSequenceEnabled;   /* 1A4 */ \
+	bool              resetCameraTimer;        /* 1A5 */ \
 	std::uint8_t      pad1A6[2];               /* 1A6 */
 
 			VR_RUNTIME_DATA_CONTENT
@@ -139,8 +136,7 @@ namespace RE
 
 		RUNTIME_DATA_ACCESSOR(RUNTIME_DATA, 0x58, 0x68);
 
-		// VR-only tail accessor; returns nullptr on SE/AE. Works in every build (incl. cross-VR) since it
-		// resolves the absolute VR offset rather than relying on inline members.
+		// Returns nullptr on SE/AE; uses absolute VR offset so it works in cross-VR builds too.
 		[[nodiscard]] inline VR_RUNTIME_DATA* GetVRRuntimeData() noexcept
 		{
 			if SKYRIM_REL_VR_CONSTEXPR (REL::Module::IsVR()) {

--- a/include/RE/M/MistMenu.h
+++ b/include/RE/M/MistMenu.h
@@ -93,7 +93,7 @@ namespace RE
 		// the model synchronously). Reachable in any build via GetVRRuntimeData().
 		struct VR_RUNTIME_DATA
 		{
-#define VR_RUNTIME_DATA_CONTENT                                                                              \
+#define VR_RUNTIME_DATA_CONTENT                                                                             \
 	std::uint8_t  unk150[0x18];            /* 150 */                                                        \
 	bool          deferredSetupNeeded;     /* 168 - set when the load-screen model NIF is not yet loaded */ \
 	std::uint8_t  pad169[0x3];             /* 169 */                                                        \
@@ -105,7 +105,7 @@ namespace RE
 	std::uint8_t  unk1A0;                  /* 1A0 */                                                        \
 	bool          loadScreenModelReady;    /* 1A1 - set once the model is loaded and set up */              \
 	bool          loadScreen3DInitialized; /* 1A2 - set after InitLoadScreen3D runs on the model */         \
-	std::uint8_t  unk1A3;                  /* 1A3 */                                                         \
+	std::uint8_t  unk1A3;                  /* 1A3 */                                                        \
 	std::uint32_t unk1A4;                  /* 1A4 */
 
 			VR_RUNTIME_DATA_CONTENT

--- a/include/RE/M/MistMenu.h
+++ b/include/RE/M/MistMenu.h
@@ -166,15 +166,7 @@ namespace RE
 #	endif
 #endif
 	};
-#ifndef SKYRIM_CROSS_VR
-#	if defined(EXCLUSIVE_SKYRIM_VR)
-	static_assert(sizeof(MistMenu) == 0x1A8);
-#	else
-	static_assert(sizeof(MistMenu) == 0x140);
-#	endif
-#else
-	static_assert(sizeof(MistMenu) == 0x30);
-#endif
+	STATIC_ASSERT_SIZE(MistMenu, 0x140, 0x140, 0x1A8, 0x30);
 }
 #undef RUNTIME_DATA_CONTENT
 #undef VR_RUNTIME_DATA_CONTENT

--- a/include/RE/M/MistMenu.h
+++ b/include/RE/M/MistMenu.h
@@ -93,8 +93,8 @@ namespace RE
 #define VR_RUNTIME_DATA_CONTENT                          \
 	std::uint32_t     unk150;                  /* 150 */ \
 	std::uint32_t     pad154;                  /* 154 */ \
-	NiPointer<NiNode> unk158;                  /* 158 */ \
-	NiPointer<NiNode> unk160;                  /* 160 */ \
+	NiPointer<NiNode> loadScreen3DModelNode;   /* 158 */ \
+	NiPointer<NiNode> loadScreen3DSceneNode;   /* 160 */ \
 	bool              deferredSetupNeeded;     /* 168 */ \
 	std::uint8_t      pad169[0x3];             /* 169 */ \
 	float             stashedModelScale;       /* 16C */ \

--- a/include/RE/M/MistMenu.h
+++ b/include/RE/M/MistMenu.h
@@ -5,6 +5,7 @@
 #include "RE/M/MenuEventHandler.h"
 #include "RE/N/NiColor.h"
 #include "RE/N/NiMatrix3.h"
+#include "RE/N/NiPoint3.h"
 #include "RE/S/SimpleAnimationGraphManagerHolder.h"
 #include "REL/RuntimeDataAccessors.h"
 
@@ -86,6 +87,31 @@ namespace RE
 		};
 		static_assert(sizeof(RUNTIME_DATA) == 0xE8);
 
+		// VR appends deferred load-screen-model setup state past the shared RUNTIME_DATA (at +0x150): the
+		// model NIF streams in asynchronously, so SetupLoadScreenModel3D stashes the InitLoadScreen3D
+		// transform here and AdvanceMovie replays setup once the model lands. Absent on SE/AE (which load
+		// the model synchronously). Reachable in any build via GetVRRuntimeData().
+		struct VR_RUNTIME_DATA
+		{
+#define VR_RUNTIME_DATA_CONTENT                                                                              \
+	std::uint8_t  unk150[0x18];            /* 150 */                                                        \
+	bool          deferredSetupNeeded;     /* 168 - set when the load-screen model NIF is not yet loaded */ \
+	std::uint8_t  pad169[0x3];             /* 169 */                                                        \
+	float         stashedModelScale;       /* 16C */                                                        \
+	NiPoint3      stashedRotateOffset;     /* 170 */                                                        \
+	NiPoint3      stashedTranslateOffset;  /* 17C */                                                        \
+	NiPoint3      unk188;                  /* 188 */                                                        \
+	NiPoint3      unk194;                  /* 194 */                                                        \
+	std::uint8_t  unk1A0;                  /* 1A0 */                                                        \
+	bool          loadScreenModelReady;    /* 1A1 - set once the model is loaded and set up */              \
+	bool          loadScreen3DInitialized; /* 1A2 - set after InitLoadScreen3D runs on the model */         \
+	std::uint8_t  unk1A3;                  /* 1A3 */                                                         \
+	std::uint32_t unk1A4;                  /* 1A4 */
+
+			VR_RUNTIME_DATA_CONTENT
+		};
+		static_assert(sizeof(VR_RUNTIME_DATA) == 0x58);
+
 		~MistMenu() override;  // 00
 
 		// override (IMenu)
@@ -107,6 +133,25 @@ namespace RE
 #endif
 
 		RUNTIME_DATA_ACCESSOR(RUNTIME_DATA, 0x58, 0x68);
+
+		// VR-only tail accessor; returns nullptr on SE/AE. Works in every build (incl. cross-VR) since it
+		// resolves the absolute VR offset rather than relying on inline members.
+		[[nodiscard]] inline VR_RUNTIME_DATA* GetVRRuntimeData() noexcept
+		{
+			if SKYRIM_REL_VR_CONSTEXPR (REL::Module::IsVR()) {
+				return &REL::RelocateMember<VR_RUNTIME_DATA>(this, 0, 0x150);
+			}
+			return nullptr;
+		}
+
+		[[nodiscard]] inline const VR_RUNTIME_DATA* GetVRRuntimeData() const noexcept
+		{
+			if SKYRIM_REL_VR_CONSTEXPR (REL::Module::IsVR()) {
+				return &REL::RelocateMember<VR_RUNTIME_DATA>(this, 0, 0x150);
+			}
+			return nullptr;
+		}
+
 		[[nodiscard]] static MistMenu* GetSingleton()
 		{
 			static REL::Relocation<MistMenu**> singleton{ RELOCATION_ID(519827, 406370) };
@@ -116,8 +161,20 @@ namespace RE
 		// members
 #ifndef SKYRIM_CROSS_VR
 		RUNTIME_DATA_CONTENT;  // 58, 68
+#	if defined(EXCLUSIVE_SKYRIM_VR)
+		VR_RUNTIME_DATA_CONTENT;  // 150
+#	endif
 #endif
 	};
-	STATIC_ASSERT_SIZE(MistMenu, 0x140, 0x140, 0x150, 0x30);
+#ifndef SKYRIM_CROSS_VR
+#	if defined(EXCLUSIVE_SKYRIM_VR)
+	static_assert(sizeof(MistMenu) == 0x1A8);
+#	else
+	static_assert(sizeof(MistMenu) == 0x140);
+#	endif
+#else
+	static_assert(sizeof(MistMenu) == 0x30);
+#endif
 }
 #undef RUNTIME_DATA_CONTENT
+#undef VR_RUNTIME_DATA_CONTENT

--- a/include/RE/M/MistMenu.h
+++ b/include/RE/M/MistMenu.h
@@ -93,20 +93,25 @@ namespace RE
 		// the model synchronously). Reachable in any build via GetVRRuntimeData().
 		struct VR_RUNTIME_DATA
 		{
-#define VR_RUNTIME_DATA_CONTENT                                                                             \
-	std::uint8_t  unk150[0x18];            /* 150 */                                                        \
-	bool          deferredSetupNeeded;     /* 168 - set when the load-screen model NIF is not yet loaded */ \
-	std::uint8_t  pad169[0x3];             /* 169 */                                                        \
-	float         stashedModelScale;       /* 16C */                                                        \
-	NiPoint3      stashedRotateOffset;     /* 170 */                                                        \
-	NiPoint3      stashedTranslateOffset;  /* 17C */                                                        \
-	NiPoint3      unk188;                  /* 188 */                                                        \
-	NiPoint3      unk194;                  /* 194 */                                                        \
-	std::uint8_t  unk1A0;                  /* 1A0 */                                                        \
-	bool          loadScreenModelReady;    /* 1A1 - set once the model is loaded and set up */              \
-	bool          loadScreen3DInitialized; /* 1A2 - set after InitLoadScreen3D runs on the model */         \
-	std::uint8_t  unk1A3;                  /* 1A3 */                                                        \
-	std::uint32_t unk1A4;                  /* 1A4 */
+#define VR_RUNTIME_DATA_CONTENT                                                                                              \
+	std::uint32_t     unk150;                  /* 150 */                                                                     \
+	std::uint32_t     pad154;                  /* 154 */                                                                     \
+	NiPointer<NiNode> unk158;                  /* 158 - NiPointer, released on camera-path teardown */                       \
+	NiPointer<NiNode> unk160;                  /* 160 - NiPointer, released on camera-path teardown */                       \
+	bool              deferredSetupNeeded;     /* 168 - set when the load-screen model NIF is not yet loaded */              \
+	std::uint8_t      pad169[0x3];             /* 169 */                                                                     \
+	float             stashedModelScale;       /* 16C */                                                                     \
+	NiPoint3          stashedRotateOffset;     /* 170 */                                                                     \
+	NiPoint3          stashedTranslateOffset;  /* 17C */                                                                     \
+	NiPoint3          unk188;                  /* 188 */                                                                     \
+	NiPoint3          unk194;                  /* 194 */                                                                     \
+	bool              cameraPathActive;        /* 1A0 - set once the camera path is initialized, guards teardown */          \
+	bool              loadScreenModelReady;    /* 1A1 - set once the model is loaded and set up */                           \
+	bool              loadScreen3DInitialized; /* 1A2 - set after InitLoadScreen3D runs on the model */                      \
+	bool              suppressPostDisplay;     /* 1A3 - when set, PostDisplay skips rendering if item menus are open */      \
+	bool              cameraSequenceEnabled;   /* 1A4 - enables camera path animation; default true */                       \
+	bool              resetCameraTimer;        /* 1A5 - cleared by AdvanceMovie after resetting the camera sequence timer */ \
+	std::uint8_t      pad1A6[2];               /* 1A6 */
 
 			VR_RUNTIME_DATA_CONTENT
 		};

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -27,6 +27,7 @@
 #include "RE/A/ActorMagicCaster.h"
 #include "RE/A/ActorMover.h"
 #include "RE/A/ActorPackage.h"
+#include "RE/A/ActorPackageData.h"
 #include "RE/A/ActorSpeedChannel.h"
 #include "RE/A/ActorState.h"
 #include "RE/A/ActorTargetCheck.h"

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -1323,6 +1323,7 @@
 #include "RE/I/IPathBuilder.h"
 #include "RE/I/IPathBuilderTracker.h"
 #include "RE/I/IPostAnimationChannelUpdateFunctor.h"
+#include "RE/I/IProcedureTreeExecState.h"
 #include "RE/I/IProcedureTreeItem.h"
 #include "RE/I/IProfilePolicy.h"
 #include "RE/I/ISavePatcherInterface.h"


### PR DESCRIPTION
## Summary
The **VR** layout of `RE::MistMenu` is **0x1A8**, but it was asserted at `0x150`. Past the shared `RUNTIME_DATA`, VR appends deferred load-screen-model setup state (the load-screen model NIF streams in asynchronously, unlike SE/AE which load it synchronously): `MistMenu::SetupLoadScreenModel3D` stashes the `InitLoadScreen3D` transform there and `AdvanceMovie` replays setup once the model lands.

## Changes
- Add `VR_RUNTIME_DATA` (the `0x58` tail) + `GetVRRuntimeData()` accessor (the `BSShaderAccumulator` idiom), so the tail is reachable in **cross-VR** builds, not only `EXCLUSIVE_SKYRIM_VR`. Returns `nullptr` on SE/AE.
- Add the `EXCLUSIVE_SKYRIM_VR` inline `VR_RUNTIME_DATA_CONTENT` and an explicit per-preset `static_assert` (VR `0x1A8` / flat `0x140` / cross-VR `0x30`), modeled on `HUDMenu.h`/`BSShaderAccumulator.h`.
- SE/AE unchanged (`0x140`).

## How the size/offsets were derived (RE)
- The menu factory `MistMenu::CreateMenu` (VR `0x1408dc610`) allocates **`0x1A8`**; the constructor (`0x1408d9af0`) writes through `+0x1A4`.
- Tail fields mapped from the constructor defaults + `SetupLoadScreenModel3D`/`AdvanceMovie` (VR 1.4.15). A couple of sub-regions remain `unk`/padding; the deferred flag (`+0x168`), stashed transform (`+0x16C`/`+0x170`/`+0x17C`), and ready flags (`+0x1A1`/`+0x1A2`) are confirmed.
- SE (1.5.97) and AE (1.6.1170) allocate `0x140` (matches the existing assert).

## Testing
- The tail layout compiles to exactly `0x58` (`static_assert(sizeof(VR_RUNTIME_DATA) == 0x58)`), giving `0x150 + 0x58 = 0x1A8`.
- Verified accessible in a cross-VR (`all`) consumer build: `mistMenu->GetVRRuntimeData()->loadScreenModelReady` compiles and resolves under `SKYRIM_CROSS_VR`.
- Please confirm the full preset matrix (vr/flatrim/all) in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VR-only runtime support to the Mist menu, exposing additional VR-specific runtime UI data and `[[nodiscard]]` accessors.
* **Behavior Changes**
  * Updated the procedure tree execution interface: replaced the previous `Unk_04(void)` override with a new `Execute(...)` context-based execution method across affected types.
  * Introduced a dedicated execution-state interface for per-node procedure tree handling.
* **Build/Chores**
  * Included the new execution-state header in the build.
  * Updated the OpenVR submodule revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->