### PR TITLE
feat(refr): bind TESObjectREFR::GetRotationMatrix

### DIFF
--- a/include/RE/T/TESObjectREFR.h
+++ b/include/RE/T/TESObjectREFR.h
@@ -48,6 +48,7 @@ namespace RE
 	class NiAVObject;
 	class NiControllerManager;
 	class NiControllerSequence;
+	class NiMatrix3;
 	class NiNode;
 	class NiObject;
 	class Projectile;
@@ -414,6 +415,7 @@ namespace RE
 		[[nodiscard]] constexpr float                   GetPositionX() const noexcept { return data.location.x; }
 		[[nodiscard]] constexpr float                   GetPositionY() const noexcept { return data.location.y; }
 		[[nodiscard]] constexpr float                   GetPositionZ() const noexcept { return data.location.z; }
+		[[nodiscard]] NiMatrix3*                        GetRotationMatrix(NiMatrix3* a_out) const;
 		[[nodiscard]] float                             GetScale() const;
 		[[nodiscard]] NiControllerSequence*             GetSequence(stl::zstring a_name) const;
 		[[nodiscard]] std::uint32_t                     GetStealValue(const InventoryEntryData* a_entryData, std::uint32_t a_numItems, bool a_useMult) const;

--- a/src/RE/T/TESObjectREFR.cpp
+++ b/src/RE/T/TESObjectREFR.cpp
@@ -22,6 +22,7 @@
 #include "RE/N/NiControllerManager.h"
 #include "RE/N/NiControllerSequence.h"
 #include "RE/N/NiMath.h"
+#include "RE/N/NiMatrix3.h"
 #include "RE/N/NiTimeController.h"
 #include "RE/T/TESContainer.h"
 #include "RE/T/TESDataHandler.h"
@@ -566,6 +567,13 @@ namespace RE
 		using func_t = decltype(&TESObjectREFR::GetOwner);
 		static REL::Relocation<func_t> func{ RELOCATION_ID(19789, 20194) };
 		return func(this);
+	}
+
+	NiMatrix3* TESObjectREFR::GetRotationMatrix(NiMatrix3* a_out) const
+	{
+		using func_t = decltype(&TESObjectREFR::GetRotationMatrix);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(19325, 19752) };
+		return func(this, a_out);
 	}
 
 	float TESObjectREFR::GetScale() const


### PR DESCRIPTION
## What

Found via reuse-count triage rather than a single call site: **\`TESObjectREFR::GetRotationMatrix(NiMatrix3* a_out)\`** is called from **27 distinct functions** across the binary (\`BGSCameraShot::SetLocationNode\`/\`Play\`, \`CheckAttack\`, \`Rotate\`, \`SetRotation\`, \`MoveToInteractionLocation\`, and more) — one of the more load-bearing unnamed \`TESObjectREFR\` internals.

## Also resolved (no new binding)

Its callee at SE \`0x140c544e0\` was mis-attributed to \`TESObjectREFR::\` by auto-analysis — the first parameter was force-typed as \`this\`, but it's actually a raw \`NiMatrix3*\` out-buffer. It's the same euler-angle-to-matrix math already reimplemented in CommonLibVR as \`NiMatrix3::SetEulerAnglesXYZ(float, float, float)\`, so no separate address binding was needed.

## Address ids

Companion PR: alandtse/skyrim_vr_address_library#136.

## Verification

Decompiled on SE, cross-checked on AE and VR via the neighboring \`TESObjectREFR::SetAngle\`/\`FindReferenceFor3D\` anchors already bound in this header. Builds clean on \`debug-msvc-vcpkg-vr\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)