### PR TITLE
fix(controlmap): bind functions to real implementations

### DIFF
--- a/include/RE/C/ControlMap.h
+++ b/include/RE/C/ControlMap.h
@@ -107,6 +107,8 @@ namespace RE
 		void                      StoreControls();
 		void                      LoadStoredControls();
 		void                      ToggleControls(UEFlag a_flags, bool a_enable, bool a_storeState);
+		void                      GetControlsState(std::uint32_t& a_enabledControls, std::uint32_t& a_storedControls) const;
+		void                      SetControlsState(std::uint32_t a_enabledControls, std::uint32_t a_storedControls);
 
 		struct RUNTIME_DATA
 		{

--- a/include/RE/C/ControlMap.h
+++ b/include/RE/C/ControlMap.h
@@ -90,6 +90,7 @@ namespace RE
 		bool                      GetMappingFromEventName(const BSFixedString& a_eventID, UserEvents::INPUT_CONTEXT_ID a_context, INPUT_DEVICE a_device, UserEventMapping& a_mapping);
 		std::string_view          GetUserEventName(std::uint32_t a_buttonID, INPUT_DEVICE a_device, InputContextID a_context = InputContextID::kGameplay) const;
 		constexpr PC_GAMEPAD_TYPE GetGamePadType() const noexcept { return GetRuntimeData().gamePadMapType.get(); }
+		void                      SetGamePadType(PC_GAMEPAD_TYPE a_gamePadType);
 		constexpr bool            IsActivateControlsEnabled() const noexcept { return GetRuntimeData().enabledControls.all(UEFlag::kActivate); }
 		constexpr bool            IsConsoleControlsEnabled() const noexcept { return GetRuntimeData().enabledControls.all(UEFlag::kConsole); }
 		constexpr bool            IsFightingControlsEnabled() const noexcept { return GetRuntimeData().enabledControls.all(UEFlag::kFighting); }

--- a/include/RE/C/ControlMap.h
+++ b/include/RE/C/ControlMap.h
@@ -83,7 +83,7 @@ namespace RE
 
 		static ControlMap* GetSingleton();
 
-		std::int8_t               AllowTextInput(bool a_allow);
+		void                      AllowTextInput(bool a_allow);
 		constexpr bool            AreControlsEnabled(UEFlag a_flags) const noexcept { return GetRuntimeData().enabledControls.all(a_flags); }
 		bool                      GetButtonNameFromUserEvent(const BSFixedString& a_eventID, INPUT_DEVICE a_device, BSFixedString& a_buttonName);
 		std::uint32_t             GetMappedKey(std::string_view a_eventID, INPUT_DEVICE a_device, InputContextID a_context = InputContextID::kGameplay) const;

--- a/include/RE/C/ControlMap.h
+++ b/include/RE/C/ControlMap.h
@@ -109,6 +109,7 @@ namespace RE
 		void                      ToggleControls(UEFlag a_flags, bool a_enable, bool a_storeState);
 		void                      GetControlsState(std::uint32_t& a_enabledControls, std::uint32_t& a_storedControls) const;
 		void                      SetControlsState(std::uint32_t a_enabledControls, std::uint32_t a_storedControls);
+		void                      ResetControls();
 
 		struct RUNTIME_DATA
 		{

--- a/src/RE/B/BSInputDeviceManager.cpp
+++ b/src/RE/B/BSInputDeviceManager.cpp
@@ -18,8 +18,9 @@ namespace RE
 
 	bool BSInputDeviceManager::GetButtonNameFromID(INPUT_DEVICE a_device, std::int32_t a_id, BSFixedString& a_buttonName) const
 	{
-		const auto device = devices[a_device];
-		return device && device->GetButtonNameFromID(a_id, a_buttonName);
+		using func_t = decltype(&BSInputDeviceManager::GetButtonNameFromID);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67316, 68618) };
+		return func(this, a_device, a_id, a_buttonName);
 	}
 
 	BSPCGamepadDeviceDelegate* BSInputDeviceManager::GetGamepad()

--- a/src/RE/C/ControlMap.cpp
+++ b/src/RE/C/ControlMap.cpp
@@ -135,4 +135,11 @@ namespace RE
 		static REL::Relocation<func_t> func{ RELOCATION_ID(67250, 68550) };
 		return func(this);
 	}
+
+	void ControlMap::SetGamePadType(PC_GAMEPAD_TYPE a_gamePadType)
+	{
+		using func_t = decltype(&ControlMap::SetGamePadType);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67237, 68537) };
+		return func(this, a_gamePadType);
+	}
 }

--- a/src/RE/C/ControlMap.cpp
+++ b/src/RE/C/ControlMap.cpp
@@ -1,7 +1,6 @@
 #include "RE/C/ControlMap.h"
 
 #include "RE/B/BSInputDeviceManager.h"
-#include "RE/U/UserEventEnabled.h"
 
 namespace RE
 {
@@ -115,41 +114,36 @@ namespace RE
 
 	void ControlMap::StoreControls()
 	{
-		auto& rd = GetRuntimeData();
-		if (rd.storedControls == UEFlag::kInvalid) {
-			rd.storedControls = rd.enabledControls;
-		}
+		using func_t = decltype(&ControlMap::StoreControls);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67246, 68546) };
+		return func(this);
 	}
 
 	void ControlMap::LoadStoredControls()
 	{
-		auto& rd = GetRuntimeData();
-		if (rd.storedControls != UEFlag::kInvalid) {
-			rd.enabledControls = rd.storedControls;
-			rd.storedControls = UEFlag::kInvalid;
-		}
+		using func_t = decltype(&ControlMap::LoadStoredControls);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67247, 68547) };
+		return func(this);
 	}
 
 	void ControlMap::ToggleControls(UEFlag a_flags, bool a_enable, bool a_storeState)
 	{
-		auto& rd = GetRuntimeData();
-		auto  oldState = rd.enabledControls;
+		using func_t = decltype(&ControlMap::ToggleControls);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67245, 68545) };
+		return func(this, a_flags, a_enable, a_storeState);
+	}
 
-		// update enabled controls
-		if (a_enable)
-			rd.enabledControls.set(a_flags);
-		else
-			rd.enabledControls.reset(a_flags);
+	void ControlMap::GetControlsState(std::uint32_t& a_enabledControls, std::uint32_t& a_storedControls) const
+	{
+		using func_t = decltype(&ControlMap::GetControlsState);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67248, 68548) };
+		return func(this, a_enabledControls, a_storedControls);
+	}
 
-		// optionally store state
-		if (a_storeState && rd.storedControls != UEFlag::kInvalid) {
-			if (a_enable)
-				rd.storedControls.set(a_flags);
-			else
-				rd.storedControls.reset(a_flags);
-		}
-
-		UserEventEnabled event{ rd.enabledControls, oldState };
-		SendEvent(std::addressof(event));
+	void ControlMap::SetControlsState(std::uint32_t a_enabledControls, std::uint32_t a_storedControls)
+	{
+		using func_t = decltype(&ControlMap::SetControlsState);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67249, 68549) };
+		return func(this, a_enabledControls, a_storedControls);
 	}
 }

--- a/src/RE/C/ControlMap.cpp
+++ b/src/RE/C/ControlMap.cpp
@@ -1,7 +1,5 @@
 #include "RE/C/ControlMap.h"
 
-#include "RE/B/BSInputDeviceManager.h"
-
 namespace RE
 {
 	ControlMap* ControlMap::GetSingleton()
@@ -19,25 +17,9 @@ namespace RE
 
 	bool ControlMap::GetButtonNameFromUserEvent(const BSFixedString& a_eventID, INPUT_DEVICE a_device, BSFixedString& a_buttonName)
 	{
-		for (const auto& inputContext : controlMap) {
-			if (!inputContext) {
-				continue;
-			}
-
-			for (const auto& mapping : inputContext->deviceMappings[a_device]) {
-				if (mapping.eventID == a_eventID) {
-					if (mapping.inputKey == 0xFF) {
-						break;
-					}
-
-					const auto inputDeviceManager = BSInputDeviceManager::GetSingleton();
-					inputDeviceManager->GetButtonNameFromID(a_device, mapping.inputKey, a_buttonName);
-					return true;
-				}
-			}
-		}
-
-		return false;
+		using func_t = decltype(&ControlMap::GetButtonNameFromUserEvent);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67253, 68553) };
+		return func(this, a_eventID, a_device, a_buttonName);
 	}
 
 	std::uint32_t ControlMap::GetMappedKey(std::string_view a_eventID, INPUT_DEVICE a_device, InputContextID a_context) const
@@ -145,5 +127,12 @@ namespace RE
 		using func_t = decltype(&ControlMap::SetControlsState);
 		static REL::Relocation<func_t> func{ RELOCATION_ID(67249, 68549) };
 		return func(this, a_enabledControls, a_storedControls);
+	}
+
+	void ControlMap::ResetControls()
+	{
+		using func_t = decltype(&ControlMap::ResetControls);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67250, 68550) };
+		return func(this);
 	}
 }

--- a/src/RE/C/ControlMap.cpp
+++ b/src/RE/C/ControlMap.cpp
@@ -11,19 +11,11 @@ namespace RE
 		return *singleton;
 	}
 
-	std::int8_t ControlMap::AllowTextInput(bool a_allow)
+	void ControlMap::AllowTextInput(bool a_allow)
 	{
-		if (a_allow) {
-			if (GetRuntimeData().textEntryCount != -1) {
-				++GetRuntimeData().textEntryCount;
-			}
-		} else {
-			if (GetRuntimeData().textEntryCount != 0) {
-				--GetRuntimeData().textEntryCount;
-			}
-		}
-
-		return GetRuntimeData().textEntryCount;
+		using func_t = decltype(&ControlMap::AllowTextInput);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(67252, 68552) };
+		return func(this, a_allow);
 	}
 
 	bool ControlMap::GetButtonNameFromUserEvent(const BSFixedString& a_eventID, INPUT_DEVICE a_device, BSFixedString& a_buttonName)


### PR DESCRIPTION
## Summary
Started as a single wrong-behavior fix, expanded into a full pass over `ControlMap` per the RE protocol - verify every hand-written method against the real binary, bind what's correct, fix what's wrong, name what's newly found.

**Fixed (was wrong):**
- `AllowTextInput` - hand-written reimplementation invented an upper-bound guard (`!= -1`) and an `int8_t` return the real function (`UIManager::AllowTextInput1`) doesn't have. Verified via raw disassembly that neither code path deliberately sets a return value. Now bound and `void`.

**Verified correct, now bound for consistency (was hand-written, logically confirmed byte-for-byte against SE/AE/VR):**
- `ToggleControls`, `StoreControls`, `LoadStoredControls`, `GetButtonNameFromUserEvent`, `BSInputDeviceManager::GetButtonNameFromID`

**New, previously-undocumented additions found while reversing:**
- `GetControlsState`/`SetControlsState` - raw get/set pair for `(enabledControls, storedControls)` together, used by `FreeCameraState` to save/restore full control state around free-cam mode
- `ResetControls` - resets to defaults, called by `PlayerCharacter::Revert`
- `SetGamePadType` - remaps gamepad-device key ids to a new controller layout, complements the existing `GetGamePadType` getter

**Still open (documented in Ghidra only, not added here):** `GetMappedKey`, `GetMappingFromEventName`, `GetUserEventName` haven't been located as standalone functions - the closest related code (`CanRemapEventToKey`/`CanRemapEventToKeyAnyDevice`, the custom-keybind conflict validator) inlines equivalent lookup logic rather than calling out to separate functions, so these may not exist standalone in the compiled binary.

Depends on alandtse/skyrim_vr_address_library#145 for the VR-side ids (SE/AE resolve without it).

## Test plan
- [x] Built `se` preset after each change - clean