### PR TITLE
fix(vr): BSTimer layout

### DIFF
--- a/include/RE/B/BSTimer.h
+++ b/include/RE/B/BSTimer.h
@@ -30,68 +30,22 @@ namespace RE
 			return func(this, a_multiplier, a_arg2);
 		}
 
-		// members
-		//
-		// Field semantics verified by RE (decompiled + disassembled, cross-checked byte-for-byte
-		// identical on SE 1.5.97, AE 1.6.1170, and VR 1.4.15): the constructor, SetGlobalTimeMultiplier,
-		// the per-frame tick update, the smoothing-window setter, and Pause()/Unpause(). Several fields
-		// also line up with pre-existing, independently-named globals at gTimeManager's fixed instance
-		// (gSecondsSinceLastFrame_WorldTime, gSecondsSinceLastFrame_RealTime,
-		// gDurationOfApplicationRunTimeMS, gChangeTimeMultSlowly) -- an authoritative second source that
-		// corroborates the RE below field-for-field. See CommonLibVR PR #203.
-		//
-		// qpcBaseline (08): a QueryPerformanceCounter baseline the constructor initializes and
-		//   Pause()/Unpause() use to measure pause duration. Verified as ONE 64-bit read/write
-		//   (`sub rax,[this+8]` / ctor's `((LARGE_INTEGER*)(this+8))->QuadPart = ...`) on all three
-		//   runtimes -- NOT the two uint32_t fields this used to be split into (the high dword was
-		//   never unused padding). Defaults to "now" at construction.
-		// clamp (10) / clampRemainder (14): fixed-timestep step size and its fractional carry. Both
-		//   default to 0 (variable timestep) at construction.
-		// delta (18) / realTimeDelta (1C): delta = realTimeDelta * current global time multiplier;
-		//   realTimeDelta is captured first, before the multiplier is applied. Matches the existing
-		//   globals gSecondsSinceLastFrame_WorldTime (delta) and gSecondsSinceLastFrame_RealTime /
-		//   fSecondsSinceLastFrameRealTime (realTimeDelta) at gTimeManager's fixed address. Both
-		//   default to 0 at construction.
-		// smoothedRunTimeMS (20) / runTimeMS (24): paired, millisecond-scale elapsed-runtime
-		//   bookkeeping (matches the authoritative AE global name gDurationOfApplicationRunTimeMS for
-		//   offset 20). runTimeMS is set to the frame's consumed elapsed time every update;
-		//   smoothedRunTimeMS mirrors it when unsmoothed but drifts by the averaged-delta contribution
-		//   when smoothing is active. Both are advanced by the pause duration in Unpause(), paired
-		//   respectively with pausedSmoothedRunTimeOffset/runTimeMSBaseline. Both default to 0 (except
-		//   runTimeMSBaseline, see below) at construction.
-		// runTimeMSBaseline (28): external elapsed-runtime input is diffed against this each update.
-		//   Verified uint32_t, not the previous (incorrect) float typing. The constructor either
-		//   computes this from QueryPerformanceCounter "now", or takes it directly as an explicit
-		//   optional 2nd constructor argument (non-zero = caller-supplied epoch).
-		// pausedSmoothedRunTimeOffset (2C) / pausedRunTimeOffset (30): Pause() scratch = elapsed-time-
-		//   at-pause minus smoothedRunTimeMS/runTimeMSBaseline; Unpause() uses them to advance those
-		//   fields by the pause duration.
-		// pauseCount (34): Pause()/Unpause() reference count (supports nested pausing), not a bool.
-		//   Defaults to 0 at construction.
-		// smoothingSampleCount (38): AE's decompile names this setter parameter
-		//   iUnstableFrameTimeHistorySize_Display (gated by bCompensateUnstableFrameTime_Display) -- an
-		//   authoritative Bethesda name. 0-2 = passthrough, >=3 = moving average over smoothingBuffer.
-		// useGlobalTimeMultiplierTarget (3A): gates whether SetGlobalTimeMultiplier snaps
-		//   gCurrentGlobalTimeMultiplier immediately or eases it toward gTargetGlobalTimeMultiplier.
-		//   Defaults to false at construction, but -- unlike every other field here -- is NOT just a
-		//   one-time default: it is refreshed every frame in the per-frame update's caller from the
-		//   ini setting bChangeTimeMultSlowly:General (matches the existing global name
-		//   gChangeTimeMultSlowly at this exact offset on all three runtimes).
-		float*        smoothingBuffer;                // 00
-		std::int64_t  qpcBaseline;                    // 08
-		float         clamp;                          // 10
-		float         clampRemainder;                 // 14
-		float         delta;                          // 18
-		float         realTimeDelta;                  // 1C
-		std::uint32_t smoothedRunTimeMS;              // 20
-		std::uint32_t runTimeMS;                      // 24
-		std::uint32_t runTimeMSBaseline;              // 28
-		std::uint32_t pausedSmoothedRunTimeOffset;    // 2C
-		std::uint32_t pausedRunTimeOffset;            // 30
-		std::uint32_t pauseCount;                     // 34
-		std::uint8_t  smoothingSampleCount;           // 38
-		std::uint8_t  smoothingBufferIndex;           // 39
-		bool          useGlobalTimeMultiplierTarget;  // 3A
+		// members (layout is identical on SE/AE/VR; do not add a per-runtime offset shift)
+		float*        smoothingBuffer;                // 00: ring buffer of past deltas, sized by smoothingSampleCount
+		std::int64_t  qpcBaseline;                    // 08: one 64-bit QueryPerformanceCounter value, not two uint32_t
+		float         clamp;                          // 10: fixed-timestep step size in ticks; 0 = variable timestep
+		float         clampRemainder;                 // 14: fractional tick carry for the fixed-timestep accumulator
+		float         delta;                          // 18: game-time delta = realTimeDelta * global time multiplier
+		float         realTimeDelta;                  // 1C: wall-clock delta, captured before the multiplier is applied
+		std::uint32_t smoothedRunTimeMS;              // 20: ms-scale elapsed runtime, averaged when smoothing is active
+		std::uint32_t runTimeMS;                      // 24: ms-scale elapsed runtime, set unconditionally every update
+		std::uint32_t runTimeMSBaseline;              // 28: external elapsed-runtime input is diffed against this
+		std::uint32_t pausedSmoothedRunTimeOffset;    // 2C: Pause() scratch restoring smoothedRunTimeMS on Unpause()
+		std::uint32_t pausedRunTimeOffset;            // 30: Pause() scratch restoring runTimeMSBaseline on Unpause()
+		std::uint32_t pauseCount;                     // 34: nested Pause()/Unpause() reference count, not a bool
+		std::uint8_t  smoothingSampleCount;           // 38: sample window; 0-2 = passthrough, >=3 = moving average
+		std::uint8_t  smoothingBufferIndex;           // 39: write index into smoothingBuffer, wraps mod smoothingSampleCount
+		bool          useGlobalTimeMultiplierTarget;  // 3A: refreshed every frame from ini bChangeTimeMultSlowly:General
 		std::uint8_t  pad3B;                          // 3B
 		std::uint32_t pad3C;                          // 3C
 	};

--- a/include/RE/B/BSTimer.h
+++ b/include/RE/B/BSTimer.h
@@ -33,35 +33,61 @@ namespace RE
 		// members
 		//
 		// Field semantics verified by RE (decompiled + disassembled, cross-checked byte-for-byte
-		// identical on SE 1.5.97, AE 1.6.1170, and VR 1.4.15): SetGlobalTimeMultiplier, the per-frame
-		// tick update, the smoothing-window setter, and Pause()/Unpause(). See CommonLibVR PR #203.
+		// identical on SE 1.5.97, AE 1.6.1170, and VR 1.4.15): the constructor, SetGlobalTimeMultiplier,
+		// the per-frame tick update, the smoothing-window setter, and Pause()/Unpause(). Several fields
+		// also line up with pre-existing, independently-named globals at gTimeManager's fixed instance
+		// (gSecondsSinceLastFrame_WorldTime, gSecondsSinceLastFrame_RealTime,
+		// gDurationOfApplicationRunTimeMS, gChangeTimeMultSlowly) -- an authoritative second source that
+		// corroborates the RE below field-for-field. See CommonLibVR PR #203.
 		//
-		// qpcBaseline (08): a QueryPerformanceCounter baseline Pause()/Unpause() use to measure pause
-		//   duration. Verified as ONE 64-bit read (`sub rax,[this+8]`) on all three runtimes -- NOT the
-		//   two uint32_t fields this used to be split into (the high dword was never unused padding).
-		// smoothedTickCount (20) / tickCount (24): paired tick bookkeeping. tickCount is set to the
-		//   frame's consumed tick count every update; smoothedTickCount mirrors it when unsmoothed but
-		//   drifts by the averaged-delta contribution when smoothing is active. Both are advanced by the
-		//   pause duration in Unpause(), paired respectively with pausedSmoothedOffset/pausedTickOffset.
-		// tickCountBaseline (28): external raw tick counter is diffed against this each update. Verified
-		//   uint32_t, not the previous (incorrect) float typing.
-		// pausedSmoothedOffset (2C) / pausedTickOffset (30): Pause() scratch = ticksAtPause minus
-		//   smoothedTickCount/tickCountBaseline; Unpause() uses them to advance those fields by the
-		//   pause duration.
+		// qpcBaseline (08): a QueryPerformanceCounter baseline the constructor initializes and
+		//   Pause()/Unpause() use to measure pause duration. Verified as ONE 64-bit read/write
+		//   (`sub rax,[this+8]` / ctor's `((LARGE_INTEGER*)(this+8))->QuadPart = ...`) on all three
+		//   runtimes -- NOT the two uint32_t fields this used to be split into (the high dword was
+		//   never unused padding). Defaults to "now" at construction.
+		// clamp (10) / clampRemainder (14): fixed-timestep step size and its fractional carry. Both
+		//   default to 0 (variable timestep) at construction.
+		// delta (18) / realTimeDelta (1C): delta = realTimeDelta * current global time multiplier;
+		//   realTimeDelta is captured first, before the multiplier is applied. Matches the existing
+		//   globals gSecondsSinceLastFrame_WorldTime (delta) and gSecondsSinceLastFrame_RealTime /
+		//   fSecondsSinceLastFrameRealTime (realTimeDelta) at gTimeManager's fixed address. Both
+		//   default to 0 at construction.
+		// smoothedRunTimeMS (20) / runTimeMS (24): paired, millisecond-scale elapsed-runtime
+		//   bookkeeping (matches the authoritative AE global name gDurationOfApplicationRunTimeMS for
+		//   offset 20). runTimeMS is set to the frame's consumed elapsed time every update;
+		//   smoothedRunTimeMS mirrors it when unsmoothed but drifts by the averaged-delta contribution
+		//   when smoothing is active. Both are advanced by the pause duration in Unpause(), paired
+		//   respectively with pausedSmoothedRunTimeOffset/runTimeMSBaseline. Both default to 0 (except
+		//   runTimeMSBaseline, see below) at construction.
+		// runTimeMSBaseline (28): external elapsed-runtime input is diffed against this each update.
+		//   Verified uint32_t, not the previous (incorrect) float typing. The constructor either
+		//   computes this from QueryPerformanceCounter "now", or takes it directly as an explicit
+		//   optional 2nd constructor argument (non-zero = caller-supplied epoch).
+		// pausedSmoothedRunTimeOffset (2C) / pausedRunTimeOffset (30): Pause() scratch = elapsed-time-
+		//   at-pause minus smoothedRunTimeMS/runTimeMSBaseline; Unpause() uses them to advance those
+		//   fields by the pause duration.
+		// pauseCount (34): Pause()/Unpause() reference count (supports nested pausing), not a bool.
+		//   Defaults to 0 at construction.
 		// smoothingSampleCount (38): AE's decompile names this setter parameter
 		//   iUnstableFrameTimeHistorySize_Display (gated by bCompensateUnstableFrameTime_Display) -- an
 		//   authoritative Bethesda name. 0-2 = passthrough, >=3 = moving average over smoothingBuffer.
+		// useGlobalTimeMultiplierTarget (3A): gates whether SetGlobalTimeMultiplier snaps
+		//   gCurrentGlobalTimeMultiplier immediately or eases it toward gTargetGlobalTimeMultiplier.
+		//   Defaults to false at construction, but -- unlike every other field here -- is NOT just a
+		//   one-time default: it is refreshed every frame in the per-frame update's caller from the
+		//   ini setting bChangeTimeMultSlowly:General (matches the existing global name
+		//   gChangeTimeMultSlowly at this exact offset on all three runtimes).
 		float*        smoothingBuffer;                // 00
 		std::int64_t  qpcBaseline;                    // 08
 		float         clamp;                          // 10
 		float         clampRemainder;                 // 14
 		float         delta;                          // 18
 		float         realTimeDelta;                  // 1C
-		std::uint32_t smoothedTickCount;              // 20
-		std::uint32_t tickCount;                      // 24
-		std::uint32_t tickCountBaseline;              // 28
-		std::uint32_t pausedSmoothedOffset;           // 2C
-		std::uint32_t pausedTickOffset;               // 30
+		std::uint32_t smoothedRunTimeMS;              // 20
+		std::uint32_t runTimeMS;                      // 24
+		std::uint32_t runTimeMSBaseline;              // 28
+		std::uint32_t pausedSmoothedRunTimeOffset;    // 2C
+		std::uint32_t pausedRunTimeOffset;            // 30
 		std::uint32_t pauseCount;                     // 34
 		std::uint8_t  smoothingSampleCount;           // 38
 		std::uint8_t  smoothingBufferIndex;           // 39

--- a/include/RE/B/BSTimer.h
+++ b/include/RE/B/BSTimer.h
@@ -31,21 +31,40 @@ namespace RE
 		}
 
 		// members
-		std::uint64_t unk00;                          // 00
-		std::uint32_t lastPerformanceCount;           // 08
-		std::uint32_t pad0C;                          // 0C
+		//
+		// Field semantics verified by RE (decompiled + disassembled, cross-checked byte-for-byte
+		// identical on SE 1.5.97, AE 1.6.1170, and VR 1.4.15): SetGlobalTimeMultiplier, the per-frame
+		// tick update, the smoothing-window setter, and Pause()/Unpause(). See CommonLibVR PR #203.
+		//
+		// qpcBaseline (08): a QueryPerformanceCounter baseline Pause()/Unpause() use to measure pause
+		//   duration. Verified as ONE 64-bit read (`sub rax,[this+8]`) on all three runtimes -- NOT the
+		//   two uint32_t fields this used to be split into (the high dword was never unused padding).
+		// smoothedTickCount (20) / tickCount (24): paired tick bookkeeping. tickCount is set to the
+		//   frame's consumed tick count every update; smoothedTickCount mirrors it when unsmoothed but
+		//   drifts by the averaged-delta contribution when smoothing is active. Both are advanced by the
+		//   pause duration in Unpause(), paired respectively with pausedSmoothedOffset/pausedTickOffset.
+		// tickCountBaseline (28): external raw tick counter is diffed against this each update. Verified
+		//   uint32_t, not the previous (incorrect) float typing.
+		// pausedSmoothedOffset (2C) / pausedTickOffset (30): Pause() scratch = ticksAtPause minus
+		//   smoothedTickCount/tickCountBaseline; Unpause() uses them to advance those fields by the
+		//   pause duration.
+		// smoothingSampleCount (38): AE's decompile names this setter parameter
+		//   iUnstableFrameTimeHistorySize_Display (gated by bCompensateUnstableFrameTime_Display) -- an
+		//   authoritative Bethesda name. 0-2 = passthrough, >=3 = moving average over smoothingBuffer.
+		float*        smoothingBuffer;                // 00
+		std::int64_t  qpcBaseline;                    // 08
 		float         clamp;                          // 10
 		float         clampRemainder;                 // 14
 		float         delta;                          // 18
 		float         realTimeDelta;                  // 1C
-		std::uint32_t unk20;                          // 20
-		std::uint32_t unk24;                          // 24
-		float         unk28;                          // 28
-		std::uint32_t unk2C;                          // 2C
-		std::uint32_t unk30;                          // 30
-		std::uint32_t unk34;                          // 34
-		std::uint8_t  unk38;                          // 38
-		std::uint8_t  unk39;                          // 39
+		std::uint32_t smoothedTickCount;              // 20
+		std::uint32_t tickCount;                      // 24
+		std::uint32_t tickCountBaseline;              // 28
+		std::uint32_t pausedSmoothedOffset;           // 2C
+		std::uint32_t pausedTickOffset;               // 30
+		std::uint32_t pauseCount;                     // 34
+		std::uint8_t  smoothingSampleCount;           // 38
+		std::uint8_t  smoothingBufferIndex;           // 39
 		bool          useGlobalTimeMultiplierTarget;  // 3A
 		std::uint8_t  pad3B;                          // 3B
 		std::uint32_t pad3C;                          // 3C

--- a/include/RE/B/BSTimer.h
+++ b/include/RE/B/BSTimer.h
@@ -30,6 +30,15 @@ namespace RE
 			return func(this, a_multiplier, a_arg2);
 		}
 
+		// Per-frame tick: computes delta/realTimeDelta from a_currentTicks (a millisecond counter),
+		// applying smoothing/fixed-timestep clamping. No-ops while pauseCount != 0.
+		void Update(std::int32_t a_currentTicks)
+		{
+			using func_t = decltype(&BSTimer::Update);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(66987, 68244) };
+			return func(this, a_currentTicks);
+		}
+
 		// members (layout is identical on SE/AE/VR; do not add a per-runtime offset shift)
 		float*        smoothingBuffer;                // 00: ring buffer of past deltas, sized by smoothingSampleCount
 		std::int64_t  qpcBaseline;                    // 08: one 64-bit QueryPerformanceCounter value, not two uint32_t

--- a/include/RE/B/BSTimer.h
+++ b/include/RE/B/BSTimer.h
@@ -39,7 +39,7 @@ namespace RE
 			return func(this, a_currentTicks);
 		}
 
-		// members (layout is identical on SE/AE/VR; do not add a per-runtime offset shift)
+		// members: layout is identical on SE/AE/VR
 		float*        smoothingBuffer;                // 00: ring buffer of past deltas, sized by smoothingSampleCount
 		std::int64_t  qpcBaseline;                    // 08: one 64-bit QueryPerformanceCounter value, not two uint32_t
 		float         clamp;                          // 10: fixed-timestep step size in ticks; 0 = variable timestep

--- a/include/RE/B/BSTimer.h
+++ b/include/RE/B/BSTimer.h
@@ -31,26 +31,24 @@ namespace RE
 		}
 
 		// members
-		std::uint64_t unk00;                 // 00
-		std::uint32_t lastPerformanceCount;  // 08
-#if !defined(ENABLE_SKYRIM_VR) || defined(ENABLE_SKYRIM_SE) || defined(ENABLE_SKYRIM_AE)
-		std::uint32_t pad0C;  // 0C - not present in VR-only builds
-#endif
-		float         clamp;                          // 10 (0C in VR)
-		float         clampRemainder;                 // 14 (10 in VR)
-		float         delta;                          // 18 (14 in VR)
-		float         realTimeDelta;                  // 1C (18 in VR)
-		std::uint32_t unk20;                          // 20 (1C in VR)
-		std::uint32_t unk24;                          // 24 (20 in VR)
-		float         unk28;                          // 28 (24 in VR)
-		std::uint32_t unk2C;                          // 2C (28 in VR)
-		std::uint32_t unk30;                          // 30 (2C in VR)
-		std::uint32_t unk34;                          // 34 (30 in VR)
-		std::uint8_t  unk38;                          // 38 (34 in VR)
-		std::uint8_t  unk39;                          // 39 (35 in VR)
-		bool          useGlobalTimeMultiplierTarget;  // 3A (36 in VR)
-		std::uint8_t  pad3B;                          // 3B (37 in VR)
-		std::uint32_t pad3C;                          // 3C (38 in VR)
+		std::uint64_t unk00;                          // 00
+		std::uint32_t lastPerformanceCount;           // 08
+		std::uint32_t pad0C;                          // 0C
+		float         clamp;                          // 10
+		float         clampRemainder;                 // 14
+		float         delta;                          // 18
+		float         realTimeDelta;                  // 1C
+		std::uint32_t unk20;                          // 20
+		std::uint32_t unk24;                          // 24
+		float         unk28;                          // 28
+		std::uint32_t unk2C;                          // 2C
+		std::uint32_t unk30;                          // 30
+		std::uint32_t unk34;                          // 34
+		std::uint8_t  unk38;                          // 38
+		std::uint8_t  unk39;                          // 39
+		bool          useGlobalTimeMultiplierTarget;  // 3A
+		std::uint8_t  pad3B;                          // 3B
+		std::uint32_t pad3C;                          // 3C
 	};
 	static_assert(sizeof(BSTimer) == 0x40);
 }


### PR DESCRIPTION
## What changed (PR rewritten after Ghidra verification, then extended)

This PR originally added a `RUNTIME_DATA` accessor for BSTimer's claimed VR layout shift. **Ghidra verification showed the shift is a phantom** — BSTimer's layout is identical across SE 1.5.97, AE 1.6.1170, and VR 1.4.15 — so the correct fix is to delete the bogus divergence, not to abstract it.

**Update:** decompiling the functions that actually touch every field (`SetGlobalTimeMultiplier`, the per-frame tick update, the smoothing-window setter, and `Pause`/`Unpause`) — cross-checked byte-for-byte identical on all three runtimes — recovered concrete semantics for the rest of the struct, previously left as `unk00`/`unk20`/`unk24`/`unk28`/`unk2C`/`unk30`/`unk34`. This PR now names all of them and fixes one more latent type bug found in the process.

## Evidence for the original claim (pad0C)

xref-count profiles against the singleton instance (`gTimeManager`, addrlib id 523657 → SE `0x142f6b930`, VR `0x1430c39f0`; AE id 410196 → `0x1431cc270`):

| offset | SE | AE | VR |
|---|---|---|---|
| 0x18 (`delta`) | 189 | 201 | 208 |
| 0x1C (`realTimeDelta`) | 33 | 43 | 36 |
| 0x20 (`unk20`) | 104 | 109 | 100 |
| 0x3A (`useGlobalTimeMultiplierTarget`) | 1 | 1 | 1 |

A missing `pad0C` would shift VR's whole profile down by 4 — it doesn't. `SetGlobalTimeMultiplier` (id 66988; SE `0x140c078b0` / VR `0x140c42730`) is **byte-identical**, accessing `[this+0x3A]` and `[this+0x18]` in both binaries.

## Additional evidence (new members)

Decompiled and disassembled, on **all three runtimes** (SE `TimeManager::sub_140C076A0`/AE `TimeManager::sub_0x140cc9520`/VR `sub_0x140c42520` for the tick update; SE `0x140c079e0`+`0x140c07980`/AE `0x140cc9920`+`0x140cc98c0`/VR `0x140c42860`+`0x140c42800` for Pause/Unpause) — every offset matches exactly, no shift anywhere:

- **`unk00` → `smoothingBuffer` (`float*`)**: heap ring buffer of past frame deltas, allocated by the sample-window setter when `smoothingSampleCount > 0`.
- **`lastPerformanceCount`+`pad0C` merged → `qpcBaseline` (`std::int64_t`)**: raw disassembly shows `Pause()`/`Unpause()` read this as **one 64-bit** `QueryPerformanceCounter` baseline (`sub rax,[this+8]`) on all three runtimes — not two independent `uint32_t` fields. `pad0C` was never unused padding; it's the high dword of a live timestamp.
- **`unk20`/`unk24` → `smoothedTickCount`/`tickCount`**: paired tick bookkeeping; `tickCount` is unconditionally set to the frame's consumed tick count every update, `smoothedTickCount` mirrors it unless smoothing is active.
- **`unk28` → `tickCountBaseline` (`std::uint32_t`, was mistyped `float`)**: the external raw tick counter is diffed against this each update — a real, independent type bug found during this pass (present before and unrelated to the pad0C issue).
- **`unk2C`/`unk30` → `pausedSmoothedOffset`/`pausedTickOffset`**: `Pause()` scratch values (`ticksAtPause − baseline`) consumed by `Unpause()` to advance the tick baselines by the pause duration.
- **`unk34` → `pauseCount`**: a nested-pause reference count, not a bool (increments/decrements with 0-transition logic).
- **`smoothingSampleCount`/`smoothingBufferIndex` (0x38/0x39)**: names/types already correct from this PR's first pass. AE's decompile additionally surfaces the **authoritative Bethesda parameter name** `iUnstableFrameTimeHistorySize_Display` (gated by `bCompensateUnstableFrameTime_Display`) for the setter's argument — independent confirmation of the smoothing-window semantics.

`sizeof(BSTimer)` is unchanged (`0x40`); double-checked against `BSTimer`'s other use as `UI::uiTimer` (embedded by value at `UI+0x180`).

## Ghidra (SE, AE, VR)

- `BSTimer` struct fields renamed/retyped to match, in all three programs' type managers.
- `TimeManager::Pause`/`TimeManager::Unpause` — renamed from `FUN_*` placeholders in all three binaries.
- Plate comments on the per-frame update function (SE) with the full field-by-field writeup this PR summarizes; VR/AE reference it.

## Impact

- Exclusive-VR builds previously read `delta` (0x18) when asking for `realTimeDelta` — a real, silent field aliasing bug, now fixed.
- Cross builds keep plain direct member access; no accessor needed.
- `tickCountBaseline` (0x28) was typed `float` but is read/written exclusively as an integer tick count — any code that read this field's value as a float would have gotten a bit-reinterpreted garbage number. No current consumer does, but the type is now correct.
- The guard dated to merging po3's `cf619e5b0` ("Fix `BSTimer` offset", which added `pad0C` for flat) while assuming VR kept the older layout — never checked against the binary until now.

## Verification

- Exclusive-VR: `debug-msvc-vcpkg-vr` builds clean (incl. `CommonLibSSETests`' `StaticAssertSize` coverage).
- Cross-VR: `debug-msvc-vcpkg-all` (unified SE/AE/VR) builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XfDBBMqUJ7ZbXCLHMijBM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the timer’s internal layout to use clearer, more descriptive field names and consistent structure.
  * Aligned timing-related fields across supported editions while preserving the same overall size and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->