### PR TITLE
feat(re): add NiCamera::CopyMembers, fix comment

### DIFF
--- a/include/RE/N/NiCamera.h
+++ b/include/RE/N/NiCamera.h
@@ -63,7 +63,7 @@ namespace RE
 
 		// override (NiAVObject)
 		const NiRTTI* GetRTTI() const override;                           // 02
-		NiObject*     CreateClone(NiCloningProcess& a_cloning) override;  // 17 - { return this; }
+		NiObject*     CreateClone(NiCloningProcess& a_cloning) override;  // 17
 		void          LoadBinary(NiStream& a_stream) override;            // 18 - { return; }
 		void          LinkObject(NiStream& a_stream) override;            // 19 - { return; }
 		bool          RegisterStreamables(NiStream& a_stream) override;   // 1A
@@ -82,6 +82,9 @@ namespace RE
 		bool        WindowPointToRay(std::int32_t a_x, std::int32_t a_y, NiPoint3& a_origin, NiPoint3& a_dir, float a_windowWidth, float a_windowHeight);
 		bool        WorldPtToScreenPt3(const NiPoint3& a_point, float& a_xOut, float& a_yOut, float& a_zOut, float a_zeroTolerance);
 		static bool WorldPtToScreenPt3(const float a_matrix[4][4], const NiRect<float>& a_port, const NiPoint3& a_point, float& a_xOut, float& a_yOut, float& a_zOut, float a_zeroTolerance);
+
+		// Called by CreateClone: copies worldToCam, viewFrustum, and world.translate onto a_target.
+		void CopyMembers(NiCamera* a_target, NiCloningProcess& a_cloning);
 
 		RUNTIME_DATA_ACCESSOR(RUNTIME_DATA, 0x110, 0);
 		RUNTIME_DATA_ACCESSOR_EX(RUNTIME_DATA2, GetRuntimeData2, 0x150, 0x1D0);

--- a/src/RE/N/NiCamera.cpp
+++ b/src/RE/N/NiCamera.cpp
@@ -42,4 +42,11 @@ namespace RE
 		static REL::Relocation<func_t> func{ RELOCATION_ID(69270, 70640) };
 		return func(a_matrix, a_port, a_point, a_xOut, a_yOut, a_zOut, a_zeroTolerance);
 	}
+
+	void NiCamera::CopyMembers(NiCamera* a_target, NiCloningProcess& a_cloning)
+	{
+		using func_t = decltype(&NiCamera::CopyMembers);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(69251, 70617) };
+		return func(this, a_target, a_cloning);
+	}
 }


### PR DESCRIPTION
## Summary
- `CreateClone` was documented as `{ return this; }`, implying a trivial no-op. Decompile evidence across SE, AE, and VR shows it actually allocates a real clone (matching the runtime's own `NiCamera` size) and copies members onto it.
- Adds the `CopyMembers` declaration `CreateClone` calls, and binds it via `RELOCATION_ID(69251, 70617)` - it was initially declared with no implementation, which would have failed to link if ever called.

## Dependency
The VR side of that binding needs alandtse/skyrim_vr_address_library#143 (adds id `69251` to `database.csv`) merged first - SE/AE resolve without it, but VR will not until that PR lands.

## Test plan
- [x] clang-format / CMake file list hooks pass
- [x] Built the `se` preset locally after adding the `CopyMembers` binding - clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera cloning so world-to-camera settings, view frustum data, and world translation are correctly copied to cloned cameras.
  * Enhanced compatibility and consistency when duplicating camera objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->