### PR TITLE
feat: name generic-subsystem methods

### DIFF
--- a/include/RE/B/BGSCameraShot.h
+++ b/include/RE/B/BGSCameraShot.h
@@ -79,20 +79,46 @@ namespace RE
 		bool Load(TESFile* a_mod) override;  // 06
 		void InitItemImpl() override;        // 13
 
+		// False for CAM_ACTION::kZoom shots; otherwise requires a loaded model and a non-null cameraNode.
+		bool IsValid()
+		{
+			using func_t = decltype(&BGSCameraShot::IsValid);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(20263, 20706) };
+			return func(this);
+		}
+
+		// Releases locationNode/targetNode/cameraNode; called on camera-shot teardown.
+		void ReleaseNodes()
+		{
+			using func_t = decltype(&BGSCameraShot::ReleaseNodes);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(20264, 20707) };
+			return func(this);
+		}
+
+		// a_node == nullptr clears targetNode/targetFadeNode. Otherwise creates a positional-snapshot
+		// proxy node (or follows a_node directly, depending on an as-yet-unnamed flag) and caches the
+		// nearest ancestor fade node into targetFadeNode.
+		void SetTargetNode(NiNode* a_node)
+		{
+			using func_t = decltype(&BGSCameraShot::SetTargetNode);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(20266, 20709) };
+			return func(this, a_node);
+		}
+
 		// members
-		CAMERA_SHOT_DATA      data;          // 58 - DATA
-		std::uint32_t         pad84;         // 84
-		NiAVObject*           locationNode;  // 88
-		NiAVObject*           targetNode;    // 90
-		RefHandle             unk98;         // 98
-		std::uint32_t         unk9C;         // 9C
-		NiPointer<NiNode>     cameraNode;    // A0 - smart ptr
-		NiPointer<NiAVObject> unkA8;         // A8 - smart ptr
-		std::uint8_t          unkB0;         // B0
-		bool                  unkB1;         // B1
-		std::uint16_t         padB2;         // B2
-		std::uint32_t         padB4;         // B4
-		ModelDBHandle         cameraHandle;  // B8
+		CAMERA_SHOT_DATA      data;            // 58 - DATA
+		std::uint32_t         pad84;           // 84
+		NiAVObject*           locationNode;    // 88
+		NiAVObject*           targetNode;      // 90
+		RefHandle             unk98;           // 98
+		std::uint32_t         unk9C;           // 9C
+		NiPointer<NiNode>     cameraNode;      // A0 - smart ptr
+		NiPointer<NiAVObject> targetFadeNode;  // A8 - smart ptr; nearest ancestor NiFadeNode of targetNode
+		std::uint8_t          unkB0;           // B0
+		bool                  unkB1;           // B1
+		std::uint16_t         padB2;           // B2
+		std::uint32_t         padB4;           // B4
+		ModelDBHandle         cameraHandle;    // B8
 	};
 	static_assert(sizeof(BGSCameraShot) == 0xC0);
 }

--- a/include/RE/B/BGSCameraShot.h
+++ b/include/RE/B/BGSCameraShot.h
@@ -8,6 +8,8 @@
 
 namespace RE
 {
+	class TESObjectREFR;
+
 	class BGSCameraShot :
 		public TESForm,                     // 00
 		public TESModel,                    // 20
@@ -102,6 +104,31 @@ namespace RE
 			using func_t = decltype(&BGSCameraShot::SetTargetNode);
 			static REL::Relocation<func_t> func{ RELOCATION_ID(20266, 20709) };
 			return func(this, a_node);
+		}
+
+		// Mirrors SetTargetNode, but for locationNode.
+		void SetLocationNode(NiAVObject* a_node)
+		{
+			using func_t = decltype(&BGSCameraShot::SetLocationNode);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(20265, 20708) };
+			return func(this, a_node);
+		}
+
+		// Starts the shot: requests the camera model, validates its NiCamera/interpolator, sets up
+		// VATS dolly-timing state, and plays the transition sound.
+		void Play(TESObjectREFR* a_target, std::int32_t a_mode)
+		{
+			using func_t = decltype(&BGSCameraShot::Play);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(20262, 20705) };
+			return func(this, a_target, a_mode);
+		}
+
+		// Per-frame position/frustum tick.
+		void Update(float a_currentTime)
+		{
+			using func_t = decltype(&BGSCameraShot::Update);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(20267, 20710) };
+			return func(this, a_currentTime);
 		}
 
 		// members

--- a/include/RE/B/BGSCameraShot.h
+++ b/include/RE/B/BGSCameraShot.h
@@ -139,7 +139,7 @@ namespace RE
 		RefHandle             unk98;           // 98
 		std::uint32_t         unk9C;           // 9C
 		NiPointer<NiNode>     cameraNode;      // A0 - smart ptr
-		NiPointer<NiAVObject> targetFadeNode;  // A8 - smart ptr; nearest ancestor NiFadeNode of targetNode
+		NiPointer<NiAVObject> targetFadeNode;  // A8 - smart ptr; nearest fade-capable ancestor node of targetNode
 		std::uint8_t          unkB0;           // B0
 		bool                  unkB1;           // B1
 		std::uint16_t         padB2;           // B2

--- a/include/RE/B/BGSCameraShot.h
+++ b/include/RE/B/BGSCameraShot.h
@@ -95,9 +95,8 @@ namespace RE
 			return func(this);
 		}
 
-		// a_node == nullptr clears targetNode/targetFadeNode. Otherwise creates a positional-snapshot
-		// proxy node (or follows a_node directly, depending on an as-yet-unnamed flag) and caches the
-		// nearest ancestor fade node into targetFadeNode.
+		// nullptr clears targetNode/targetFadeNode; otherwise creates a positional-snapshot proxy (or
+		// follows a_node directly, per an as-yet-unnamed flag) and caches the nearest fade-node ancestor.
 		void SetTargetNode(NiNode* a_node)
 		{
 			using func_t = decltype(&BGSCameraShot::SetTargetNode);

--- a/include/RE/B/BGSCameraShot.h
+++ b/include/RE/B/BGSCameraShot.h
@@ -98,7 +98,7 @@ namespace RE
 		}
 
 		// nullptr clears targetNode/targetFadeNode; otherwise creates a positional-snapshot proxy (or
-		// follows a_node directly, per an as-yet-unnamed flag) and caches the nearest fade-node ancestor.
+		// follows a_node directly, per an internal flag) and caches the nearest fade-node ancestor.
 		void SetTargetNode(NiNode* a_node)
 		{
 			using func_t = decltype(&BGSCameraShot::SetTargetNode);

--- a/include/RE/I/ImageSpaceModifierInstanceForm.h
+++ b/include/RE/I/ImageSpaceModifierInstanceForm.h
@@ -35,12 +35,12 @@ namespace RE
 		}
 
 		// Retargets an already-active instance. Returns false without effect if either the current or
-		// new target has a lock-like flag set (checked at +0x20 on both).
-		bool SetTarget(TESImageSpaceModifier* a_target, float a_transitionTime, float a_duration, NiAVObject* a_node)
+		// new (node) target has a lock-like flag set (checked at +0x20 on both).
+		bool SetTarget(TESImageSpaceModifier* a_imod, float a_transitionTime, float a_duration, NiAVObject* a_target)
 		{
 			using func_t = decltype(&ImageSpaceModifierInstanceForm::SetTarget);
 			static REL::Relocation<func_t> func{ RELOCATION_ID(18183, 18568) };
-			return func(this, a_target, a_transitionTime, a_duration, a_node);
+			return func(this, a_imod, a_transitionTime, a_duration, a_target);
 		}
 
 		static void StopCrossFade(float a_seconds)

--- a/include/RE/I/ImageSpaceModifierInstanceForm.h
+++ b/include/RE/I/ImageSpaceModifierInstanceForm.h
@@ -34,6 +34,15 @@ namespace RE
 			return func(a_imod);
 		}
 
+		// Retargets an already-active instance. Returns false without effect if either the current or
+		// new target has a lock-like flag set (checked at +0x20 on both).
+		bool SetTarget(TESImageSpaceModifier* a_target, float a_transitionTime, float a_duration, NiAVObject* a_node)
+		{
+			using func_t = decltype(&ImageSpaceModifierInstanceForm::SetTarget);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(18183, 18568) };
+			return func(this, a_target, a_transitionTime, a_duration, a_node);
+		}
+
 		static void StopCrossFade(float a_seconds)
 		{
 			using func_t = decltype(&ImageSpaceModifierInstanceForm::StopCrossFade);

--- a/include/RE/S/ShadowSceneNode.h
+++ b/include/RE/S/ShadowSceneNode.h
@@ -126,7 +126,7 @@ namespace RE
 		// Convenience overload for a non-shadow, non-portal-strict, never-fading light.
 		void AddLight(NiLight* a_light)
 		{
-			using func_t = decltype(static_cast<void (ShadowSceneNode::*)(NiLight*)>(&ShadowSceneNode::AddLight));
+			using func_t = void (*)(ShadowSceneNode*, NiLight*);
 			static REL::Relocation<func_t> func{ RELOCATION_ID(99691, 106325) };
 			return func(this, a_light);
 		}

--- a/include/RE/S/ShadowSceneNode.h
+++ b/include/RE/S/ShadowSceneNode.h
@@ -120,8 +120,16 @@ namespace RE
 			return func(this, object);
 		}
 
-		BSLight*           AddLight(NiLight* a_light, const LIGHT_CREATE_PARAMS& a_params);
-		void               AddLight(BSLight* a_light);
+		BSLight* AddLight(NiLight* a_light, const LIGHT_CREATE_PARAMS& a_params);
+		void     AddLight(BSLight* a_light);
+
+		// Convenience overload for a non-shadow, non-portal-strict, never-fading light.
+		void AddLight(NiLight* a_light)
+		{
+			using func_t = decltype(static_cast<void (ShadowSceneNode::*)(NiLight*)>(&ShadowSceneNode::AddLight));
+			static REL::Relocation<func_t> func{ RELOCATION_ID(99691, 106325) };
+			return func(this, a_light);
+		}
 		BSLight*           GetLight(NiLight* a_light);
 		BSLight*           GetPointLight(NiLight* a_light);
 		BSLight*           GetShadowLight(NiLight* a_light);


### PR DESCRIPTION
## What

Found while tracing `VATS::SetMode`/`UpdateKillCam`'s call graph — a tangent from [PR #204](https://github.com/alandtse/CommonLibVR/pull/204). These methods belong to classes broader than VATS: `BGSCameraShot`, `ImageSpaceModifierInstanceForm`, `ShadowSceneNode` are all reused by other engine systems.

- **`BGSCameraShot::IsValid()`** — false for `CAM_ACTION::kZoom` shots; otherwise requires a loaded model and non-null `cameraNode`.
- **`BGSCameraShot::ReleaseNodes()`** — releases `locationNode`/`targetNode`/`cameraNode`; camera-shot teardown.
- **`BGSCameraShot::SetTargetNode(NiNode*)`** — null clears `targetNode`/`targetFadeNode`; non-null creates a positional-snapshot proxy (or follows directly, depending on an as-yet-unnamed flag) and caches the nearest fade node.
  - Also renames `unkA8` → `targetFadeNode`, confirmed by `SetTargetNode`'s parent-chain walk.
- **`BGSCameraShot::SetLocationNode(NiAVObject*)`** — mirrors `SetTargetNode`, but for `locationNode`.
- **`BGSCameraShot::Play(TESObjectREFR*, std::int32_t)`** — starts the shot: requests the camera model, validates its `NiCamera`/interpolator, sets up VATS dolly-timing state, plays the transition sound.
- **`BGSCameraShot::Update(float)`** — per-frame position/frustum tick. Its real signature takes a `float a_currentTime` that only AE's decompiler surfaced explicitly (SE/VR folded it into an implicit incoming XMM register).
- **`ImageSpaceModifierInstanceForm::SetTarget(...)`** — retargets an already-active instance; returns `false` without effect if a lock-like flag is set on either the current or new target.
- **`ShadowSceneNode::AddLight(NiLight*)`** — a convenience overload of the existing `AddLight(NiLight*, LIGHT_CREATE_PARAMS&)`, filling fixed defaults (non-shadow, non-portal-strict, never-fades).

## Address ids

Companion PRs: alandtse/skyrim_vr_address_library#132, alandtse/skyrim_vr_address_library#135.

## Verification

Decompiled on SE, cross-checked on AE and VR (mostly via `VATS::SetMode`/`UpdateKillCam`'s call graph, whose VR/AE addresses PR #204 already established, and via the `BGSCameraShot` method cluster's own internal proximity for the later three). Builds clean on `debug-msvc-vcpkg-vr` and `debug-msvc-vcpkg-all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)