### PR TITLE
feat(havok): add BGSAcousticSpaceListener

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -63,6 +63,7 @@ set(SOURCES
 	include/RE/A/ahkpWorld.h
 	include/RE/B/BGSAbilityPerkEntry.h
 	include/RE/B/BGSAcousticSpace.h
+	include/RE/B/BGSAcousticSpaceListener.h
 	include/RE/B/BGSAction.h
 	include/RE/B/BGSActionData.h
 	include/RE/B/BGSActorCellEvent.h

--- a/include/RE/B/BGSAcousticSpaceListener.h
+++ b/include/RE/B/BGSAcousticSpaceListener.h
@@ -15,6 +15,10 @@ namespace RE
 		// override (hkpEntityListener)
 		void EntityRemovedCallback(hkpEntity* a_entity) override;  // 02
 
+		// add
+		virtual void Unk_06(void);  // 06 - removes an entry from an internal handle set
+		virtual void Unk_07(void);  // 07 - inserts an entry into the same handle set
+
 		// members
 		std::uint8_t unk08[0x48];  // 08 - not yet RE'd
 	};

--- a/include/RE/B/BGSAcousticSpaceListener.h
+++ b/include/RE/B/BGSAcousticSpaceListener.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "RE/H/hkpEntityListener.h"
+
+namespace RE
+{
+	class BGSAcousticSpaceListener : public hkpEntityListener
+	{
+	public:
+		inline static constexpr auto RTTI = RTTI_BGSAcousticSpaceListener;
+		inline static constexpr auto VTABLE = VTABLE_BGSAcousticSpaceListener;
+
+		~BGSAcousticSpaceListener() override;  // 00
+
+		// override (hkpEntityListener)
+		void EntityRemovedCallback(hkpEntity* a_entity) override;  // 02
+
+		// members
+		std::uint8_t unk08[0x48];  // 08 - not yet RE'd
+	};
+	static_assert(sizeof(BGSAcousticSpaceListener) == 0x50);
+}

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -66,6 +66,7 @@
 #include "RE/A/ahkpWorld.h"
 #include "RE/B/BGSAbilityPerkEntry.h"
 #include "RE/B/BGSAcousticSpace.h"
+#include "RE/B/BGSAcousticSpaceListener.h"
 #include "RE/B/BGSAction.h"
 #include "RE/B/BGSActionData.h"
 #include "RE/B/BGSActorCellEvent.h"


### PR DESCRIPTION
## Summary
- Adds `RE::BGSAcousticSpaceListener`, a Havok `hkpEntityListener` override RE'd while investigating a recurring `EXCEPTION_ACCESS_VIOLATION` in `hkpEntityListener::EntityRemovedCallback` (null `PlayerCamera::rigidBody` deref in the vanilla implementation).
- Object size (0x50) confirmed via the class's deleting-destructor's `operator delete(this, size)` call.
- Only the confirmed `EntityRemovedCallback` (slot 02) override is declared; remaining internal members are left as an unk padding block pending further RE.

## Test plan
- [x] `cmake --preset build-debug-clang-cl-vcpkg-all` + `cmake --build ... --target CommonLibSSE` succeeds (SKYRIM_CROSS_VR)