### PR TITLE
docs(bsinputdevicemanager): fix stale comment

### DIFF
--- a/src/RE/B/BSInputDeviceManager.cpp
+++ b/src/RE/B/BSInputDeviceManager.cpp
@@ -152,8 +152,8 @@ namespace RE
 	void BSInputDeviceManager::PollInputDevices(float a_secsSinceLastFrame)
 	{
 		// Calls Process() on each device
-		// Calls ControlMap::sub_140C11600(InputEvent*)
-		// Calls Rumble::Update_140C10860(float secsSinceLastFrame)
+		// Calls ControlMap::ProcessButtonEvent(ButtonEvent*)
+		// Calls Rumble::Update(float secsSinceLastFrame)
 		// Emits the last InputEvent
 		// resets the global BSInputEventQueue
 		using func_t = decltype(&BSInputDeviceManager::PollInputDevices);


### PR DESCRIPTION
## Summary
- The comment referenced `ControlMap::sub_140C11600` (stale/never-renamed placeholder) and `Rumble::Update_140C10860` (stale address suffix); both are now confirmed named in Ghidra as `InputManager::ProcessButtonEvent` and `Rumble::Update` respectively.
- `Rumble::Update` was previously mislabeled `BSInputDeviceManager::PollInputDevices_140c108` in Ghidra (this comment's original attribution was actually correct and caught the mislabel) -- fixed across SE/AE/VR in the same pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal comments to accurately reference current input-processing and controller-feedback routines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->