### PR TITLE
fix: missing SKSE namespace with USE_SIGNATURE_SCANNING

### DIFF
--- a/cmake/CommonLibSSE.cmake
+++ b/cmake/CommonLibSSE.cmake
@@ -119,7 +119,7 @@ function(target_commonlibsse_properties TARGET)
         endif()
 
         if(NOT ADD_COMMONLIBSSE_PLUGIN_USE_ADDRESS_LIBRARY)
-            set(commonlibsse_plugin_compatibility "VersionIndependence::SignatureScanning")
+            set(commonlibsse_plugin_compatibility "SKSE::VersionIndependence::SignatureScanning")
         else()
             set(commonlibsse_plugin_compatibility "SKSE::VersionIndependence::AddressLibrary")
         endif()


### PR DESCRIPTION
e.g.

```cmake
add_commonlibsse_plugin(
	${CURRENT_PROJECT}
	NAME "Foo"
	AUTHOR "Bar"
	USE_SIGNATURE_SCANNING
)
```

Produces a compiler error when including the generated header file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected runtime compatibility handling when no address library or explicit compatible runtimes are configured.
  * Improved generation of plugin compatibility settings for signature scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->