### PR TITLE
feat(havok): add hkpWorld::RemoveEntity

### DIFF
--- a/include/RE/H/hkpWorld.h
+++ b/include/RE/H/hkpWorld.h
@@ -23,6 +23,7 @@ namespace RE
 	class hkpContactImpulseLimitBreachedListener;
 	class hkpContactListener;
 	class hkpConvexListFilter;
+	class hkpEntity;
 	class hkpEntityEntityBroadPhaseListener;
 	class hkpEntityListener;
 	class hkpIslandActivationListener;
@@ -83,6 +84,13 @@ namespace RE
 			using func_t = decltype(&hkpWorld::RemovePhantom);
 			static REL::Relocation<func_t> func{ RELOCATION_ID(60504, 61316) };
 			return func(this, a_phantom);
+		}
+
+		inline void RemoveEntity(hkpEntity* a_entity)
+		{
+			using func_t = decltype(&hkpWorld::RemoveEntity);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(60493, 61305) };
+			return func(this, a_entity);
 		}
 
 		inline void CastRay(const hkpWorldRayCastInput& a_input, hkpWorldRayCastOutput& a_output) const


### PR DESCRIPTION
## Summary
- Adds `RE::hkpWorld::RemoveEntity`, following the existing `AddPhantom`/`RemovePhantom` inline-wrapper pattern in the same class.
- Locks critical operations, unlinks the entity from broadphase/simulation-island bookkeeping, fires `FireEntityRemovedCallback` for every registered `hkpEntityListener`, tears down rigid-body-specific state, then flushes any operations queued while locked.
- RE'd via the same caller-anchor technique used to identify `FireEntityRemovedCallback` while investigating the `BGSAcousticSpaceListener` crash (see #230): matched this function's SE/AE/VR call-position to the known-good SE/VR address mapping, then decompiled all three to confirm identical body shape before naming.

## Test plan
- [x] `cmake --preset build-debug-clang-cl-vcpkg-all` + `cmake --build ... --target CommonLibSSE` succeeds (SKYRIM_CROSS_VR)