### PR TITLE
fix(menucontrols): bind real handler functions

### DIFF
--- a/include/RE/M/MenuControls.h
+++ b/include/RE/M/MenuControls.h
@@ -64,10 +64,12 @@ namespace RE
 		static MenuControls* GetSingleton();
 
 		void               AddHandler(MenuEventHandler* a_handler);
+		void               GetKeyRepeatRates(float& a_shortRate, float& a_longRate);
 		[[nodiscard]] bool InBeastForm() const noexcept { return GetRuntimeData().beastForm; }
 		void               RegisterHandler(MenuEventHandler* a_handler);
 		void               RemoveHandler(MenuEventHandler* a_handler);
 		bool               QueueScreenshot();
+		void               SetKeyRepeatRates(float a_shortRate, float a_longRate);
 		void               UnregisterHandler(MenuEventHandler* a_handler);
 
 		RUNTIME_DATA_ACCESSOR(RUNTIME_DATA, 0x80, 0x88);

--- a/src/RE/M/MenuControls.cpp
+++ b/src/RE/M/MenuControls.cpp
@@ -24,29 +24,18 @@ namespace RE
 		return RegisterHandler(a_handler);
 	}
 
+	void MenuControls::GetKeyRepeatRates(float& a_shortRate, float& a_longRate)
+	{
+		using func_t = decltype(&MenuControls::GetKeyRepeatRates);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(51360, 52207) };
+		return func(this, a_shortRate, a_longRate);
+	}
+
 	void MenuControls::RegisterHandler(MenuEventHandler* a_handler)
 	{
-		if (!a_handler) {
-			return;
-		}
-
-		if (GetRuntimeData().isProcessing) {
-			auto pos = std::find_if(regBuffer.begin(), regBuffer.end(), [a_handler](const QueuedReg& a_elem) -> bool {
-				return a_elem.handler == a_handler;
-			});
-
-			if (pos == regBuffer.end()) {
-				QueuedReg reg(a_handler, true);
-				regBuffer.push_back(std::move(reg));
-			} else {
-				pos->add = true;
-			}
-		} else {
-			a_handler->registered = true;
-			if (std::find(handlers.begin(), handlers.end(), a_handler) == handlers.end()) {
-				handlers.push_back(a_handler);
-			}
-		}
+		using func_t = decltype(&MenuControls::RegisterHandler);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(51358, 52202) };
+		return func(this, a_handler);
 	}
 
 	void MenuControls::RemoveHandler(MenuEventHandler* a_handler)
@@ -63,29 +52,17 @@ namespace RE
 		return true;
 	}
 
+	void MenuControls::SetKeyRepeatRates(float a_shortRate, float a_longRate)
+	{
+		using func_t = decltype(&MenuControls::SetKeyRepeatRates);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(51361, 52208) };
+		return func(this, a_shortRate, a_longRate);
+	}
+
 	void MenuControls::UnregisterHandler(MenuEventHandler* a_handler)
 	{
-		if (!a_handler) {
-			return;
-		}
-
-		if (GetRuntimeData().isProcessing) {
-			a_handler->registered = false;
-			auto pos = std::find_if(regBuffer.begin(), regBuffer.end(), [a_handler](const QueuedReg& a_elem) -> bool {
-				return a_elem.handler == a_handler;
-			});
-
-			if (pos == regBuffer.end()) {
-				QueuedReg reg(a_handler, false);
-				regBuffer.push_back(std::move(reg));
-			} else {
-				pos->add = false;
-			}
-		} else {
-			auto pos = std::find(handlers.begin(), handlers.end(), a_handler);
-			if (pos != handlers.end()) {
-				handlers.erase(pos);
-			}
-		}
+		using func_t = decltype(&MenuControls::UnregisterHandler);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(51359, 52203) };
+		return func(this, a_handler);
 	}
 }


### PR DESCRIPTION
## Summary
- The hand-rolled `RegisterHandler`/`UnregisterHandler` added a dedup guard (`std::find`/`std::find_if`) that the real binary does not have: the immediate-add path unconditionally pushes into `handlers` (and the deferred path unconditionally pushes into `regBuffer`), even for a handler already registered.
- Replaced both with real `RELOCATION_ID` bindings (SE 51358/51359, AE 52202/52203) rather than reimplementing, to eliminate the divergence risk.
- SE/AE/VR cross-verified via Ghidra Version Tracking + decompile diff; SE/VR bodies byte-identical in size.
- Companion address entries: alandtse/skyrim_vr_address_library#147