### PR TITLE
fix(form): null-check GetFile(0) in GetLocalFormID

### DIFF
--- a/include/RE/T/TESForm.h
+++ b/include/RE/T/TESForm.h
@@ -295,6 +295,9 @@ namespace RE
 		[[nodiscard]] FormID GetLocalFormID() const
 		{
 			auto file = GetFile(0);
+			if (!file) {
+				return formID;
+			}
 
 			RE::FormID fileIndex = file->compileIndex << (3 * 8);
 			fileIndex += file->smallFileCompileIndex << ((1 * 8) + 4);


### PR DESCRIPTION
Fixes #91. Forms with no originating mod file (e.g. the player, form ID 0x14) crash on the unguarded `file->compileIndex` dereference since `GetFile(0)` returns nullptr for them. Mirrors the null-check pattern already used by `GetRawFormID` just above it in the same file — when there's no file, the ID has nothing to strip, so return `formID` unchanged.