### PR TITLE
fix(actor): remove dangling GetRider declaration

### DIFF
--- a/include/RE/A/Actor.h
+++ b/include/RE/A/Actor.h
@@ -588,7 +588,6 @@ namespace RE
 		[[nodiscard]] TESRace*                  GetRace() const;
 		[[nodiscard]] float                     GetReach() const;
 		[[nodiscard]] float                     GetRegenDelay(ActorValue a_actorValue) const;
-		[[nodiscard]] bool                      GetRider(NiPointer<Actor>& a_outRider);
 		[[nodiscard]] float                     GetSubmergedLevel(float a_zPos, RE::TESObjectCELL* a_cell);
 		[[nodiscard]] TESObjectARMO*            GetSkin() const;
 		[[nodiscard]] TESObjectARMO*            GetSkin(BGSBipedObjectForm::BipedObjectSlot a_slot, bool a_noInit = false);


### PR DESCRIPTION
## Summary
- `Actor::GetRider(NiPointer<Actor>&)` is declared in `Actor.h` but has no implementation anywhere in the tree.
- `Actor::GetMountedBy(NiPointer<Actor>&)` was added alongside it and covers the same functionality — it's the one with a real implementation (`RELOCATION_ID(37758, 38703)`) and the one actually used by consumers.
- Same class of bug as #201: an unresolved external at link time for any caller of the dangling declaration. Nothing in this repo currently calls `GetRider`, so this is pure dead-API removal, caught while auditing for similar issues.

## Test plan
- [x] Confirmed no references to `GetRider` remain anywhere in the tree after removal.
- [ ] CI build/format checks on this PR

https://claude.ai/code/session_01JTH9yRBarmqeNkJ8pqXhVX