### PR TITLE
fix: DualValueModifierEffect member layout

### DIFF
--- a/include/RE/D/DualValueModifierEffect.h
+++ b/include/RE/D/DualValueModifierEffect.h
@@ -22,12 +22,15 @@ namespace RE
 		virtual void ModifyActorValue(Actor* a_actor, float a_value, ActorValue a_actorValue) override;  // 20
 
 		// add
-		virtual ActorValue GetAdditionalActorValue() const;  // 21
-		virtual float      GetSecondaryAVWeight() const;     // 22
+		virtual ActorValue GetAdditionalActorValue() const;  // 21 - returns GetBaseObject()->data.secondaryAV; not cached in a member
+		virtual float      GetSecondaryAVWeight() const;     // 22 - returns secondaryAVWeight
 
 		// members
-		ActorValue secondaryActorValue;  // 98
-		float      secondaryAVWeight;    // 9C
+		// The ctor stores mgef->data.secondAVWeight here (0.0f when
+		// data.secondaryAV is kNone); the secondary ActorValue itself is
+		// never cached — read it via GetAdditionalActorValue().
+		float         secondaryAVWeight;  // 98
+		std::uint32_t pad9C;              // 9C
 	};
 	static_assert(sizeof(DualValueModifierEffect) == 0xA0);
 }

--- a/include/RE/D/DualValueModifierEffect.h
+++ b/include/RE/D/DualValueModifierEffect.h
@@ -22,8 +22,8 @@ namespace RE
 		virtual void ModifyActorValue(Actor* a_actor, float a_value, ActorValue a_actorValue) override;  // 20
 
 		// add
-		virtual ActorValue GetAdditionalActorValue() const;  // 21 - returns GetBaseObject()->data.secondaryAV; not cached in a member
-		virtual float      GetSecondaryAVWeight() const;     // 22 - returns secondaryAVWeight
+		virtual ActorValue GetAdditionalActorValue() const;  // 21
+		virtual float      GetSecondaryAVWeight() const;     // 22
 
 		// members
 		// The ctor stores mgef->data.secondAVWeight here (0.0f when


### PR DESCRIPTION
## What

Corrects the member layout of `RE::DualValueModifierEffect`. The class previously declared:

```cpp
ActorValue secondaryActorValue;  // 98
float      secondaryAVWeight;    // 9C
```

The engine actually stores **one** member here: the constructor writes `mgef->data.secondAVWeight` as a **float at `this+0x98`** (or `0.0f` when `data.secondaryAV == kNone`), and `0x9C` is padding. The secondary ActorValue is never cached in the instance — `GetAdditionalActorValue()` (vfunc `0x21`) reads `GetBaseObject()->data.secondaryAV` from the MGEF form each call, and `GetSecondaryAVWeight()` (vfunc `0x22`) returns `[this+0x98]`.

So with the old layout, `secondaryActorValue` returned the weight's float bits reinterpreted as an `ActorValue`, and `secondaryAVWeight` read uninitialized padding.

## Evidence

Verified in Ghidra against all three runtimes — the constructor bytes are identical in each: the ctor (SE 1.5.97 `0x140548990`) stores the weight float at `this+0x98` and initializes nothing at `0x9C`, and `GetSecondaryAVWeight` returns `[this+0x98]` on SE, AE 1.6.1170, and VR 1.4.15 alike.

Also relevant for consumers: `DualValueModifierEffect::ModifyActorValue` applies the secondary AV via a **direct call** to the base `ValueModifierEffect::ModifyActorValue` (multiplying by this weight), not a vtable dispatch — found while investigating why a slot-0x20 vfunc hook never sees frost/shock secondary drains.

## Compatibility

Anything reading the old members was reading garbage, so no working code can regress. The correct access path (the two vfunc getters) is unchanged. `sizeof` (0xA0) and the vfunc table are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aMeDkPjdeUMhc761nDUdp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal effect data handling and documentation to keep the implementation aligned with current behavior.
  * No user-facing functionality changes are expected from this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->