### PR TITLE
feat(vats): name orchestration methods

### DIFF
--- a/include/RE/V/VATS.h
+++ b/include/RE/V/VATS.h
@@ -18,6 +18,9 @@ namespace RE
 	class Projectile;
 	class TESBoundObject;
 
+	// Opaque node in VATS::cameraShotQueue's singly-linked list; layout unknown.
+	struct VATSCameraShotQueueNode;
+
 	class VATSCommand
 	{
 	public:
@@ -80,12 +83,12 @@ namespace RE
 		}
 
 		// Pops the front of commandList once it finishes playing, or fully clears it and restores
-		// the global time multiplier when a_last is false.
-		void AdvanceCommand(bool a_arg1, bool a_last, bool a_arg3)
+		// the global time multiplier when a_hasMoreCommands is false.
+		void AdvanceCommand(bool a_arg1, bool a_hasMoreCommands, bool a_arg3)
 		{
 			using func_t = decltype(&VATS::AdvanceCommand);
 			static REL::Relocation<func_t> func{ RELOCATION_ID(43094, 44289) };
-			return func(this, a_arg1, a_last, a_arg3);
+			return func(this, a_arg1, a_hasMoreCommands, a_arg3);
 		}
 
 		// Per-frame kill-cam update; no-ops unless mode == kKillCam.
@@ -101,7 +104,7 @@ namespace RE
 		BSTArray<BSTSmartPointer<VATSCommand>> commandList;              // 08
 		VATS_MODE                              mode;                     // 20
 		std::uint32_t                          pad24;                    // 24
-		void*                                  cameraShotQueue;          // 28 - singly-linked list of pending BGSCameraShot nodes; advanced when cameraTime elapses
+		VATSCameraShotQueueNode*               cameraShotQueue;          // 28 - singly-linked list of pending BGSCameraShot nodes; advanced when cameraTime elapses
 		BGSCameraShot*                         cameraShot;               // 30
 		float                                  safetyTime;               // 38
 		float                                  cameraTime;               // 3C

--- a/include/RE/V/VATS.h
+++ b/include/RE/V/VATS.h
@@ -14,6 +14,8 @@ namespace RE
 	class BSLight;
 	class ExtraDataList;
 	class ImageSpaceModifierInstanceRB;
+	class PlayerCharacter;
+	class Projectile;
 	class TESBoundObject;
 
 	class VATSCommand
@@ -39,6 +41,9 @@ namespace RE
 	class VATS : public BSTSingletonSDM<VATS>
 	{
 	public:
+		// SetMode's decompile also handles 2 and 3 (both run identical setup: attach a NiPointLight
+		// if VATSLight is unset); no caller in the binary reaches either, and both are behaviorally
+		// indistinguishable from what's decompiled, so they're intentionally left unnamed here.
 		enum class VATS_MODE : std::uint32_t
 		{
 			kNone = 0,
@@ -58,27 +63,61 @@ namespace RE
 			return func(this, a_magicTimeSlowdown, a_playerMagicTimeSlowdown);
 		}
 
+		// Mode-transition function: performs full enter/exit side effects (teardown on kNone,
+		// kill-cam setup on kKillCam) before setting `mode`.
+		void SetMode(VATS_MODE a_mode)
+		{
+			using func_t = decltype(&VATS::SetMode);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(43087, 44282) };
+			return func(this, a_mode);
+		}
+
+		// Allocates a VATSCommand, appends it to commandList, and calls SetMode(kKillCam).
+		void QueueCommand()
+		{
+			using func_t = decltype(&VATS::QueueCommand);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(43090, 44285) };
+			return func(this);
+		}
+
+		// Pops the front of commandList once it finishes playing, or fully clears it and restores
+		// the global time multiplier when a_last is false.
+		void AdvanceCommand(bool a_arg1, bool a_last, bool a_arg3)
+		{
+			using func_t = decltype(&VATS::AdvanceCommand);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(43094, 44289) };
+			return func(this, a_arg1, a_last, a_arg3);
+		}
+
+		// Per-frame kill-cam update; no-ops unless mode == kKillCam.
+		void UpdateKillCam(PlayerCharacter* a_player, void* a_arg2, std::uint32_t* a_arg3)
+		{
+			using func_t = decltype(&VATS::UpdateKillCam);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(43098, 44295) };
+			return func(this, a_player, a_arg2, a_arg3);
+		}
+
 		// members
 		std::uint32_t                          pad00;                    // 00
 		BSTArray<BSTSmartPointer<VATSCommand>> commandList;              // 08
 		VATS_MODE                              mode;                     // 20
 		std::uint32_t                          pad24;                    // 24
-		std::uint64_t                          unk28;                    // 28
+		void*                                  cameraShotQueue;          // 28 - singly-linked list of pending BGSCameraShot nodes; advanced when cameraTime elapses
 		BGSCameraShot*                         cameraShot;               // 30
 		float                                  safetyTime;               // 38
 		float                                  cameraTime;               // 3C
 		float                                  castingAfterKillDelay;    // 40
 		std::uint32_t                          pad44;                    // 44
-		std::uint64_t                          unk48;                    // 48
-		std::uint64_t                          unk50;                    // 50
+		Projectile*                            killProjectile;           // 48 - camera location/target node fallback when cameraShot lacks one
+		Projectile*                            killProjectile2;          // 50 - checked when killProjectile is null
 		std::uint64_t                          unk58;                    // 58
 		ImageSpaceModifierInstanceRB*          unk60;                    // 60
 		ImageSpaceModifierInstanceRB*          unk68;                    // 68
 		NiPointer<BSLight>                     VATSLight;                // 70
-		bool                                   unk78;                    // 78
-		bool                                   unk79;                    // 79
+		bool                                   killCamActive;            // 78 - set true entering kKillCam; redundant with mode in what's decompiled so far
+		bool                                   killCamInitialized;       // 79 - false entering kKillCam, latched true after UpdateKillCam's first-frame setup
 		std::uint16_t                          pad7A;                    // 7A
-		std::int32_t                           unk7C;                    // 7C
+		std::int32_t                           pendingCameraTransition;  // 7C - reset to 0 alongside camera-transition setup on kKillCam entry
 		float                                  magicTimeSlowdown;        // 80
 		float                                  playerMagicTimeSlowdown;  // 84
 		TESBoundObject*                        item;                     // 88

--- a/include/RE/V/VATS.h
+++ b/include/RE/V/VATS.h
@@ -41,9 +41,8 @@ namespace RE
 	class VATS : public BSTSingletonSDM<VATS>
 	{
 	public:
-		// SetMode's decompile also handles 2 and 3 (both run identical setup: attach a NiPointLight
-		// if VATSLight is unset); no caller in the binary reaches either, and both are behaviorally
-		// indistinguishable from what's decompiled, so they're intentionally left unnamed here.
+		// SetMode also handles values 2 and 3 identically; no caller reaches either, so they're
+		// intentionally omitted rather than guessed.
 		enum class VATS_MODE : std::uint32_t
 		{
 			kNone = 0,


### PR DESCRIPTION
## What

`RE::VATS`'s struct layout was already fully named, but its internal orchestration methods weren't bound. Found while tracing `BSTimer::SetGlobalTimeMultiplier`'s callers (a tangent from [PR #203](https://github.com/alandtse/CommonLibVR/pull/203)) — `VATS::SetMode` calls it directly.

- **`SetMode(VATS_MODE)`** — enter/exit side effects per mode, then sets `mode`.
- **`QueueCommand()`** — allocates a `VATSCommand`, appends it to `commandList`, calls `SetMode(kKillCam)`.
- **`AdvanceCommand(bool, bool, bool)`** — pops `commandList`'s front entry, or fully clears it and resets the global time multiplier.
- **`UpdateKillCam(PlayerCharacter*, void*, std::uint32_t*)`** — per-frame kill-cam tick, gated to `mode == kKillCam`.

## Also resolved

- `unk28` → `cameraShotQueue`: a linked list of pending `BGSCameraShot` nodes, confirmed via the advance-on-timeout logic.
- `unk48`/`unk50` → `killProjectile`/`killProjectile2`: confirmed `Projectile*` via a direct `Projectile::TurnOffParticles(...)` call on whichever is non-null; used as a camera location/target fallback when `cameraShot` lacks one.
- `unk78`/`unk79` → `killCamActive`/`killCamInitialized`, `unk7C` → `pendingCameraTransition`: inferred from `SetMode`/`UpdateKillCam` (set/cleared alongside kill-cam entry and first-frame setup).

## Left alone (documented, not fabricated)

`VATS_MODE` has two more live enum values (`2`, `3`) that `SetMode`'s decompile handles — identically to each other — but **no caller in the binary reaches either value**. Documented as a comment rather than guessing enum names with zero distinguishing evidence.

## Address ids

`id`/`aeid` pairs added in a companion PR: alandtse/skyrim_vr_address_library#131.

## Verification

Decompiled + cross-checked on SE and VR (byte-identical for `QueueCommand`/`AdvanceCommand`, verified-equivalent-but-structurally-different for `SetMode`/`UpdateKillCam` — see the address-library PR for details). Builds clean on `debug-msvc-vcpkg-vr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional VATS and kill-cam actions, improving combat camera handling and command flow.
  * Expanded kill-cam state tracking for smoother transitions during targeted attacks.

* **Bug Fixes**
  * Clarified and stabilized internal handling for queued camera shots and projectile-related kill-cam behavior, helping reduce animation and camera inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->