### PR TITLE
feat(refr): bind BGSCreatedObjectManager::AddPotion, AddPoison

### DIFF
--- a/include/RE/B/BGSCreatedObjectManager.h
+++ b/include/RE/B/BGSCreatedObjectManager.h
@@ -4,12 +4,14 @@
 #include "RE/B/BSTArray.h"
 #include "RE/B/BSTHashMap.h"
 #include "RE/B/BSTSingleton.h"
+#include "RE/B/BSTSmartPointer.h"
 #include "RE/E/Effect.h"
 
 namespace RE
 {
 	class MagicItem;
 	class EnchantmentItem;
+	class AlchemyItem;
 
 	class BGSCreatedObjectManager : public BSTSingletonSDM<BGSCreatedObjectManager>
 	{
@@ -26,6 +28,8 @@ namespace RE
 
 		EnchantmentItem* AddArmorEnchantment(BSTArray<Effect>& a_effects);
 		EnchantmentItem* AddWeaponEnchantment(BSTArray<Effect>& a_effects);
+		AlchemyItem*     AddPoison(BSTSmartPointer<AlchemyItem>& a_out, BSTArray<Effect>& a_effects);
+		AlchemyItem*     AddPotion(BSTSmartPointer<AlchemyItem>& a_out, BSTArray<Effect>& a_effects);
 		void             DestroyEnchantment(EnchantmentItem* a_enchantment, bool a_isWeapon);
 
 		// members

--- a/src/RE/B/BGSCreatedObjectManager.cpp
+++ b/src/RE/B/BGSCreatedObjectManager.cpp
@@ -22,6 +22,20 @@ namespace RE
 		return func(this, a_effects);
 	}
 
+	AlchemyItem* BGSCreatedObjectManager::AddPoison(BSTSmartPointer<AlchemyItem>& a_out, BSTArray<Effect>& a_effects)
+	{
+		using func_t = decltype(&BGSCreatedObjectManager::AddPoison);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(35266, 36168) };
+		return func(this, a_out, a_effects);
+	}
+
+	AlchemyItem* BGSCreatedObjectManager::AddPotion(BSTSmartPointer<AlchemyItem>& a_out, BSTArray<Effect>& a_effects)
+	{
+		using func_t = decltype(&BGSCreatedObjectManager::AddPotion);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(35265, 36167) };
+		return func(this, a_out, a_effects);
+	}
+
 	void BGSCreatedObjectManager::DestroyEnchantment(EnchantmentItem* a_enchantment, bool a_isWeapon)
 	{
 		using func_t = decltype(&BGSCreatedObjectManager::DestroyEnchantment);


### PR DESCRIPTION
## Summary
- Adds `BGSCreatedObjectManager::AddPotion`/`AddPoison`, the two remaining siblings of the already-bound `AddArmorEnchantment`/`AddWeaponEnchantment` -- both delegate to the same lock-guarded get-or-create pattern, but against the `potions`/`poisons` `BSTHashMap` fields via a shared helper distinguished by an `isPoison` flag (a different helper than the array-based enchantment siblings use, since potions/poisons are hash-keyed).
- ids 35263-35267 (weapon, armor, potion, poison, destroy) form one consecutive block -- strong independent confirmation these are correctly identified and ordered.
- SE (`0x14059f230`/`0x14059f2e0`), AE (`0x14062c770`/`0x14062c820`), VR (`0x1405a68f0`/`0x1405a69a0`) all confirmed structurally byte-identical via direct decompile comparison.
- Found via a `GameFunc__handler::PlayerCreatePotion` script-handler caller already named in SE, matching this session's cross-runtime-via-named-anchor technique.

## Test plan
- [x] Builds clean on all 5 presets (se/ae/vr/flatrim/all)
- [ ] CI

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>