### PR TITLE
feat(menuhandlers): expose VR touchpad input

### DIFF
--- a/include/RE/D/DirectionHandler.h
+++ b/include/RE/D/DirectionHandler.h
@@ -4,6 +4,8 @@
 
 namespace RE
 {
+	class VrWandTouchpadPositionEvent;
+
 	struct DirectionHandler : public MenuEventHandler
 	{
 	public:
@@ -17,6 +19,12 @@ namespace RE
 #ifndef SKYRIM_CROSS_VR
 		bool ProcessThumbstick(ThumbstickEvent* a_event) override;  // 03 (VR 06)
 		bool ProcessButton(ButtonEvent* a_event) override;          // 05 (VR 08)
+#endif
+#if defined(EXCLUSIVE_SKYRIM_VR)
+		bool ProcessVrWandTouchpadPosition([[maybe_unused]] VrWandTouchpadPositionEvent* a_event) override
+		{
+			return false;
+		}  // VR 03
 #endif
 
 		// members

--- a/include/RE/F/FavoritesHandler.h
+++ b/include/RE/F/FavoritesHandler.h
@@ -4,6 +4,8 @@
 
 namespace RE
 {
+	class VrWandTouchpadPositionEvent;
+
 	struct FavoritesHandler : public MenuEventHandler
 	{
 	public:
@@ -17,6 +19,9 @@ namespace RE
 #ifndef SKYRIM_CROSS_VR
 		bool ProcessKinect(KinectEvent* a_event) override;  // 02 (VR 05)
 		bool ProcessButton(ButtonEvent* a_event) override;  // 05 (VR 08)
+#endif
+#if defined(EXCLUSIVE_SKYRIM_VR)
+		bool ProcessVrWandTouchpadPosition(VrWandTouchpadPositionEvent* a_event) override;  // VR 03
 #endif
 	};
 	static_assert(sizeof(FavoritesHandler) == 0x10);

--- a/include/RE/M/MenuEventHandler.h
+++ b/include/RE/M/MenuEventHandler.h
@@ -29,11 +29,13 @@ namespace RE
 		// MenuControls dispatcher routes INPUT_EVENT_TYPE::kVrTouchpadSwipe (7) -> slot 02 and
 		// kVrTouchpadPosition (6) -> slot 03; slot 04 is not routed by MenuControls.
 		//
-		// No SKYRIM_CROSS_VR accessor exists for these three (unlike the four below): RelocateVirtual
-		// needs a slot in BOTH layouts to relocate between, and flat has none for touchpad input at
-		// all (its vtable goes straight from CanProcess(01) to ProcessKinect(02)). A SKYRIM_CROSS_VR
-		// derived class genuinely cannot receive VR wand-touchpad events today; that would need a new
-		// mechanism, not a RelocateVirtual wrapper.
+		// The 3 VR-only slots have no flat-layout counterpart at all (flat's vtable goes straight
+		// from CanProcess(01) to ProcessKinect(02)), so unlike the 4 shifting methods below they
+		// can't be RelocateVirtual'd with a real SE/AE index. In SKYRIM_CROSS_VR they're exposed as
+		// runtime-guarded accessors instead (IsVR() check first, matching GetVRTouchpadData() in
+		// BSInputEventQueue.h and GetVRControllerRight() in BSInputDeviceManager.cpp) rather than a
+		// RelocateVirtual wrapper -- same "check IsVR(), no-op on flat" idiom used throughout this
+		// codebase for VR-exclusive data, just applied to a function instead of a member.
 #if defined(EXCLUSIVE_SKYRIM_VR)
 		virtual bool ProcessVrWandTouchpadSwipe(VrWandTouchpadSwipeEvent* a_event);        // VR 02 - { return false; }
 		virtual bool ProcessVrWandTouchpadPosition(VrWandTouchpadPositionEvent* a_event);  // VR 03 - { return false; }
@@ -66,6 +68,35 @@ namespace RE
 		bool ProcessButton(ButtonEvent* a_event)
 		{
 			return REL::RelocateVirtual<decltype(&MenuEventHandler::ProcessButton)>(0x05, 0x08, this, a_event);
+		}
+
+		// VR-only slots (no flat counterpart to relocate to): no-op on flat, dispatch to the real
+		// VR vtable slot only when actually running as VR. The repeated index passed as the SE/AE
+		// slot is a dead placeholder, not a real flat-layout value -- RelocateVirtual is unreachable
+		// on flat because of the IsVR() guard above it.
+		bool ProcessVrWandTouchpadSwipe(VrWandTouchpadSwipeEvent* a_event)
+		{
+			if SKYRIM_REL_VR_CONSTEXPR (!REL::Module::IsVR()) {
+				return false;
+			} else {
+				return REL::RelocateVirtual<bool(MenuEventHandler*, VrWandTouchpadSwipeEvent*)>(0x02, 0x02, this, a_event);
+			}
+		}
+		bool ProcessVrWandTouchpadPosition(VrWandTouchpadPositionEvent* a_event)
+		{
+			if SKYRIM_REL_VR_CONSTEXPR (!REL::Module::IsVR()) {
+				return false;
+			} else {
+				return REL::RelocateVirtual<bool(MenuEventHandler*, VrWandTouchpadPositionEvent*)>(0x03, 0x03, this, a_event);
+			}
+		}
+		bool Unk_04(void* a_event)
+		{
+			if SKYRIM_REL_VR_CONSTEXPR (!REL::Module::IsVR()) {
+				return false;
+			} else {
+				return REL::RelocateVirtual<bool(MenuEventHandler*, void*)>(0x04, 0x04, this, a_event);
+			}
 		}
 #endif
 

--- a/include/RE/M/MenuEventHandler.h
+++ b/include/RE/M/MenuEventHandler.h
@@ -28,6 +28,12 @@ namespace RE
 		// ProcessKinect/Thumbstick/MouseMove/Button from slots 02-05 down to 05-08. The
 		// MenuControls dispatcher routes INPUT_EVENT_TYPE::kVrTouchpadSwipe (7) -> slot 02 and
 		// kVrTouchpadPosition (6) -> slot 03; slot 04 is not routed by MenuControls.
+		//
+		// No SKYRIM_CROSS_VR accessor exists for these three (unlike the four below): RelocateVirtual
+		// needs a slot in BOTH layouts to relocate between, and flat has none for touchpad input at
+		// all (its vtable goes straight from CanProcess(01) to ProcessKinect(02)). A SKYRIM_CROSS_VR
+		// derived class genuinely cannot receive VR wand-touchpad events today; that would need a new
+		// mechanism, not a RelocateVirtual wrapper.
 #if defined(EXCLUSIVE_SKYRIM_VR)
 		virtual bool ProcessVrWandTouchpadSwipe(VrWandTouchpadSwipeEvent* a_event);        // VR 02 - { return false; }
 		virtual bool ProcessVrWandTouchpadPosition(VrWandTouchpadPositionEvent* a_event);  // VR 03 - { return false; }


### PR DESCRIPTION
## Summary
- Ghidra already had `DirectionHandler::ProcessVrWandTouchpadPosition` (trivial no-op) and `FavoritesHandler::ProcessVrWandTouchpadPosition` (real, 809-byte body) correctly named, confirming both classes genuinely compile this VR-only override -- declared in the headers now.
- `MenuEventHandler`'s 3 VR-only slots (`ProcessVrWandTouchpadSwipe`/`Position`, `Unk_04`) previously had no `SKYRIM_CROSS_VR` accessor at all, unlike the 4 shifting Kinect/Thumbstick/MouseMove/Button methods -- `RelocateVirtual` can't help here since it needs a slot in *both* layouts and flat has none for touchpad input. Added runtime-guarded accessors instead (`IsVR()` check, no-op on flat), matching the existing `GetVRTouchpadData()`/`GetVRControllerRight()` idiom already used throughout this codebase for VR-exclusive functionality -- so a `SKYRIM_CROSS_VR` ("all" preset) build, which is the dominant real-world build target, is no longer locked out of VR wand-touchpad input.
- Verified locally: `all` preset (debug, clang-cl) builds and links clean.