### PR TITLE
feat(vm): bind SkyrimVM::Freeze

### DIFF
--- a/include/RE/S/SkyrimVM.h
+++ b/include/RE/S/SkyrimVM.h
@@ -290,6 +290,9 @@ namespace RE
 		void RelayEvent(VMHandle handle, BSFixedString* event, BSScript::IFunctionArguments* args, ISendEventFilter* optionalFilter);
 		void SendAndRelayEvent(VMHandle handle, BSFixedString* event, BSScript::IFunctionArguments* args, ISendEventFilter* optionalFilter);
 
+		// Blocks the calling thread, pumping ProcessRegisteredUpdates, until isFrozen or a timeout.
+		void Freeze();
+
 		// members
 		BSTSmartPointer<BSScript::IVirtualMachine> impl;                       // 0200
 		BSScript::IVMSaveLoadInterface*            saveLoadInterface;          // 0208

--- a/include/RE/S/SkyrimVM.h
+++ b/include/RE/S/SkyrimVM.h
@@ -290,7 +290,8 @@ namespace RE
 		void RelayEvent(VMHandle handle, BSFixedString* event, BSScript::IFunctionArguments* args, ISendEventFilter* optionalFilter);
 		void SendAndRelayEvent(VMHandle handle, BSFixedString* event, BSScript::IFunctionArguments* args, ISendEventFilter* optionalFilter);
 
-		// Blocks the calling thread, pumping ProcessRegisteredUpdates, until isFrozen or a timeout.
+		// Blocks the calling thread, pumping ProcessRegisteredUpdates, until GetIsFrozen() returns true
+		// (see BSScript::IFreezeQuery) or a timeout.
 		void Freeze();
 
 		// members

--- a/src/RE/S/SkyrimVM.cpp
+++ b/src/RE/S/SkyrimVM.cpp
@@ -30,4 +30,11 @@ namespace RE
 		impl.get()->SendEvent(a_handle, *a_event, a_args);
 		RelayEvent(a_handle, a_event, a_args, a_optionalFilter);
 	}
+
+	void SkyrimVM::Freeze()
+	{
+		using func_t = decltype(&SkyrimVM::Freeze);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(53204, 54015) };
+		return func(this);
+	}
 }


### PR DESCRIPTION
## What

Found while tracing \`BGSSaveLoadManager\`'s save/load reset call graph — a continuation of the RE thread started in PR #203.

**\`SkyrimVM::Freeze()\`** — blocks the calling thread, pumping \`ProcessRegisteredUpdates\`, until \`isFrozen()\` returns true or a timeout elapses. Confirmed by a literal log string on the timeout path: \`"error: VM timed out while waiting to freeze! Save will be bad."\`

## Address ids

Companion PR: alandtse/skyrim_vr_address_library#134.

## Verification

Decompiled on SE, cross-checked on AE and VR by locating the same relative position in \`SkyrimVM\`'s function cluster (anchored on the already-catalogued \`QueuePostRenderCall\`/\`RelayEvent\`). Builds clean on \`debug-msvc-vcpkg-vr\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)