### PR TITLE
fix(havok): correct bhkWorldObject world field

### DIFF
--- a/include/RE/B/bhkWorldObject.h
+++ b/include/RE/B/bhkWorldObject.h
@@ -20,15 +20,18 @@ namespace RE
 		bool          RegisterStreamables(NiStream& a_stream) override;  // 1A
 		void          SaveBinary(NiStream& a_stream) override;           // 1B
 		void          AdjustRefCount(bool a_increment) override;         // 26
-		hkpWorld*     GetWorld1() override;                              // 27 - { return world; }
-		ahkpWorld*    GetWorld2() override;                              // 28 - { return world; }
+		hkpWorld*     GetWorld1() override;                              // 27 - { return referencedObject ? static_cast<hkpWorldObject*>(referencedObject.get())->world : nullptr; }
+		ahkpWorld*    GetWorld2() override;                              // 28 - same as GetWorld1
 		void          MoveToWorld(bhkWorld* a_world) override;           // 29
 
 		// add
 		virtual void Unk_32(void);  // 32 - { return Unk_29(); }
 
 		// members
-		hkpWorld* world;  // 20
+		// NOT hkpWorld* - GetWorld1/GetWorld2/MoveToWorld resolve the live hkpWorld via referencedObject
+		// instead. Low word is toggled as a flag by bhkNiCollisionObject's tree-visitor callback; the
+		// rest is unconfirmed.
+		std::uint64_t unk20;  // 20
 	};
 	static_assert(sizeof(bhkWorldObject) == 0x28);
 }


### PR DESCRIPTION
## Summary
- `bhkWorldObject::world` was declared `hkpWorld*` with `GetWorld1`/`GetWorld2` documented as trivial `{ return world; }` accessors. Disassembly (SE/AE/VR, identical) shows they actually resolve the live `hkpWorld` through `referencedObject` (`bhkRefObject+0x10`) -> `hkpWorldObject::world` (`+0x10`); `MoveToWorld` and the full destructor chain never touch `+0x20` either.
- With no accessor or lifecycle path supporting the `hkpWorld*` type, replaced the field with `unk64` (this repo's convention for confirmed-size/unconfirmed-content fields) and corrected the accessor comments to describe the actual resolved path.
- Confirmed no other file in this repo references `bhkWorldObject::world` before changing its type.

## Verification
Traced via Ghidra across SE/AE/VR:
- `GetWorld1`/`GetWorld2`: `MOV RAX,[RCX+0x10]` (referencedObject) -> null-check -> `MOV RAX,[RAX+0x10]` (matches `hkpWorldObject::world` per this repo's own header)
- `MoveToWorld`: full body reads `this+0x10` only, never `this+0x20`
- Destructor chain (`~bhkWorldObject` -> `bhkSerializable` cleanup): same, only touches `+0x10`
- Cross-checked that `referencedObject` is genuinely the live Havok object by tracing `hkpRigidBody::isActive`, which reads `(this->_base).simulationIsland` matching `hkpEntity::simulationIsland` at its documented offset (`0x130`)

## Test plan
- [ ] Docs/type-only change; no other file references the corrected field
- [ ] `clang-format` pre-commit hook passed locally