### PR TITLE
feat(playercontrols): add RegisterHandler

### DIFF
--- a/include/RE/P/PlayerControls.h
+++ b/include/RE/P/PlayerControls.h
@@ -46,6 +46,9 @@ namespace RE
 
 		constexpr ActivateHandler* GetActivateHandler() const noexcept { return activateHandler; }
 
+		void RegisterHandler(PlayerInputHandler* a_handler, bool a_addToHeldStateHandlers);
+		void UnregisterHandler(PlayerInputHandler* a_handler);
+
 		// members
 		std::uint8_t                  pad021;                 // 021
 		std::uint16_t                 pad022;                 // 022

--- a/src/RE/P/PlayerControls.cpp
+++ b/src/RE/P/PlayerControls.cpp
@@ -22,4 +22,18 @@ namespace RE
 		static REL::Relocation<func_t> func{ RELOCATION_ID(41257, 42336) };
 		return func(this);
 	}
+
+	void PlayerControls::RegisterHandler(PlayerInputHandler* a_handler, bool a_addToHeldStateHandlers)
+	{
+		using func_t = decltype(&PlayerControls::RegisterHandler);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(41277, 42356) };
+		return func(this, a_handler, a_addToHeldStateHandlers);
+	}
+
+	void PlayerControls::UnregisterHandler(PlayerInputHandler* a_handler)
+	{
+		using func_t = decltype(&PlayerControls::UnregisterHandler);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(41278, 42357) };
+		return func(this, a_handler);
+	}
 }


### PR DESCRIPTION
## Summary
- Bind `PlayerControls::RegisterHandler(PlayerInputHandler*, bool)` / `UnregisterHandler(PlayerInputHandler*)` — mod-visible handler registration pair, confirmed via `PlayerInputHandler::inputEventHandlingEnabled` (0x08) being toggled and dual-array insert/remove into `handlers`/`heldStateHandlers`.
- Deferred-add semantics (queued via `unk088` when handlers are mid-iteration) not modeled at the C++ API level — callers just see synchronous register/unregister.
- SE/AE/VR cross-verified via Ghidra Version Tracking; SE/VR bodies are byte-identical in size.
- Companion address entries: alandtse/skyrim_vr_address_library#146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for registering player input handlers.
  * Added support for unregistering player input handlers.
  * Registration can optionally include handlers for held input states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->