### PR TITLE
fix(playercharacter): correct AE quest offsets

### DIFF
--- a/include/RE/P/PlayerCharacter.h
+++ b/include/RE/P/PlayerCharacter.h
@@ -997,8 +997,8 @@ namespace RE
 		// plus WriteToSaveGame/FinishLoadGame (questLog, questTargets) in all three binaries.
 		using QuestTargetsMap = BSTHashMap<TESQuest*, BSTArray<TESQuestTarget*>*>;
 		RUNTIME_MEMBER_ACCESSOR_VERSIONED(BSSpinLock, GetQuestTargetsLock, SKSE::RUNTIME_SSE_1_6_629, 0x3D8, 0x9C8, 0x3E0);
-		RUNTIME_MEMBER_ACCESSOR_VERSIONED(BSSimpleList<TESQuestStageItem*>, GetQuestLog, SKSE::RUNTIME_SSE_1_6_629, 0x570, 0xB60, 0x570);
-		RUNTIME_MEMBER_ACCESSOR_VERSIONED(QuestTargetsMap, GetQuestTargets, SKSE::RUNTIME_SSE_1_6_629, 0x598, 0xB88, 0x598);
+		RUNTIME_MEMBER_ACCESSOR_VERSIONED(BSSimpleList<TESQuestStageItem*>, GetQuestLog, SKSE::RUNTIME_SSE_1_6_629, 0x570, 0xB60, 0x578);
+		RUNTIME_MEMBER_ACCESSOR_VERSIONED(QuestTargetsMap, GetQuestTargets, SKSE::RUNTIME_SSE_1_6_629, 0x598, 0xB88, 0x5A0);
 
 		RUNTIME_MEMBER_ACCESSOR_VERSIONED(INFO_RUNTIME_DATA, GetInfoRuntimeData, SKSE::RUNTIME_SSE_1_6_629, 0x8E4, 0x8E4, 0x8EC);
 


### PR DESCRIPTION
## Problem

#210's `GetQuestLog`/`GetQuestTargets` accessors pass the SE offset as the AE (≥ 1.6.629) argument of `RUNTIME_MEMBER_ACCESSOR_VERSIONED` (arg order is `SE, VR, AE`). On AE ≥ 1.6.629 both accessors return references 8 bytes low. Reported by @langfod in #207.

## Verification

Walked `PlayerCharacter`'s vtable (slot 0x12, `Revert`) in all three binaries and matched the quest-member access patterns instruction-for-instruction:

| member | SE 1.5.97 | VR 1.4.15 | AE 1.6.1170 |
|---|---|---|---|
| `questLog` | `0x570` | `0xB60` | **`0x578`** (head store `[this+0x578]`) |
| `questTargets` | `0x598` | `0xB88` | **`0x5A0`** (hashmap capacity `[this+0x5AC]` = +0xC) |

Internal consistency check: every other versioned accessor in the file already has AE = SE + 8 (`GetCrimeValue`, `GetRaceData`, `GetGameStatsData`, `GetPlayerFlags`, `GetQuestTargetsLock`); these two were the only AE == SE outliers. SE and VR arguments are unchanged — VR `0xB60`/`0xB88` re-verified in the VR binary, so #210's VR fix stands.

Change is two integer literals in the accessor macro arguments; no layout/struct edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EEz3ZzFwhSRdd7q3UujymD
