### PR TITLE
fix(prebuilt): fall back to source on MSVC mismatch

### DIFF
--- a/.github/workflows/prebuilt.yml
+++ b/.github/workflows/prebuilt.yml
@@ -246,12 +246,8 @@ jobs:
           # openvr_api.lib is linked PUBLIC by the IMPORTED target, so it ships in the bundle.
           Copy-Item extern/openvr/lib/win64/openvr_api.lib "$stage/lib/"
           Copy-Item PREBUILT.md "$stage/"
-          # Stamp the producing cl.exe version so a consumer's cmake/Prebuilt.cmake can refuse
-          # (and fall back to source) a different toolset that may lack MSVC STL internal
-          # dispatch symbols this bundle's objects reference (see Prebuilt.cmake for detail).
-          # Reads the file-version resource directly rather than scraping the usage banner:
-          # locale-independent, and matches the dotted numbering CMAKE_CXX_COMPILER_VERSION
-          # reports on the consumer side.
+          # Stamp the toolset version (Prebuilt.cmake's compatibility gate); the file-version
+          # resource, not the usage banner, is locale-independent and matches CMake's own format.
           $clPath = (Get-Command cl.exe -ErrorAction Stop).Source
           $clVersion = (Get-Item $clPath).VersionInfo.FileVersion
           if (-not $clVersion) { Write-Error "could not read cl.exe FileVersion"; exit 1 }

--- a/.github/workflows/prebuilt.yml
+++ b/.github/workflows/prebuilt.yml
@@ -246,6 +246,16 @@ jobs:
           # openvr_api.lib is linked PUBLIC by the IMPORTED target, so it ships in the bundle.
           Copy-Item extern/openvr/lib/win64/openvr_api.lib "$stage/lib/"
           Copy-Item PREBUILT.md "$stage/"
+          # Stamp the producing cl.exe version so a consumer's cmake/Prebuilt.cmake can refuse
+          # (and fall back to source) a different toolset that may lack MSVC STL internal
+          # dispatch symbols this bundle's objects reference (see Prebuilt.cmake for detail).
+          # Reads the file-version resource directly rather than scraping the usage banner:
+          # locale-independent, and matches the dotted numbering CMAKE_CXX_COMPILER_VERSION
+          # reports on the consumer side.
+          $clPath = (Get-Command cl.exe -ErrorAction Stop).Source
+          $clVersion = (Get-Item $clPath).VersionInfo.FileVersion
+          if (-not $clVersion) { Write-Error "could not read cl.exe FileVersion"; exit 1 }
+          $clVersion | Out-File "$stage/TOOLSET_VERSION.txt" -Encoding ascii -NoNewline
           Copy-Item -Recurse include "$stage/include"
           Copy-Item -Recurse extern/openvr/headers "$stage/extern/openvr/headers"
           # .zip so the consumer's file(ARCHIVE_EXTRACT) (libarchive) unpacks it reliably.

--- a/PREBUILT.md
+++ b/PREBUILT.md
@@ -138,7 +138,22 @@ top-level project is CommonLib itself (you only auto-fetch when *consumed*), a D
 multi-config build (the bundle is Release `/MD`; a Debug `/MDd` link would be an ABI
 mismatch), a **static-CRT** consumer (`/MT` / the `x64-windows-static` triplet — the bundle
 is `/MD`, so the CRTs would collide), not on an exact tag, a dirty tree, options that don't
-match the baked config, or a missing/unverified asset.
+match the baked config, a missing/unverified asset, or a **different MSVC toolset** than the
+one that produced the bundle (see below).
+
+A CRT/config match doesn't guarantee the bundle links: its objects may reference MSVC STL
+internal dispatch helpers (e.g. `__std_replace_copy_2`) that only exist in the import libs of
+a specific toolset/SDK vintage — not part of the stable ABI, so a toolset mismatch in either
+direction can hit a deep `LNK2001` at final link that a CRT/config check can't predict. The
+bundle carries a `TOOLSET_VERSION.txt` stamp (the producing `cl.exe` version); `Prebuilt.cmake`
+rejects the bundle — falling back to source, with a `STATUS` message — unless the consumer's
+toolset shares the same **major.minor** version (an exact patch/build match would over-trigger
+on ordinary servicing updates that change nothing relevant). This only protects against
+version *drift*, not a preview/Insiders channel that has genuinely dropped or not-yet-added a
+given internal symbol at the same nominal version — that residual case still needs a manual
+`-DCOMMONLIB_PREBUILT=OFF`. A bundle published before this stamp existed, or a non-MSVC/clang-cl
+compiler (whose reported version isn't the cl.exe toolset version this stamp compares against),
+is treated as compatible (no change for already-published tags).
 
 A **multi-config generator** (Visual Studio) is skipped by default because the config is
 chosen at build time, so Debug can't be ruled out. A consumer that only ever builds

--- a/cmake/Prebuilt.cmake
+++ b/cmake/Prebuilt.cmake
@@ -23,6 +23,46 @@ function(_commonlib_prebuilt_complete dir out_var)
     endif()
 endfunction()
 
+# A CRT/config match (checked by the caller) doesn't guarantee the bundle links: its objects
+# may reference MSVC STL internal dispatch helpers (e.g. __std_replace_copy_2) that only exist
+# in the import libs of a specific toolset/SDK vintage — these aren't part of the stable ABI,
+# so a mismatch in EITHER direction can hit a deep LNK2001 at final link (a newer consumer
+# toolset isn't safe either: MS can drop an internal helper a preview channel had, as observed
+# between a stable release and a newer VS Insiders build). TOOLSET_VERSION.txt (added to the
+# bundle by prebuilt.yml's assemble step) records the producer's cl.exe version; require the
+# same major.minor toolset (an exact patch/build match would over-trigger on ordinary
+# servicing updates that change nothing relevant). Missing stamp (a bundle published before
+# this check existed), or CMAKE_CXX_COMPILER_VERSION not yet available (CXX not enabled at
+# this point), is treated as compatible — matching prior behavior for already-published tags.
+# Gated on CMAKE_CXX_COMPILER_ID rather than the MSVC variable: MSVC is also TRUE for clang-cl,
+# whose CMAKE_CXX_COMPILER_VERSION is the Clang version, not the cl.exe version this stamp
+# records, so comparing them would be comparing two unrelated numbering schemes.
+function(_commonlib_prebuilt_toolset_compatible dir out_var)
+    set(${out_var} TRUE PARENT_SCOPE)
+    if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR NOT CMAKE_CXX_COMPILER_VERSION)
+        return()
+    endif()
+    set(_stamp "${dir}/TOOLSET_VERSION.txt")
+    if(NOT EXISTS "${_stamp}")
+        return()
+    endif()
+    file(READ "${_stamp}" _producer_version)
+    string(STRIP "${_producer_version}" _producer_version)
+    if(NOT _producer_version MATCHES "^[0-9]+\\.[0-9]+(\\.[0-9]+)*$")
+        return()
+    endif()
+    string(REGEX MATCH "^([0-9]+)\\.([0-9]+)" _ignore "${_producer_version}")
+    set(_producer_majmin "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}")
+    string(REGEX MATCH "^([0-9]+)\\.([0-9]+)" _ignore "${CMAKE_CXX_COMPILER_VERSION}")
+    set(_consumer_majmin "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}")
+    if(NOT _consumer_majmin STREQUAL _producer_majmin)
+        set(${out_var} FALSE PARENT_SCOPE)
+        message(STATUS "CommonLibSSE prebuilt bundle was built with a different MSVC toolset "
+                        "(${_producer_version}) than this one (${CMAKE_CXX_COMPILER_VERSION}) "
+                        "- building from source instead of risking an unresolved-STL-symbol link.")
+    endif()
+endfunction()
+
 function(commonlib_resolve_prebuilt out_dir)
     set(${out_dir} "" PARENT_SCOPE)
 
@@ -54,11 +94,17 @@ function(commonlib_resolve_prebuilt out_dir)
         return()
     endif()
 
-    # explicit override: a consumer (or this repo's self-test) points at an extracted bundle
+    # explicit override: a consumer (or this repo's self-test) points at an extracted bundle.
+    # An incomplete override falls through to auto-fetch (existing behavior); a complete but
+    # toolset-incompatible one returns empty rather than silently auto-fetching an unrelated
+    # release tag the caller didn't ask for.
     if(COMMONLIB_PREBUILT_DIR)
         _commonlib_prebuilt_complete("${COMMONLIB_PREBUILT_DIR}" _ok)
         if(_ok)
-            set(${out_dir} "${COMMONLIB_PREBUILT_DIR}" PARENT_SCOPE)
+            _commonlib_prebuilt_toolset_compatible("${COMMONLIB_PREBUILT_DIR}" _toolset_ok)
+            if(_toolset_ok)
+                set(${out_dir} "${COMMONLIB_PREBUILT_DIR}" PARENT_SCOPE)
+            endif()
             return()
         endif()
     endif()
@@ -95,7 +141,14 @@ function(commonlib_resolve_prebuilt out_dir)
     set(_cache "${CMAKE_CURRENT_BINARY_DIR}/.prebuilt/${_tag}")
     _commonlib_prebuilt_complete("${_cache}" _ok)
     if(_ok)
-        set(${out_dir} "${_cache}" PARENT_SCOPE)
+        # A complete-but-toolset-incompatible cache is left as-is (no .failed marker): the
+        # completeness check above always wins on a later run, so a marker here would never
+        # be read — and leaving the extracted bundle in place lets a later run re-check
+        # cheaply if the consumer's toolset changes, without re-downloading.
+        _commonlib_prebuilt_toolset_compatible("${_cache}" _toolset_ok)
+        if(_toolset_ok)
+            set(${out_dir} "${_cache}" PARENT_SCOPE)
+        endif()
         return()
     endif()
     if(EXISTS "${_cache}/.failed")
@@ -135,6 +188,12 @@ function(commonlib_resolve_prebuilt out_dir)
     if(NOT _ok)
         file(MAKE_DIRECTORY "${_cache}")
         file(TOUCH "${_cache}/.failed")
+        return()
+    endif()
+    # No .failed marker on toolset incompatibility here either — see the cached-bundle
+    # short-circuit above for why it would never be read back.
+    _commonlib_prebuilt_toolset_compatible("${_cache}" _toolset_ok)
+    if(NOT _toolset_ok)
         return()
     endif()
     set(${out_dir} "${_cache}" PARENT_SCOPE)

--- a/cmake/Prebuilt.cmake
+++ b/cmake/Prebuilt.cmake
@@ -23,20 +23,11 @@ function(_commonlib_prebuilt_complete dir out_var)
     endif()
 endfunction()
 
-# A CRT/config match (checked by the caller) doesn't guarantee the bundle links: its objects
-# may reference MSVC STL internal dispatch helpers (e.g. __std_replace_copy_2) that only exist
-# in the import libs of a specific toolset/SDK vintage — these aren't part of the stable ABI,
-# so a mismatch in EITHER direction can hit a deep LNK2001 at final link (a newer consumer
-# toolset isn't safe either: MS can drop an internal helper a preview channel had, as observed
-# between a stable release and a newer VS Insiders build). TOOLSET_VERSION.txt (added to the
-# bundle by prebuilt.yml's assemble step) records the producer's cl.exe version; require the
-# same major.minor toolset (an exact patch/build match would over-trigger on ordinary
-# servicing updates that change nothing relevant). Missing stamp (a bundle published before
-# this check existed), or CMAKE_CXX_COMPILER_VERSION not yet available (CXX not enabled at
-# this point), is treated as compatible — matching prior behavior for already-published tags.
-# Gated on CMAKE_CXX_COMPILER_ID rather than the MSVC variable: MSVC is also TRUE for clang-cl,
-# whose CMAKE_CXX_COMPILER_VERSION is the Clang version, not the cl.exe version this stamp
-# records, so comparing them would be comparing two unrelated numbering schemes.
+# A CRT/config match doesn't guarantee the bundle links: MSVC STL internal dispatch helpers
+# (e.g. __std_replace_copy_2) aren't part of the stable ABI, so a toolset mismatch in either
+# direction can LNK2001 at final link. Requires matching major.minor against TOOLSET_VERSION.txt
+# (a bundle/compiler predating this stamp is treated as compatible); CMAKE_CXX_COMPILER_ID, not
+# MSVC, since MSVC is also TRUE for clang-cl, whose version isn't the cl.exe one being compared.
 function(_commonlib_prebuilt_toolset_compatible dir out_var)
     set(${out_var} TRUE PARENT_SCOPE)
     if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR NOT CMAKE_CXX_COMPILER_VERSION)
@@ -95,9 +86,8 @@ function(commonlib_resolve_prebuilt out_dir)
     endif()
 
     # explicit override: a consumer (or this repo's self-test) points at an extracted bundle.
-    # An incomplete override falls through to auto-fetch (existing behavior); a complete but
-    # toolset-incompatible one returns empty rather than silently auto-fetching an unrelated
-    # release tag the caller didn't ask for.
+    # Incomplete falls through to auto-fetch (existing behavior); toolset-incompatible returns
+    # empty instead, so it doesn't silently auto-fetch an unrelated tag.
     if(COMMONLIB_PREBUILT_DIR)
         _commonlib_prebuilt_complete("${COMMONLIB_PREBUILT_DIR}" _ok)
         if(_ok)
@@ -141,10 +131,8 @@ function(commonlib_resolve_prebuilt out_dir)
     set(_cache "${CMAKE_CURRENT_BINARY_DIR}/.prebuilt/${_tag}")
     _commonlib_prebuilt_complete("${_cache}" _ok)
     if(_ok)
-        # A complete-but-toolset-incompatible cache is left as-is (no .failed marker): the
-        # completeness check above always wins on a later run, so a marker here would never
-        # be read — and leaving the extracted bundle in place lets a later run re-check
-        # cheaply if the consumer's toolset changes, without re-downloading.
+        # No .failed marker for toolset incompatibility: completeness always wins on a later
+        # run, so a marker here would never be read, and this lets a toolset upgrade retry free.
         _commonlib_prebuilt_toolset_compatible("${_cache}" _toolset_ok)
         if(_toolset_ok)
             set(${out_dir} "${_cache}" PARENT_SCOPE)


### PR DESCRIPTION
## Summary
- A prebuilt CommonLibSSE.lib built by CI can reference MSVC STL internal dispatch helpers (e.g. `__std_replace_copy_2`) absent from a consumer's differently-versioned toolset import libs, since these aren't part of the stable ABI. This surfaced as a deep `LNK2001` for downstream consumers on a different toolset than CI's, with no actionable diagnostic — reported against an open-shaders fresh worktree build.
- `prebuilt.yml` now stamps each cmake bundle with the producing `cl.exe`'s `FileVersion` (read directly from the file's version resource, not scraped from the localized usage banner).
- `cmake/Prebuilt.cmake` compares the stamp against the consumer's `CMAKE_CXX_COMPILER_VERSION` and requires the same **major.minor** toolset (an exact patch/build match would over-trigger on ordinary servicing updates that change nothing relevant). A mismatch falls back to the existing source-build path with a `STATUS` message instead of failing deep at final link.
- A bundle published before this stamp existed, or a non-MSVC/clang-cl compiler (whose reported version isn't the cl.exe toolset version this stamp compares against), is treated as compatible — no behavior change for already-published tags.

Deliberately does **not** pin the CI producer toolset older, and adds no new CI build matrix entries — the fix is a consumer-side configure-time compatibility check, not a producer-side workaround. See discussion for why an older-toolset pin was rejected (no stable "old enough" baseline exists; even a newer VS Insiders build was observed missing a symbol a stable release had, so any fixed pin just relocates the problem).

## Known residual limitation
The major.minor check only protects against ordinary toolset *drift* (the common, reported case). It does not protect a same-nominal-version preview/Insiders channel that has genuinely dropped or not-yet-added a given internal symbol — that residual case still needs a manual `-DCOMMONLIB_PREBUILT=OFF`. Documented in PREBUILT.md.

## Test plan
- [x] Verified the version-comparison logic standalone via `cmake -P` against mock `TOOLSET_VERSION.txt` stamps: newer bundle, older bundle, same-major.minor-different-patch, missing stamp, clang-cl compiler ID, and empty `CMAKE_CXX_COMPILER_VERSION` all resolve to the expected accept/reject outcome.
- [x] Verified `Get-Item cl.exe | .VersionInfo.FileVersion` on a local VS install yields the same `19.xx.xxxxx.x` dotted format `CMAKE_CXX_COMPILER_VERSION` reports.
- [x] Adversarially reviewed (two independent passes) and iterated: fixed a missing `return()` causing unwanted auto-fetch fallthrough on an explicit `COMMONLIB_PREBUILT_DIR` override, an unguarded `CMAKE_CXX_COMPILER_ID`/clang-cl version-scheme mismatch, an unguarded empty `CMAKE_CXX_COMPILER_VERSION`, a locale-fragile `cl.exe` banner regex (replaced with the FileVersion resource read), a one-directional-only `VERSION_LESS` check that wouldn't catch a newer-consumer symbol-removal case (replaced with symmetric major.minor equality), and removed two now-dead `.failed` marker writes.
- [ ] CI `prebuilt.yml` run on this PR (producer + self-test both run on `windows-latest`, so this cannot exercise real cross-toolset drift — that's the reported bug's actual blind spot in CI, unchanged by this fix. The self-test does confirm the stamp file is produced correctly and normal same-toolset resolution still works.)