### PR TITLE
feat(vr): name PlayerCharacter::UpdateVRComfortCheck and vrComfortFadeActive

### DIFF
--- a/include/RE/P/PlayerCharacter.h
+++ b/include/RE/P/PlayerCharacter.h
@@ -450,7 +450,7 @@ namespace RE
 			bool unk6_5: 1;                                                                // 6:5
 			bool unk6_6: 1;                                                                // 6:6
 			bool unk6_7: 1;                                                                // 6:7
-			bool unk7_0: 1;                                                                // 7:0
+			bool vrComfortFadeActive: 1;                                                   // 7:0 - Set/cleared by PlayerCharacter::UpdateVRComfortCheck's per-frame comfort-radius Havok collision test (normally around the player's head; retargeted at DialogueMenu::occlusionCheckNode's position while a dialogue is open). Drives the VR comfort screen-fade-to-black. VR only.
 			bool unk7_1: 1;                                                                // 7:1
 			bool unk7_2: 1;                                                                // 7:2
 			bool unk7_3: 1;                                                                // 7:3
@@ -742,7 +742,13 @@ namespace RE
 		void                                   SetGodMode(bool a_enable);
 		void                                   StartGrabObject(VR_DEVICE a_device = VR_DEVICE::kLeftController);
 		void                                   UpdateCrosshairs();
-		void                                   UsePoisonFromInventory(AlchemyItem* a_poison);
+		// Per-frame VR comfort-radius Havok collision check; sets/clears playerFlags.vrComfortFadeActive.
+		// Normally casts around the player's head (radius fPlayerComfortRadiusMeters:VRTeleport);
+		// retargets at DialogueMenu::occlusionCheckNode's world position (radius
+		// fPlayerDialogueMenuOcclusionCheckSize:VRUI) while the dialogue menu is open and no other
+		// blocking menu (container/barter/training/gift) is open. No-op outside VR.
+		void UpdateVRComfortCheck();
+		void UsePoisonFromInventory(AlchemyItem* a_poison);
 
 		RUNTIME_CAST_ACCESSOR_VERSIONED(BSTEventSource<BGSActorCellEvent>, AsBGSActorCellEventSource, SKSE::RUNTIME_SSE_1_6_629, 0x2D0, 0x2D8)
 

--- a/src/RE/P/PlayerCharacter.cpp
+++ b/src/RE/P/PlayerCharacter.cpp
@@ -259,6 +259,15 @@ namespace RE
 		return func(this);
 	}
 
+	void PlayerCharacter::UpdateVRComfortCheck()
+	{
+		if (REL::Module::IsVR()) {
+			using func_t = decltype(&PlayerCharacter::UpdateVRComfortCheck);
+			static REL::Relocation<func_t> func{ REL::VariantID(0, 0, 0x6B9AA0) };
+			func(this);
+		}
+	}
+
 	void PlayerCharacter::UsePoisonFromInventory(AlchemyItem* a_poison)
 	{
 		using func_t = decltype(&PlayerCharacter::UsePoisonFromInventory);


### PR DESCRIPTION
## Summary
- Ports RE from the legacy `vr` branch (commit c23303a) forward to `ng`: names `PlayerCharacter::UpdateVRComfortCheck` and the `playerFlags` bit it drives (`unk7_0` -> `vrComfortFadeActive`)
- Converts the legacy single-runtime `#ifdef SKYRIMVR` + `REL::Offset(...)` form to `ng`'s cross-runtime convention: unconditional declaration, `REL::Module::IsVR()` runtime dispatch, `REL::VariantID(0, 0, vrOffset)` resolution -- matches the existing `PlayerCamera::UpdateYaw` precedent
- Per-frame VR comfort-radius Havok collision check; normally casts around the player's head, retargets at `DialogueMenu::occlusionCheckNode`'s position while a dialogue is open (found while tracking a VR dialogue-menu black-screen issue)

## Test plan
- [x] All 5 presets build clean (`scripts\build-all-presets.cmd`): se, ae, vr, flatrim, and the cross-runtime `all` build
- [x] `SE`/`AE` resolve `VariantID`'s zero id to a no-op (function never calls through); `VR` and cross-runtime `all` resolve the real offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuM742GiWFKuK1c7DgwYTi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a VR-specific comfort check that helps manage fade-to-black behavior during gameplay.
  * Improved handling for dialogue menu targeting in VR, while remaining inactive in non-VR play.
  * Renamed an internal VR-related flag for clearer behavior tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->