### PR TITLE
fix(actor): remove dangling IsPointSubmergedMoreThan

### DIFF
--- a/include/RE/A/Actor.h
+++ b/include/RE/A/Actor.h
@@ -654,7 +654,6 @@ namespace RE
 		[[nodiscard]] bool                      IsRunning() const;
 		[[nodiscard]] bool                      IsSneaking() const;
 		[[nodiscard]] bool                      IsStaggering() const;
-		[[nodiscard]] bool                      IsPointSubmergedMoreThan(const NiPoint3& a_pos, TESObjectCELL* a_cell, float a_waterLevel);
 		[[nodiscard]] bool                      IsSummoned() const noexcept;
 		[[nodiscard]] bool                      IsSummonedByPlayer() const noexcept;
 		[[nodiscard]] bool                      IsTrespassing() const;


### PR DESCRIPTION
## Summary
- `Actor::IsPointSubmergedMoreThan` was moved to `TESObjectREFR` (as `const`, with a real implementation) in 6934ab1e5.
- A later merge of high-priority functions from max-su-2019/CommonLibSSE (7ace92edb) reintroduced a stray, non-const, unimplemented `Actor::IsPointSubmergedMoreThan` declaration in `Actor.h`.
- Because member lookup finds the derived-class declaration first, any unqualified `actor->IsPointSubmergedMoreThan(...)` call resolves to this dangling declaration instead of the working `TESObjectREFR` base method, producing an unresolved external symbol at link time for any downstream consumer.
- This removes the stray declaration so the call falls through to the correct, implemented `TESObjectREFR::IsPointSubmergedMoreThan`.

## Test plan
- [x] Confirmed downstream (PapyrusExtenderSSE VR build) links successfully against this change with an unqualified `a_actor->IsPointSubmergedMoreThan(...)` call.
- [ ] CI build/format checks on this PR

https://claude.ai/code/session_01JTH9yRBarmqeNkJ8pqXhVX