### PR TITLE
feat(REL): add hook-integrity verification (REL::VerifyBytes)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,14 @@ option(REX_OPTION_INI "Enables ini config support for REX." OFF)
 option(REX_OPTION_JSON "Enables json config support for REX." OFF)
 option(REX_OPTION_TOML "Enables toml config support for REX." OFF)
 option(SKSE_SUPPORT_XBYAK "Enables trampoline support for Xbyak." OFF)
+option(SKSE_SUPPORT_PATCH_SAFETY "Validate Trampoline::write_branch patch sites land on instruction boundaries before writing (vendors hde64); logs and still writes on failure, never blocks." ON)
 option(ENABLE_SKYRIM_SE "Enable support for Skyrim SE in the dynamic runtime feature." ON)
 option(ENABLE_SKYRIM_AE "Enable support for Skyrim AE in the dynamic runtime feature." ON)
 option(ENABLE_SKYRIM_VR "Enable support for Skyrim VR in the dynamic runtime feature." ON)
 option(BUILD_TESTS "Enable building of the unit tests." ON)
 message("Options:")
 message("\tEnable Xbyak: ${SKSE_SUPPORT_XBYAK}")
+message("\tEnable Patch Safety Checks: ${SKSE_SUPPORT_PATCH_SAFETY}")
 message("\tEnable Skyrim SE: ${ENABLE_SKYRIM_SE}")
 message("\tEnable Skyrim AE: ${ENABLE_SKYRIM_AE}")
 message("\tEnable Skyrim VR: ${ENABLE_SKYRIM_VR}")
@@ -115,6 +117,27 @@ endif()
 include(cmake/sourcelist.cmake)
 include(cmake/testlist.cmake)
 
+if(SKSE_SUPPORT_PATCH_SAFETY)
+	# hde64 (Hacker Disassembler Engine 64) has no vcpkg port -- it's a 3-file, ~500-line
+	# instruction-length decoder vendored inside MinHook for exactly this purpose (deciding
+	# how many whole instructions a hotpatch jmp safely covers). Populate-only: we want the
+	# 3 files as plain sources, not MinHook's own CMake project (its own trampoline/hooking
+	# code is irrelevant here and must not be added as a subdirectory/target).
+	include(FetchContent)
+	FetchContent_Declare(
+		hde64
+		GIT_REPOSITORY https://github.com/TsudaKageyu/minhook.git
+		GIT_TAG v1.3.4
+		GIT_SHALLOW TRUE
+		# MinHook's own root CMakeLists.txt builds its full hooking library, which we don't
+		# want as a subdirectory/target. src/hde has no CMakeLists.txt of its own, so
+		# FetchContent_MakeAvailable populates the source without trying to add_subdirectory
+		# anything -- source-only fetch, no deprecated FetchContent_Populate call needed.
+		SOURCE_SUBDIR src/hde
+	)
+	FetchContent_MakeAvailable(hde64)
+endif()
+
 source_group(
 	TREE "${CMAKE_CURRENT_SOURCE_DIR}"
 	FILES ${SOURCES}
@@ -145,6 +168,7 @@ target_compile_definitions(
 	"$<$<BOOL:${REX_OPTION_JSON}>:REX_OPTION_JSON=1>"
 	"$<$<BOOL:${REX_OPTION_TOML}>:REX_OPTION_TOML=1>"
 	"$<$<BOOL:${SKSE_SUPPORT_XBYAK}>:SKSE_SUPPORT_XBYAK=1>"
+	"$<$<BOOL:${SKSE_SUPPORT_PATCH_SAFETY}>:SKSE_SUPPORT_PATCH_SAFETY=1>"
 	"$<$<BOOL:${ENABLE_SKYRIM_SE}>:ENABLE_SKYRIM_SE=1>"
 	"$<$<BOOL:${ENABLE_SKYRIM_AE}>:ENABLE_SKYRIM_AE=1>"
 	"$<$<BOOL:${ENABLE_SKYRIM_VR}>:ENABLE_SKYRIM_VR=1>"
@@ -215,6 +239,14 @@ target_include_directories(
 	${spdlog_INCLUDE_DIRS}
 	${RAPIDCSV_INCLUDE_DIRS}
 )
+
+if(SKSE_SUPPORT_PATCH_SAFETY)
+	# hde64.h is only ever included from Trampoline.cpp -- the check never appears in a
+	# public header, so PRIVATE keeps the vendored dependency off every downstream
+	# consumer's include path.
+	target_sources("${PROJECT_NAME}" PRIVATE "${hde64_SOURCE_DIR}/src/hde/hde64.c")
+	target_include_directories("${PROJECT_NAME}" PRIVATE "${hde64_SOURCE_DIR}/src/hde")
+endif()
 
 target_compile_definitions(
 	"${PROJECT_NAME}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,12 @@ if(SKSE_SUPPORT_PATCH_SAFETY)
 	# consumer's include path.
 	target_sources("${PROJECT_NAME}" PRIVATE "${hde64_SOURCE_DIR}/src/hde/hde64.c")
 	target_include_directories("${PROJECT_NAME}" PRIVATE "${hde64_SOURCE_DIR}/src/hde")
+	# The Visual Studio generator doesn't reliably infer a .c file's language when it lives
+	# outside the project's own source tree (a FetchContent _deps directory here) -- without
+	# this it silently classifies hde64.c as <None> (never compiled at all) instead of
+	# <ClCompile>, which only fails at LINK time with an unresolved hde64_disasm symbol, not
+	# at configure/compile time. Ninja-based generators infer this correctly on their own.
+	set_source_files_properties("${hde64_SOURCE_DIR}/src/hde/hde64.c" PROPERTIES LANGUAGE C)
 endif()
 
 target_compile_definitions(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,10 @@ if(SKSE_SUPPORT_PATCH_SAFETY)
 	# how many whole instructions a hotpatch jmp safely covers). Populate-only: we want the
 	# 3 files as plain sources, not MinHook's own CMake project (its own trampoline/hooking
 	# code is irrelevant here and must not be added as a subdirectory/target).
+	# hde64.c is plain C; the project only declares LANGUAGES CXX, so its LANGUAGE C source
+	# property (below) needs C explicitly enabled or Ninja-based generators fail at generate
+	# time (the Visual Studio generator tolerates the omission, Ninja does not).
+	enable_language(C)
 	include(FetchContent)
 	FetchContent_Declare(
 		hde64
@@ -251,7 +255,15 @@ if(SKSE_SUPPORT_PATCH_SAFETY)
 	# this it silently classifies hde64.c as <None> (never compiled at all) instead of
 	# <ClCompile>, which only fails at LINK time with an unresolved hde64_disasm symbol, not
 	# at configure/compile time. Ninja-based generators infer this correctly on their own.
-	set_source_files_properties("${hde64_SOURCE_DIR}/src/hde/hde64.c" PROPERTIES LANGUAGE C)
+	# A C file can't consume the project's C++ precompiled header. hde64.c is vendored,
+	# unmodified third-party source -- /WX- keeps its own build warnings from becoming
+	# errors without touching the vendored file.
+	set_source_files_properties(
+		"${hde64_SOURCE_DIR}/src/hde/hde64.c" PROPERTIES
+		LANGUAGE C
+		SKIP_PRECOMPILE_HEADERS ON
+		COMPILE_OPTIONS "$<$<CXX_COMPILER_ID:MSVC>:/WX->"
+	)
 endif()
 
 target_compile_definitions(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,14 +118,9 @@ include(cmake/sourcelist.cmake)
 include(cmake/testlist.cmake)
 
 if(SKSE_SUPPORT_PATCH_SAFETY)
-	# hde64 (Hacker Disassembler Engine 64) has no vcpkg port -- it's a 3-file, ~500-line
-	# instruction-length decoder vendored inside MinHook for exactly this purpose (deciding
-	# how many whole instructions a hotpatch jmp safely covers). Populate-only: we want the
-	# 3 files as plain sources, not MinHook's own CMake project (its own trampoline/hooking
-	# code is irrelevant here and must not be added as a subdirectory/target).
-	# hde64.c is plain C; the project only declares LANGUAGES CXX, so its LANGUAGE C source
-	# property (below) needs C explicitly enabled or Ninja-based generators fail at generate
-	# time (the Visual Studio generator tolerates the omission, Ninja does not).
+	# hde64 has no vcpkg port -- vendor MinHook's 3-file instruction-length decoder directly.
+	# LANGUAGE C (set below) needs an explicit enable_language(C), or Ninja-based
+	# generators fail at generate time (the VS generator tolerates the omission).
 	enable_language(C)
 	include(FetchContent)
 	FetchContent_Declare(
@@ -133,10 +128,8 @@ if(SKSE_SUPPORT_PATCH_SAFETY)
 		GIT_REPOSITORY https://github.com/TsudaKageyu/minhook.git
 		GIT_TAG v1.3.4
 		GIT_SHALLOW TRUE
-		# MinHook's own root CMakeLists.txt builds its full hooking library, which we don't
-		# want as a subdirectory/target. src/hde has no CMakeLists.txt of its own, so
-		# FetchContent_MakeAvailable populates the source without trying to add_subdirectory
-		# anything -- source-only fetch, no deprecated FetchContent_Populate call needed.
+		# Populate source only -- MinHook's own root CMakeLists.txt would otherwise add
+		# its full hooking library as a subdirectory/target, which we don't want.
 		SOURCE_SUBDIR src/hde
 	)
 	FetchContent_MakeAvailable(hde64)
@@ -250,14 +243,9 @@ if(SKSE_SUPPORT_PATCH_SAFETY)
 	# consumer's include path.
 	target_sources("${PROJECT_NAME}" PRIVATE "${hde64_SOURCE_DIR}/src/hde/hde64.c")
 	target_include_directories("${PROJECT_NAME}" PRIVATE "${hde64_SOURCE_DIR}/src/hde")
-	# The Visual Studio generator doesn't reliably infer a .c file's language when it lives
-	# outside the project's own source tree (a FetchContent _deps directory here) -- without
-	# this it silently classifies hde64.c as <None> (never compiled at all) instead of
-	# <ClCompile>, which only fails at LINK time with an unresolved hde64_disasm symbol, not
-	# at configure/compile time. Ninja-based generators infer this correctly on their own.
-	# A C file can't consume the project's C++ precompiled header. hde64.c is vendored,
-	# unmodified third-party source -- /WX- keeps its own build warnings from becoming
-	# errors without touching the vendored file.
+	# VS doesn't reliably infer hde64.c's LANGUAGE without this (silent <None>, fails only
+	# at link time); a vendored C file also can't use our C++ precompiled header, and /WX-
+	# keeps its own warnings from becoming errors without touching the file itself.
 	set_source_files_properties(
 		"${hde64_SOURCE_DIR}/src/hde/hde64.c" PROPERTIES
 		LANGUAGE C

--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -1958,6 +1958,7 @@ set(SOURCES
 	include/REL/REL.h
 	include/REL/Relocation.h
 	include/REL/RuntimeDataAccessors.h
+	include/REL/Verify.h
 	include/REL/Version.h
 	include/REX/PS4.h
 	include/REX/PS4/SCEPAD.h
@@ -2489,6 +2490,7 @@ set(SOURCES
 	src/REL/ID.cpp
 	src/REL/Module.cpp
 	src/REL/Relocation.cpp
+	src/REL/Verify.cpp
 	src/REL/Version.cpp
 	src/REX/REX.cpp
 	src/REX/W32.cpp

--- a/include/REL/Relocation.h
+++ b/include/REL/Relocation.h
@@ -743,32 +743,35 @@ namespace REL
 			safe_write(address(), a_data.data(), a_data.size_bytes());
 		}
 
+		// a_skipSafetyCheck: suppress the SKSE_SUPPORT_PATCH_SAFETY instruction-boundary
+		// check (see SKSE::Trampoline::write_branch) for this call site. Only pass true
+		// once you've manually verified the flagged boundary byte isn't reachable.
 		template <std::size_t N>
-		std::uintptr_t write_branch(const std::uintptr_t a_dst)
+		std::uintptr_t write_branch(const std::uintptr_t a_dst, bool a_skipSafetyCheck = false)
 			requires(std::same_as<value_type, std::uintptr_t>)
 		{
-			return SKSE::GetTrampoline().write_branch<N>(address(), a_dst);
+			return SKSE::GetTrampoline().write_branch<N>(address(), a_dst, a_skipSafetyCheck);
 		}
 
 		template <std::size_t N, class F>
-		std::uintptr_t write_branch(const F a_dst)
+		std::uintptr_t write_branch(const F a_dst, bool a_skipSafetyCheck = false)
 			requires(std::same_as<value_type, std::uintptr_t>)
 		{
-			return SKSE::GetTrampoline().write_branch<N>(address(), stl::unrestricted_cast<std::uintptr_t>(a_dst));
+			return SKSE::GetTrampoline().write_branch<N>(address(), stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck);
 		}
 
 		template <std::size_t N>
-		std::uintptr_t write_call(const std::uintptr_t a_dst)
+		std::uintptr_t write_call(const std::uintptr_t a_dst, bool a_skipSafetyCheck = false)
 			requires(std::same_as<value_type, std::uintptr_t>)
 		{
-			return SKSE::GetTrampoline().write_call<N>(address(), a_dst);
+			return SKSE::GetTrampoline().write_call<N>(address(), a_dst, a_skipSafetyCheck);
 		}
 
 		template <std::size_t N, class F>
-		std::uintptr_t write_call(const F a_dst)
+		std::uintptr_t write_call(const F a_dst, bool a_skipSafetyCheck = false)
 			requires(std::same_as<value_type, std::uintptr_t>)
 		{
-			return SKSE::GetTrampoline().write_call<N>(address(), stl::unrestricted_cast<std::uintptr_t>(a_dst));
+			return SKSE::GetTrampoline().write_call<N>(address(), stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck);
 		}
 
 		void write_fill(const std::uint8_t a_value, const std::size_t a_count)

--- a/include/REL/Relocation.h
+++ b/include/REL/Relocation.h
@@ -747,12 +747,14 @@ namespace REL
 		// check (see SKSE::Trampoline::write_branch) for this call site. Only pass true
 		// once you've manually verified the flagged boundary byte isn't reachable.
 		//
-		// a_expectedPatchHash: once you've done that verification, pass the hash the
-		// check printed (rather than a_skipSafetyCheck=true) so the check re-verifies
-		// on every launch instead of trusting you forever -- a match stays silent, a
-		// mismatch (the game binary or a conflicting mod's patch shifted since you
-		// verified) re-escalates instead of silently assuming the old verdict still
-		// holds. Leave at 0 (unset) until you have a real hash to pin.
+		// a_expectedPatchHash: once you've done that verification, pass the hash printed
+		// (rather than a_skipSafetyCheck=true) so it re-verifies on every launch instead of
+		// trusting you forever -- a match stays silent, a mismatch (the game binary or a
+		// conflicting mod's patch shifted since you verified) re-escalates instead of
+		// silently assuming the old verdict still holds. Leave at 0 (unset) until you have
+		// a real hash to pin. This only covers the boundary-overlap check's own byte range
+		// -- for hook verification generally, see REL::VerifyBytes (REL/Verify.h), which is
+		// independent of write_branch/write_call and callable on any byte range.
 		//
 		// a_loc defaults to the caller's location and is forwarded so the safety-check log
 		// line names the patch's own source file instead of Trampoline.cpp. Leave defaulted.

--- a/include/REL/Relocation.h
+++ b/include/REL/Relocation.h
@@ -746,32 +746,35 @@ namespace REL
 		// a_skipSafetyCheck: suppress the SKSE_SUPPORT_PATCH_SAFETY instruction-boundary
 		// check (see SKSE::Trampoline::write_branch) for this call site. Only pass true
 		// once you've manually verified the flagged boundary byte isn't reachable.
+		//
+		// a_loc defaults to the caller's location and is forwarded so the safety-check log
+		// line names the patch's own source file instead of Trampoline.cpp. Leave defaulted.
 		template <std::size_t N>
-		std::uintptr_t write_branch(const std::uintptr_t a_dst, bool a_skipSafetyCheck = false)
+		std::uintptr_t write_branch(const std::uintptr_t a_dst, bool a_skipSafetyCheck = false, std::source_location a_loc = std::source_location::current())
 			requires(std::same_as<value_type, std::uintptr_t>)
 		{
-			return SKSE::GetTrampoline().write_branch<N>(address(), a_dst, a_skipSafetyCheck);
+			return SKSE::GetTrampoline().write_branch<N>(address(), a_dst, a_skipSafetyCheck, a_loc);
 		}
 
 		template <std::size_t N, class F>
-		std::uintptr_t write_branch(const F a_dst, bool a_skipSafetyCheck = false)
+		std::uintptr_t write_branch(const F a_dst, bool a_skipSafetyCheck = false, std::source_location a_loc = std::source_location::current())
 			requires(std::same_as<value_type, std::uintptr_t>)
 		{
-			return SKSE::GetTrampoline().write_branch<N>(address(), stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck);
+			return SKSE::GetTrampoline().write_branch<N>(address(), stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck, a_loc);
 		}
 
 		template <std::size_t N>
-		std::uintptr_t write_call(const std::uintptr_t a_dst, bool a_skipSafetyCheck = false)
+		std::uintptr_t write_call(const std::uintptr_t a_dst, bool a_skipSafetyCheck = false, std::source_location a_loc = std::source_location::current())
 			requires(std::same_as<value_type, std::uintptr_t>)
 		{
-			return SKSE::GetTrampoline().write_call<N>(address(), a_dst, a_skipSafetyCheck);
+			return SKSE::GetTrampoline().write_call<N>(address(), a_dst, a_skipSafetyCheck, a_loc);
 		}
 
 		template <std::size_t N, class F>
-		std::uintptr_t write_call(const F a_dst, bool a_skipSafetyCheck = false)
+		std::uintptr_t write_call(const F a_dst, bool a_skipSafetyCheck = false, std::source_location a_loc = std::source_location::current())
 			requires(std::same_as<value_type, std::uintptr_t>)
 		{
-			return SKSE::GetTrampoline().write_call<N>(address(), stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck);
+			return SKSE::GetTrampoline().write_call<N>(address(), stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck, a_loc);
 		}
 
 		void write_fill(const std::uint8_t a_value, const std::size_t a_count)

--- a/include/REL/Relocation.h
+++ b/include/REL/Relocation.h
@@ -747,34 +747,41 @@ namespace REL
 		// check (see SKSE::Trampoline::write_branch) for this call site. Only pass true
 		// once you've manually verified the flagged boundary byte isn't reachable.
 		//
+		// a_expectedPatchHash: once you've done that verification, pass the hash the
+		// check printed (rather than a_skipSafetyCheck=true) so the check re-verifies
+		// on every launch instead of trusting you forever -- a match stays silent, a
+		// mismatch (the game binary or a conflicting mod's patch shifted since you
+		// verified) re-escalates instead of silently assuming the old verdict still
+		// holds. Leave at 0 (unset) until you have a real hash to pin.
+		//
 		// a_loc defaults to the caller's location and is forwarded so the safety-check log
 		// line names the patch's own source file instead of Trampoline.cpp. Leave defaulted.
 		template <std::size_t N>
-		std::uintptr_t write_branch(const std::uintptr_t a_dst, bool a_skipSafetyCheck = false, std::source_location a_loc = std::source_location::current())
+		std::uintptr_t write_branch(const std::uintptr_t a_dst, bool a_skipSafetyCheck = false, std::uint64_t a_expectedPatchHash = 0, std::source_location a_loc = std::source_location::current())
 			requires(std::same_as<value_type, std::uintptr_t>)
 		{
-			return SKSE::GetTrampoline().write_branch<N>(address(), a_dst, a_skipSafetyCheck, a_loc);
+			return SKSE::GetTrampoline().write_branch<N>(address(), a_dst, a_skipSafetyCheck, a_expectedPatchHash, a_loc);
 		}
 
 		template <std::size_t N, class F>
-		std::uintptr_t write_branch(const F a_dst, bool a_skipSafetyCheck = false, std::source_location a_loc = std::source_location::current())
+		std::uintptr_t write_branch(const F a_dst, bool a_skipSafetyCheck = false, std::uint64_t a_expectedPatchHash = 0, std::source_location a_loc = std::source_location::current())
 			requires(std::same_as<value_type, std::uintptr_t>)
 		{
-			return SKSE::GetTrampoline().write_branch<N>(address(), stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck, a_loc);
+			return SKSE::GetTrampoline().write_branch<N>(address(), stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck, a_expectedPatchHash, a_loc);
 		}
 
 		template <std::size_t N>
-		std::uintptr_t write_call(const std::uintptr_t a_dst, bool a_skipSafetyCheck = false, std::source_location a_loc = std::source_location::current())
+		std::uintptr_t write_call(const std::uintptr_t a_dst, bool a_skipSafetyCheck = false, std::uint64_t a_expectedPatchHash = 0, std::source_location a_loc = std::source_location::current())
 			requires(std::same_as<value_type, std::uintptr_t>)
 		{
-			return SKSE::GetTrampoline().write_call<N>(address(), a_dst, a_skipSafetyCheck, a_loc);
+			return SKSE::GetTrampoline().write_call<N>(address(), a_dst, a_skipSafetyCheck, a_expectedPatchHash, a_loc);
 		}
 
 		template <std::size_t N, class F>
-		std::uintptr_t write_call(const F a_dst, bool a_skipSafetyCheck = false, std::source_location a_loc = std::source_location::current())
+		std::uintptr_t write_call(const F a_dst, bool a_skipSafetyCheck = false, std::uint64_t a_expectedPatchHash = 0, std::source_location a_loc = std::source_location::current())
 			requires(std::same_as<value_type, std::uintptr_t>)
 		{
-			return SKSE::GetTrampoline().write_call<N>(address(), stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck, a_loc);
+			return SKSE::GetTrampoline().write_call<N>(address(), stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck, a_expectedPatchHash, a_loc);
 		}
 
 		void write_fill(const std::uint8_t a_value, const std::size_t a_count)

--- a/include/REL/Relocation.h
+++ b/include/REL/Relocation.h
@@ -743,21 +743,7 @@ namespace REL
 			safe_write(address(), a_data.data(), a_data.size_bytes());
 		}
 
-		// a_skipSafetyCheck: suppress the SKSE_SUPPORT_PATCH_SAFETY instruction-boundary
-		// check (see SKSE::Trampoline::write_branch) for this call site. Only pass true
-		// once you've manually verified the flagged boundary byte isn't reachable.
-		//
-		// a_expectedPatchHash: once you've done that verification, pass the hash printed
-		// (rather than a_skipSafetyCheck=true) so it re-verifies on every launch instead of
-		// trusting you forever -- a match stays silent, a mismatch (the game binary or a
-		// conflicting mod's patch shifted since you verified) re-escalates instead of
-		// silently assuming the old verdict still holds. Leave at 0 (unset) until you have
-		// a real hash to pin. This only covers the boundary-overlap check's own byte range
-		// -- for hook verification generally, see REL::VerifyBytes (REL/Verify.h), which is
-		// independent of write_branch/write_call and callable on any byte range.
-		//
-		// a_loc defaults to the caller's location and is forwarded so the safety-check log
-		// line names the patch's own source file instead of Trampoline.cpp. Leave defaulted.
+		// a_skipSafetyCheck/a_expectedPatchHash/a_loc: see SKSE::Trampoline::write_branch.
 		template <std::size_t N>
 		std::uintptr_t write_branch(const std::uintptr_t a_dst, bool a_skipSafetyCheck = false, std::uint64_t a_expectedPatchHash = 0, std::source_location a_loc = std::source_location::current())
 			requires(std::same_as<value_type, std::uintptr_t>)

--- a/include/REL/Verify.h
+++ b/include/REL/Verify.h
@@ -2,6 +2,20 @@
 
 namespace REL
 {
+	namespace detail
+	{
+		// Basename only -- the full compiler path buries the one token that identifies the
+		// responsible patch (e.g. "actorvaluestorage_clear_race_crash.h").
+		[[nodiscard]] inline std::string_view basename(std::source_location a_loc) noexcept
+		{
+			std::string_view file{ a_loc.file_name() };
+			if (const auto sep = file.find_last_of("/\\"); sep != std::string_view::npos) {
+				file.remove_prefix(sep + 1);
+			}
+			return file;
+		}
+	}
+
 	// FNV-1a 64-bit -- a change-detector, not a security hash.
 	[[nodiscard]] std::uint64_t HashBytes(std::uintptr_t a_addr, std::size_t a_len) noexcept;
 

--- a/include/REL/Verify.h
+++ b/include/REL/Verify.h
@@ -1,0 +1,34 @@
+#pragma once
+
+namespace REL
+{
+	// FNV-1a 64-bit hash of a byte range. Not a security hash -- a cheap, deterministic
+	// change-detector for hook-integrity verification: "are these bytes still what I
+	// verified them to be."
+	[[nodiscard]] std::uint64_t HashBytes(std::uintptr_t a_addr, std::size_t a_len) noexcept;
+
+	enum class VerifyResult
+	{
+		kUnset,     // a_expectedHash was 0 -- no pin to compare against
+		kMatch,     // live bytes hash to the pinned value
+		kMismatch,  // live bytes differ from the pinned value
+	};
+
+	// Verifies [a_addr, a_addr + a_len) against a_expectedHash and logs the result:
+	//   unset    -> debug, and prints the live hash so a caller can capture + pin it.
+	//   match    -> trace (quiet -- already verified, nothing changed).
+	//   mismatch -> warn (loud -- something changed since the pin was captured: a different
+	//               game binary, or another patch now overlapping this range).
+	//
+	// General-purpose hook-integrity primitive, not tied to any specific patch mechanism:
+	// pin a patch's own target bytes before writing, a downstream collateral range after
+	// writing, or any other hook-adjacent byte range worth tracking for silent drift.
+	// Never fails/blocks by itself -- callers that want fail-closed behavior on kMismatch
+	// (e.g. skip a patch whose target bytes no longer match) check the return value.
+	VerifyResult VerifyBytes(
+		std::uintptr_t       a_addr,
+		std::size_t          a_len,
+		std::uint64_t        a_expectedHash,
+		std::string_view     a_context,
+		std::source_location a_loc = std::source_location::current());
+}

--- a/include/REL/Verify.h
+++ b/include/REL/Verify.h
@@ -2,9 +2,7 @@
 
 namespace REL
 {
-	// FNV-1a 64-bit hash of a byte range. Not a security hash -- a cheap, deterministic
-	// change-detector for hook-integrity verification: "are these bytes still what I
-	// verified them to be."
+	// FNV-1a 64-bit -- a change-detector, not a security hash.
 	[[nodiscard]] std::uint64_t HashBytes(std::uintptr_t a_addr, std::size_t a_len) noexcept;
 
 	enum class VerifyResult
@@ -14,17 +12,9 @@ namespace REL
 		kMismatch,  // live bytes differ from the pinned value
 	};
 
-	// Verifies [a_addr, a_addr + a_len) against a_expectedHash and logs the result:
-	//   unset    -> debug, and prints the live hash so a caller can capture + pin it.
-	//   match    -> trace (quiet -- already verified, nothing changed).
-	//   mismatch -> warn (loud -- something changed since the pin was captured: a different
-	//               game binary, or another patch now overlapping this range).
-	//
-	// General-purpose hook-integrity primitive, not tied to any specific patch mechanism:
-	// pin a patch's own target bytes before writing, a downstream collateral range after
-	// writing, or any other hook-adjacent byte range worth tracking for silent drift.
-	// Never fails/blocks by itself -- callers that want fail-closed behavior on kMismatch
-	// (e.g. skip a patch whose target bytes no longer match) check the return value.
+	// Verifies [a_addr, a_addr + a_len) against a_expectedHash: unset logs the live hash to
+	// capture, match stays quiet, mismatch warns. Never blocks -- callers wanting fail-closed
+	// behavior check the returned VerifyResult themselves.
 	VerifyResult VerifyBytes(
 		std::uintptr_t       a_addr,
 		std::size_t          a_len,

--- a/include/SKSE/Trampoline.h
+++ b/include/SKSE/Trampoline.h
@@ -78,8 +78,14 @@ namespace SKSE
 		[[nodiscard]] constexpr std::size_t allocated_size() const noexcept { return _size; }
 		[[nodiscard]] constexpr std::size_t free_size() const noexcept { return _capacity - _size; }
 
+		// a_skipSafetyCheck: suppress the SKSE_SUPPORT_PATCH_SAFETY instruction-boundary
+		// check for this specific call site. Only pass true once you've actually verified
+		// the site is safe (walked callers/xrefs for the boundary byte the check flagged) --
+		// prefer this over disabling the whole feature, and prefer fixing the patch site
+		// (a longer instruction, or re-running more of the displaced code in the trampoline)
+		// over suppressing when relocating the site is practical.
 		template <std::size_t N>
-		std::uintptr_t write_branch(std::uintptr_t a_src, std::uintptr_t a_dst)
+		std::uintptr_t write_branch(std::uintptr_t a_src, std::uintptr_t a_dst, bool a_skipSafetyCheck = false)
 		{
 			std::uint8_t data = 0;
 			if constexpr (N == 5) {
@@ -94,17 +100,17 @@ namespace SKSE
 				static_assert(false && N, "invalid branch size");
 			}
 
-			return write_branch<N>(a_src, a_dst, data);
+			return write_branch<N>(a_src, a_dst, data, a_skipSafetyCheck);
 		}
 
 		template <std::size_t N, class F>
-		std::uintptr_t write_branch(std::uintptr_t a_src, F a_dst)
+		std::uintptr_t write_branch(std::uintptr_t a_src, F a_dst, bool a_skipSafetyCheck = false)
 		{
-			return write_branch<N>(a_src, stl::unrestricted_cast<std::uintptr_t>(a_dst));
+			return write_branch<N>(a_src, stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck);
 		}
 
 		template <std::size_t N>
-		std::uintptr_t write_call(std::uintptr_t a_src, std::uintptr_t a_dst)
+		std::uintptr_t write_call(std::uintptr_t a_src, std::uintptr_t a_dst, bool a_skipSafetyCheck = false)
 		{
 			std::uint8_t data = 0;
 			if constexpr (N == 5) {
@@ -119,24 +125,24 @@ namespace SKSE
 				static_assert(false && N, "invalid call size");
 			}
 
-			return write_branch<N>(a_src, a_dst, data);
+			return write_branch<N>(a_src, a_dst, data, a_skipSafetyCheck);
 		}
 
 		template <std::size_t N, class F>
-		std::uintptr_t write_call(std::uintptr_t a_src, F a_dst)
+		std::uintptr_t write_call(std::uintptr_t a_src, F a_dst, bool a_skipSafetyCheck = false)
 		{
-			return write_call<N>(a_src, stl::unrestricted_cast<std::uintptr_t>(a_dst));
+			return write_call<N>(a_src, stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck);
 		}
 
 	private:
 		[[nodiscard]] void* do_create(std::size_t a_size, std::uintptr_t a_address);
 		[[nodiscard]] void* do_allocate(std::size_t a_size);
 
-		void write_5branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_opcode);
-		void write_6branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_modrm);
+		void write_5branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_opcode, bool a_skipSafetyCheck);
+		void write_6branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_modrm, bool a_skipSafetyCheck);
 
 		template <std::size_t N>
-		[[nodiscard]] std::uintptr_t write_branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_data)
+		[[nodiscard]] std::uintptr_t write_branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_data, bool a_skipSafetyCheck = false)
 		{
 			const auto isNop = *reinterpret_cast<std::int8_t*>(a_src) == 0x90;
 			const auto disp = reinterpret_cast<std::int32_t*>(a_src + N - 4);
@@ -144,9 +150,9 @@ namespace SKSE
 			const auto func = isNop ? 0 : nextOp + *disp;
 
 			if constexpr (N == 5) {
-				write_5branch(a_src, a_dst, a_data);
+				write_5branch(a_src, a_dst, a_data, a_skipSafetyCheck);
 			} else if constexpr (N == 6) {
-				write_6branch(a_src, a_dst, a_data);
+				write_6branch(a_src, a_dst, a_data, a_skipSafetyCheck);
 			} else {
 				static_assert(false && N, "invalid branch size");
 			}

--- a/include/SKSE/Trampoline.h
+++ b/include/SKSE/Trampoline.h
@@ -78,12 +78,9 @@ namespace SKSE
 		[[nodiscard]] constexpr std::size_t allocated_size() const noexcept { return _size; }
 		[[nodiscard]] constexpr std::size_t free_size() const noexcept { return _capacity - _size; }
 
-		// a_skipSafetyCheck: suppress the SKSE_SUPPORT_PATCH_SAFETY instruction-boundary
-		// check for this specific call site. Only pass true once you've actually verified
-		// the site is safe (walked callers/xrefs for the boundary byte the check flagged) --
-		// prefer this over disabling the whole feature, and prefer fixing the patch site
-		// (a longer instruction, or re-running more of the displaced code in the trampoline)
-		// over suppressing when relocating the site is practical.
+		// a_skipSafetyCheck: suppress the SKSE_SUPPORT_PATCH_SAFETY boundary check for this
+		// call site. Only pass true once you've verified the flagged byte is unreachable;
+		// prefer relocating the patch over suppressing when that's practical.
 		template <std::size_t N>
 		std::uintptr_t write_branch(std::uintptr_t a_src, std::uintptr_t a_dst, bool a_skipSafetyCheck = false)
 		{

--- a/include/SKSE/Trampoline.h
+++ b/include/SKSE/Trampoline.h
@@ -81,9 +81,12 @@ namespace SKSE
 		// a_skipSafetyCheck: suppress the SKSE_SUPPORT_PATCH_SAFETY boundary check for this
 		// call site. Only pass true once you've verified the flagged byte is unreachable;
 		// prefer relocating the patch over suppressing when that's practical.
-		// a_expectedPatchHash: pass the hash the check printed once you've verified this
-		// site, instead of a_skipSafetyCheck=true -- re-verified every launch, re-escalates
-		// on mismatch instead of trusting the old verdict forever. 0 = unset.
+		// a_expectedPatchHash: pass a hook-verification hash (see REL::VerifyBytes) for the
+		// orphan tail past this patch, instead of a_skipSafetyCheck=true -- re-verified every
+		// launch, re-escalates on mismatch instead of trusting the old verdict forever. 0 =
+		// unset. This only pins the boundary-overlap check's own byte range; call
+		// REL::VerifyBytes directly to pin any other range (e.g. the patch's own target
+		// bytes before writing).
 		// a_loc names the calling patch in that check's log line; leave it defaulted unless
 		// forwarding a location through a wrapper.
 		template <std::size_t N>

--- a/include/SKSE/Trampoline.h
+++ b/include/SKSE/Trampoline.h
@@ -78,17 +78,9 @@ namespace SKSE
 		[[nodiscard]] constexpr std::size_t allocated_size() const noexcept { return _size; }
 		[[nodiscard]] constexpr std::size_t free_size() const noexcept { return _capacity - _size; }
 
-		// a_skipSafetyCheck: suppress the SKSE_SUPPORT_PATCH_SAFETY boundary check for this
-		// call site. Only pass true once you've verified the flagged byte is unreachable;
-		// prefer relocating the patch over suppressing when that's practical.
-		// a_expectedPatchHash: pass a hook-verification hash (see REL::VerifyBytes) for the
-		// orphan tail past this patch, instead of a_skipSafetyCheck=true -- re-verified every
-		// launch, re-escalates on mismatch instead of trusting the old verdict forever. 0 =
-		// unset. This only pins the boundary-overlap check's own byte range; call
-		// REL::VerifyBytes directly to pin any other range (e.g. the patch's own target
-		// bytes before writing).
-		// a_loc names the calling patch in that check's log line; leave it defaulted unless
-		// forwarding a location through a wrapper.
+		// a_skipSafetyCheck suppresses the SKSE_SUPPORT_PATCH_SAFETY boundary check; prefer
+		// a_expectedPatchHash (0 = unset) instead -- it re-verifies every launch rather than
+		// trusting the call site forever. a_loc defaults to the caller; leave it as-is.
 		template <std::size_t N>
 		std::uintptr_t write_branch(std::uintptr_t a_src, std::uintptr_t a_dst, bool a_skipSafetyCheck = false, std::uint64_t a_expectedPatchHash = 0, std::source_location a_loc = std::source_location::current())
 		{

--- a/include/SKSE/Trampoline.h
+++ b/include/SKSE/Trampoline.h
@@ -81,10 +81,13 @@ namespace SKSE
 		// a_skipSafetyCheck: suppress the SKSE_SUPPORT_PATCH_SAFETY boundary check for this
 		// call site. Only pass true once you've verified the flagged byte is unreachable;
 		// prefer relocating the patch over suppressing when that's practical.
+		// a_expectedPatchHash: pass the hash the check printed once you've verified this
+		// site, instead of a_skipSafetyCheck=true -- re-verified every launch, re-escalates
+		// on mismatch instead of trusting the old verdict forever. 0 = unset.
 		// a_loc names the calling patch in that check's log line; leave it defaulted unless
 		// forwarding a location through a wrapper.
 		template <std::size_t N>
-		std::uintptr_t write_branch(std::uintptr_t a_src, std::uintptr_t a_dst, bool a_skipSafetyCheck = false, std::source_location a_loc = std::source_location::current())
+		std::uintptr_t write_branch(std::uintptr_t a_src, std::uintptr_t a_dst, bool a_skipSafetyCheck = false, std::uint64_t a_expectedPatchHash = 0, std::source_location a_loc = std::source_location::current())
 		{
 			std::uint8_t data = 0;
 			if constexpr (N == 5) {
@@ -99,17 +102,17 @@ namespace SKSE
 				static_assert(false && N, "invalid branch size");
 			}
 
-			return write_branch<N>(a_src, a_dst, data, a_skipSafetyCheck, a_loc);
+			return write_branch<N>(a_src, a_dst, data, a_skipSafetyCheck, a_expectedPatchHash, a_loc);
 		}
 
 		template <std::size_t N, class F>
-		std::uintptr_t write_branch(std::uintptr_t a_src, F a_dst, bool a_skipSafetyCheck = false, std::source_location a_loc = std::source_location::current())
+		std::uintptr_t write_branch(std::uintptr_t a_src, F a_dst, bool a_skipSafetyCheck = false, std::uint64_t a_expectedPatchHash = 0, std::source_location a_loc = std::source_location::current())
 		{
-			return write_branch<N>(a_src, stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck, a_loc);
+			return write_branch<N>(a_src, stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck, a_expectedPatchHash, a_loc);
 		}
 
 		template <std::size_t N>
-		std::uintptr_t write_call(std::uintptr_t a_src, std::uintptr_t a_dst, bool a_skipSafetyCheck = false, std::source_location a_loc = std::source_location::current())
+		std::uintptr_t write_call(std::uintptr_t a_src, std::uintptr_t a_dst, bool a_skipSafetyCheck = false, std::uint64_t a_expectedPatchHash = 0, std::source_location a_loc = std::source_location::current())
 		{
 			std::uint8_t data = 0;
 			if constexpr (N == 5) {
@@ -124,24 +127,24 @@ namespace SKSE
 				static_assert(false && N, "invalid call size");
 			}
 
-			return write_branch<N>(a_src, a_dst, data, a_skipSafetyCheck, a_loc);
+			return write_branch<N>(a_src, a_dst, data, a_skipSafetyCheck, a_expectedPatchHash, a_loc);
 		}
 
 		template <std::size_t N, class F>
-		std::uintptr_t write_call(std::uintptr_t a_src, F a_dst, bool a_skipSafetyCheck = false, std::source_location a_loc = std::source_location::current())
+		std::uintptr_t write_call(std::uintptr_t a_src, F a_dst, bool a_skipSafetyCheck = false, std::uint64_t a_expectedPatchHash = 0, std::source_location a_loc = std::source_location::current())
 		{
-			return write_call<N>(a_src, stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck, a_loc);
+			return write_call<N>(a_src, stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck, a_expectedPatchHash, a_loc);
 		}
 
 	private:
 		[[nodiscard]] void* do_create(std::size_t a_size, std::uintptr_t a_address);
 		[[nodiscard]] void* do_allocate(std::size_t a_size);
 
-		void write_5branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_opcode, bool a_skipSafetyCheck, std::source_location a_loc);
-		void write_6branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_modrm, bool a_skipSafetyCheck, std::source_location a_loc);
+		void write_5branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_opcode, bool a_skipSafetyCheck, std::uint64_t a_expectedPatchHash, std::source_location a_loc);
+		void write_6branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_modrm, bool a_skipSafetyCheck, std::uint64_t a_expectedPatchHash, std::source_location a_loc);
 
 		template <std::size_t N>
-		[[nodiscard]] std::uintptr_t write_branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_data, bool a_skipSafetyCheck, std::source_location a_loc)
+		[[nodiscard]] std::uintptr_t write_branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_data, bool a_skipSafetyCheck, std::uint64_t a_expectedPatchHash, std::source_location a_loc)
 		{
 			const auto isNop = *reinterpret_cast<std::int8_t*>(a_src) == 0x90;
 			const auto disp = reinterpret_cast<std::int32_t*>(a_src + N - 4);
@@ -149,9 +152,9 @@ namespace SKSE
 			const auto func = isNop ? 0 : nextOp + *disp;
 
 			if constexpr (N == 5) {
-				write_5branch(a_src, a_dst, a_data, a_skipSafetyCheck, a_loc);
+				write_5branch(a_src, a_dst, a_data, a_skipSafetyCheck, a_expectedPatchHash, a_loc);
 			} else if constexpr (N == 6) {
-				write_6branch(a_src, a_dst, a_data, a_skipSafetyCheck, a_loc);
+				write_6branch(a_src, a_dst, a_data, a_skipSafetyCheck, a_expectedPatchHash, a_loc);
 			} else {
 				static_assert(false && N, "invalid branch size");
 			}

--- a/include/SKSE/Trampoline.h
+++ b/include/SKSE/Trampoline.h
@@ -81,8 +81,10 @@ namespace SKSE
 		// a_skipSafetyCheck: suppress the SKSE_SUPPORT_PATCH_SAFETY boundary check for this
 		// call site. Only pass true once you've verified the flagged byte is unreachable;
 		// prefer relocating the patch over suppressing when that's practical.
+		// a_loc names the calling patch in that check's log line; leave it defaulted unless
+		// forwarding a location through a wrapper.
 		template <std::size_t N>
-		std::uintptr_t write_branch(std::uintptr_t a_src, std::uintptr_t a_dst, bool a_skipSafetyCheck = false)
+		std::uintptr_t write_branch(std::uintptr_t a_src, std::uintptr_t a_dst, bool a_skipSafetyCheck = false, std::source_location a_loc = std::source_location::current())
 		{
 			std::uint8_t data = 0;
 			if constexpr (N == 5) {
@@ -97,17 +99,17 @@ namespace SKSE
 				static_assert(false && N, "invalid branch size");
 			}
 
-			return write_branch<N>(a_src, a_dst, data, a_skipSafetyCheck);
+			return write_branch<N>(a_src, a_dst, data, a_skipSafetyCheck, a_loc);
 		}
 
 		template <std::size_t N, class F>
-		std::uintptr_t write_branch(std::uintptr_t a_src, F a_dst, bool a_skipSafetyCheck = false)
+		std::uintptr_t write_branch(std::uintptr_t a_src, F a_dst, bool a_skipSafetyCheck = false, std::source_location a_loc = std::source_location::current())
 		{
-			return write_branch<N>(a_src, stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck);
+			return write_branch<N>(a_src, stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck, a_loc);
 		}
 
 		template <std::size_t N>
-		std::uintptr_t write_call(std::uintptr_t a_src, std::uintptr_t a_dst, bool a_skipSafetyCheck = false)
+		std::uintptr_t write_call(std::uintptr_t a_src, std::uintptr_t a_dst, bool a_skipSafetyCheck = false, std::source_location a_loc = std::source_location::current())
 		{
 			std::uint8_t data = 0;
 			if constexpr (N == 5) {
@@ -122,24 +124,24 @@ namespace SKSE
 				static_assert(false && N, "invalid call size");
 			}
 
-			return write_branch<N>(a_src, a_dst, data, a_skipSafetyCheck);
+			return write_branch<N>(a_src, a_dst, data, a_skipSafetyCheck, a_loc);
 		}
 
 		template <std::size_t N, class F>
-		std::uintptr_t write_call(std::uintptr_t a_src, F a_dst, bool a_skipSafetyCheck = false)
+		std::uintptr_t write_call(std::uintptr_t a_src, F a_dst, bool a_skipSafetyCheck = false, std::source_location a_loc = std::source_location::current())
 		{
-			return write_call<N>(a_src, stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck);
+			return write_call<N>(a_src, stl::unrestricted_cast<std::uintptr_t>(a_dst), a_skipSafetyCheck, a_loc);
 		}
 
 	private:
 		[[nodiscard]] void* do_create(std::size_t a_size, std::uintptr_t a_address);
 		[[nodiscard]] void* do_allocate(std::size_t a_size);
 
-		void write_5branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_opcode, bool a_skipSafetyCheck);
-		void write_6branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_modrm, bool a_skipSafetyCheck);
+		void write_5branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_opcode, bool a_skipSafetyCheck, std::source_location a_loc);
+		void write_6branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_modrm, bool a_skipSafetyCheck, std::source_location a_loc);
 
 		template <std::size_t N>
-		[[nodiscard]] std::uintptr_t write_branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_data, bool a_skipSafetyCheck = false)
+		[[nodiscard]] std::uintptr_t write_branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_data, bool a_skipSafetyCheck, std::source_location a_loc)
 		{
 			const auto isNop = *reinterpret_cast<std::int8_t*>(a_src) == 0x90;
 			const auto disp = reinterpret_cast<std::int32_t*>(a_src + N - 4);
@@ -147,9 +149,9 @@ namespace SKSE
 			const auto func = isNop ? 0 : nextOp + *disp;
 
 			if constexpr (N == 5) {
-				write_5branch(a_src, a_dst, a_data, a_skipSafetyCheck);
+				write_5branch(a_src, a_dst, a_data, a_skipSafetyCheck, a_loc);
 			} else if constexpr (N == 6) {
-				write_6branch(a_src, a_dst, a_data, a_skipSafetyCheck);
+				write_6branch(a_src, a_dst, a_data, a_skipSafetyCheck, a_loc);
 			} else {
 				static_assert(false && N, "invalid branch size");
 			}

--- a/src/REL/Verify.cpp
+++ b/src/REL/Verify.cpp
@@ -21,13 +21,7 @@ namespace REL
 	VerifyResult VerifyBytes(std::uintptr_t a_addr, std::size_t a_len, std::uint64_t a_expectedHash,
 		std::string_view a_context, std::source_location a_loc)
 	{
-		// Basename only -- the full compiler path buries the one token that identifies the
-		// responsible patch (e.g. "actorvaluestorage_clear_race_crash.h").
-		std::string_view file{ a_loc.file_name() };
-		if (const auto sep = file.find_last_of("/\\"); sep != std::string_view::npos) {
-			file.remove_prefix(sep + 1);
-		}
-
+		const auto file = detail::basename(a_loc);
 		const auto hash = HashBytes(a_addr, a_len);
 
 		if (a_expectedHash == 0) {

--- a/src/REL/Verify.cpp
+++ b/src/REL/Verify.cpp
@@ -1,0 +1,56 @@
+#include "REL/Verify.h"
+
+#include "SKSE/Logger.h"
+
+namespace REL
+{
+	std::uint64_t HashBytes(std::uintptr_t a_addr, std::size_t a_len) noexcept
+	{
+		constexpr std::uint64_t offsetBasis = 0xCBF29CE484222325ULL;
+		constexpr std::uint64_t prime = 0x00000100000001B3ULL;
+
+		auto       hash = offsetBasis;
+		const auto bytes = reinterpret_cast<const std::uint8_t*>(a_addr);
+		for (std::size_t i = 0; i < a_len; ++i) {
+			hash ^= bytes[i];
+			hash *= prime;
+		}
+		return hash;
+	}
+
+	VerifyResult VerifyBytes(std::uintptr_t a_addr, std::size_t a_len, std::uint64_t a_expectedHash,
+		std::string_view a_context, std::source_location a_loc)
+	{
+		// Basename only -- the full compiler path buries the one token that identifies the
+		// responsible patch (e.g. "actorvaluestorage_clear_race_crash.h").
+		std::string_view file{ a_loc.file_name() };
+		if (const auto sep = file.find_last_of("/\\"); sep != std::string_view::npos) {
+			file.remove_prefix(sep + 1);
+		}
+
+		const auto hash = HashBytes(a_addr, a_len);
+
+		if (a_expectedHash == 0) {
+			SKSE::log::debug(
+				"hook verification [{}:{}]: {} at 0x{:X} ({} bytes) hash 0x{:X} -- pass "
+				"a_expectedHash=0x{:X} to pin this state (re-checked every launch)."sv,
+				file, a_loc.line(), a_context, a_addr, a_len, hash, hash);
+			return VerifyResult::kUnset;
+		}
+
+		if (a_expectedHash == hash) {
+			SKSE::log::trace(
+				"hook verification [{}:{}]: {} at 0x{:X} matches its pinned hash 0x{:X} -- "
+				"already verified, nothing changed."sv,
+				file, a_loc.line(), a_context, a_addr, hash);
+			return VerifyResult::kMatch;
+		}
+
+		SKSE::log::warn(
+			"hook verification [{}:{}]: {} at 0x{:X} pinned hash 0x{:X} no longer matches the "
+			"live bytes (now 0x{:X}) -- the verification this relied on may no longer hold (a "
+			"different game binary, or another patch now overlapping this range)."sv,
+			file, a_loc.line(), a_context, a_addr, a_expectedHash, hash);
+		return VerifyResult::kMismatch;
+	}
+}

--- a/src/SKSE/Trampoline.cpp
+++ b/src/SKSE/Trampoline.cpp
@@ -32,10 +32,32 @@ namespace SKSE
 	namespace detail
 	{
 #ifdef SKSE_SUPPORT_PATCH_SAFETY
-		// Warns (never blocks) when a write_branch<N> patch partially overwrites the
-		// instruction after the one it targets -- those bytes can still be a live
-		// indirect-dispatch target. Suppress via write_branch's a_skipSafetyCheck.
-		void check_patch_site_boundary(std::uintptr_t a_src, std::size_t a_len, std::source_location a_loc)
+		// FNV-1a 64-bit. Not a security hash -- just a cheap, deterministic change-detector
+		// so a_expectedPatchHash can tell "still the bytes I verified" from "something moved."
+		[[nodiscard]] std::uint64_t fnv1a64(std::uintptr_t a_addr, std::size_t a_len) noexcept
+		{
+			constexpr std::uint64_t offsetBasis = 0xCBF29CE484222325ULL;
+			constexpr std::uint64_t prime = 0x00000100000001B3ULL;
+
+			auto       hash = offsetBasis;
+			const auto bytes = reinterpret_cast<const std::uint8_t*>(a_addr);
+			for (std::size_t i = 0; i < a_len; ++i) {
+				hash ^= bytes[i];
+				hash *= prime;
+			}
+			return hash;
+		}
+
+		// Warns when a write_branch<N> patch partially overwrites the instruction after the
+		// one it targets -- those bytes can still be a live indirect-dispatch target. Never
+		// blocks the write either way.
+		//
+		// a_expectedPatchHash pins the check to a specific verified byte pattern (see
+		// SKSE::Trampoline::write_branch's doc comment): 0 means unset (today's behavior,
+		// always logs and prints the hash to capture), a match goes quiet (already verified,
+		// nothing to re-read), a mismatch escalates (something changed since verification --
+		// a different game binary, or a newly-installed patch colliding with this site).
+		void check_patch_site_boundary(std::uintptr_t a_src, std::size_t a_len, std::uint64_t a_expectedPatchHash, std::source_location a_loc)
 		{
 			// Basename only -- the full compiler path buries the one token that identifies
 			// the responsible patch (e.g. "actorvaluestorage_clear_race_crash.h").
@@ -69,15 +91,36 @@ namespace SKSE
 
 			const auto badAddr = a_src + (consumed - lastLen);
 			const auto overwritten = a_len - (consumed - lastLen);
+			const auto hash = fnv1a64(badAddr, lastLen);
+
+			if (a_expectedPatchHash != 0 && a_expectedPatchHash == hash) {
+				log::trace(
+					"patch-site safety [{}:{}]: write_branch<{}> at 0x{:X} matches its pinned hash "
+					"0x{:X} -- already verified, nothing changed."sv,
+					file, a_loc.line(), a_len, a_src, hash);
+				return;
+			}
+
+			if (a_expectedPatchHash != 0 && a_expectedPatchHash != hash) {
+				log::warn(
+					"patch-site safety [{}:{}]: write_branch<{}> at 0x{:X} pinned hash 0x{:X} no longer "
+					"matches the live bytes at 0x{:X} (now 0x{:X}) -- the verification this site relied "
+					"on may no longer hold (different game binary, or another patch now overlaps this "
+					"site). Re-verify: code xrefs (CALL/JMP) AND vtable slots holding 0x{:X} as a "
+					"function pointer. Writing anyway for now."sv,
+					file, a_loc.line(), a_len, a_src, a_expectedPatchHash, badAddr, hash, badAddr);
+				return;
+			}
+
 			log::debug(
 				"patch-site safety [{}:{}]: write_branch<{}> at 0x{:X} fully consumes {} instruction(s) then "
-				"partially overwrites {} of {} bytes of the instruction at 0x{:X} -- that address "
-				"used to be a valid instruction start. Before treating this site as safe, check for "
-				"anything targeting it directly: code xrefs (CALL/JMP) AND vtable slots holding it "
-				"as a function pointer (indirect vtable dispatch won't show as a code xref). If "
-				"clean, pass a_skipSafetyCheck=true to silence this; otherwise relocate the patch "
-				"onto a longer instruction. Writing anyway for now."sv,
-				file, a_loc.line(), a_len, a_src, instrCount - 1, overwritten, lastLen, badAddr);
+				"partially overwrites {} of {} bytes of the instruction at 0x{:X} (hash 0x{:X}) -- that "
+				"address used to be a valid instruction start. Before treating this site as safe, check "
+				"for anything targeting it directly: code xrefs (CALL/JMP) AND vtable slots holding it "
+				"as a function pointer (indirect vtable dispatch won't show as a code xref). If clean, "
+				"pass a_expectedPatchHash=0x{:X} to pin this verified state (re-checked every launch), "
+				"or relocate the patch onto a longer instruction. Writing anyway for now."sv,
+				file, a_loc.line(), a_len, a_src, instrCount - 1, overwritten, lastLen, badAddr, hash, hash);
 		}
 #endif
 
@@ -185,7 +228,7 @@ namespace SKSE
 		return mem;
 	}
 
-	void Trampoline::write_5branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_opcode, bool a_skipSafetyCheck, std::source_location a_loc)
+	void Trampoline::write_5branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_opcode, bool a_skipSafetyCheck, std::uint64_t a_expectedPatchHash, std::source_location a_loc)
 	{
 #pragma pack(push, 1)
 		struct SrcAssembly
@@ -232,7 +275,7 @@ namespace SKSE
 
 #ifdef SKSE_SUPPORT_PATCH_SAFETY
 		if (!a_skipSafetyCheck) {
-			detail::check_patch_site_boundary(a_src, sizeof(SrcAssembly), a_loc);
+			detail::check_patch_site_boundary(a_src, sizeof(SrcAssembly), a_expectedPatchHash, a_loc);
 		}
 #endif
 
@@ -247,7 +290,7 @@ namespace SKSE
 		mem->addr = static_cast<std::uint64_t>(a_dst);
 	}
 
-	void Trampoline::write_6branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_modrm, bool a_skipSafetyCheck, std::source_location a_loc)
+	void Trampoline::write_6branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_modrm, bool a_skipSafetyCheck, std::uint64_t a_expectedPatchHash, std::source_location a_loc)
 	{
 #pragma pack(push, 1)
 		struct Assembly
@@ -280,7 +323,7 @@ namespace SKSE
 
 #ifdef SKSE_SUPPORT_PATCH_SAFETY
 		if (!a_skipSafetyCheck) {
-			detail::check_patch_site_boundary(a_src, sizeof(Assembly), a_loc);
+			detail::check_patch_site_boundary(a_src, sizeof(Assembly), a_expectedPatchHash, a_loc);
 		}
 #endif
 

--- a/src/SKSE/Trampoline.cpp
+++ b/src/SKSE/Trampoline.cpp
@@ -15,10 +15,71 @@
 #	undef PAGE_EXECUTE_READWRITE
 #endif
 
+// hde64.h transitively pulls in <Windows.h> (like xbyak above), colliding with REX::W32's
+// own MEM_*/PAGE_* names used below.
+#ifdef SKSE_SUPPORT_PATCH_SAFETY
+#	include <hde64.h>
+#	undef max
+#	undef MEM_COMMIT
+#	undef MEM_FREE
+#	undef MEM_RELEASE
+#	undef MEM_RESERVE
+#	undef PAGE_EXECUTE_READWRITE
+#endif
+
 namespace SKSE
 {
 	namespace detail
 	{
+#ifdef SKSE_SUPPORT_PATCH_SAFETY
+		// A write_branch<N> patch is safe iff [a_src, a_src+a_len) lands exactly on
+		// instruction boundaries, or ends inside the single instruction it starts in. It's
+		// unsafe the moment it fully consumes one instruction and then partially overwrites
+		// the next -- that leaves corrupted, non-instruction bytes at an address that used
+		// to be (and, to anything that jumps/calls there, still looks like) a real
+		// instruction's start. Confirmed by an actual incident: EngineFixesSkyrim64 patched
+		// a 4-byte load with a 5-byte jmp, borrowing 1 byte of the following `test`
+		// instruction; that byte turned out to be independently reachable and the resulting
+		// corruption crashed a live game. Log-only: a decode we can't trust (or a real
+		// unsafe site) still gets the intended patch written, matching how the rest of this
+		// codebase degrades -- log with context, never silently break an install that
+		// worked yesterday.
+		void check_patch_site_boundary(std::uintptr_t a_src, std::size_t a_len)
+		{
+			std::size_t consumed = 0;
+			std::size_t instrCount = 0;
+			std::size_t lastLen = 0;
+
+			while (consumed < a_len) {
+				hde64s     hs{};
+				const auto len = hde64_disasm(reinterpret_cast<const void*>(a_src + consumed), &hs);
+				if (len == 0 || (hs.flags & F_ERROR) != 0) {
+					log::warn(
+						"patch-site safety: failed to decode instruction at 0x{:X} (+0x{:X} into a "
+						"write_branch<{}> at 0x{:X}) -- skipping boundary check for this patch"sv,
+						a_src + consumed, consumed, a_len, a_src);
+					return;
+				}
+				consumed += len;
+				lastLen = len;
+				++instrCount;
+			}
+
+			if (consumed == a_len || instrCount == 1) {
+				return;  // safe: exact boundary, or never left the first instruction
+			}
+
+			const auto badAddr = a_src + (consumed - lastLen);
+			const auto overwritten = a_len - (consumed - lastLen);
+			log::warn(
+				"patch-site safety: write_branch<{}> at 0x{:X} fully consumes {} instruction(s) then "
+				"partially overwrites {} of {} bytes of the instruction at 0x{:X} -- that address is "
+				"a real instruction boundary something else may target, not just this patch's own "
+				"trampoline. Writing anyway; consider relocating this patch to a longer instruction."sv,
+				a_len, a_src, instrCount - 1, overwritten, lastLen, badAddr);
+		}
+#endif
+
 		[[nodiscard]] constexpr std::size_t roundup(std::size_t a_number, std::size_t a_multiple) noexcept
 		{
 			if (a_multiple == 0)
@@ -168,6 +229,10 @@ namespace SKSE
 			stl::report_and_fail("displacement is out of range"sv);
 		}
 
+#ifdef SKSE_SUPPORT_PATCH_SAFETY
+		detail::check_patch_site_boundary(a_src, sizeof(SrcAssembly));
+#endif
+
 		SrcAssembly assembly;
 		assembly.opcode = a_opcode;
 		assembly.disp = static_cast<std::int32_t>(disp);
@@ -209,6 +274,10 @@ namespace SKSE
 		if (!in_range(disp)) {  // the trampoline should already be in range, so this should never happen
 			stl::report_and_fail("displacement is out of range"sv);
 		}
+
+#ifdef SKSE_SUPPORT_PATCH_SAFETY
+		detail::check_patch_site_boundary(a_src, sizeof(Assembly));
+#endif
 
 		Assembly assembly;
 		assembly.opcode = static_cast<std::uint8_t>(0xFF);

--- a/src/SKSE/Trampoline.cpp
+++ b/src/SKSE/Trampoline.cpp
@@ -44,6 +44,18 @@ namespace SKSE
 		// unsafe site) still gets the intended patch written, matching how the rest of this
 		// codebase degrades -- log with context, never silently break an install that
 		// worked yesterday.
+		//
+		// A flagged site is a real structural risk (the boundary byte genuinely used to be
+		// a valid instruction start), not proof of an active bug -- the check has no way to
+		// confirm anything actually targets that byte (our real incident wasn't visible via
+		// static xrefs either). Logged at `debug`, not `warn`: this codebase's own logger
+		// convention (see EngineFixesSkyrim64/src/main.cpp) sets Release builds -- what ships
+		// to players -- to `info` and above, and Debug builds to `debug` and above, so this
+		// is dev-visible by default and silent for end users without any extra plumbing here.
+		// A specific site a developer has manually verified safe (walked callers, confirmed
+		// no reachable entry into the boundary byte) can suppress this per call site via
+		// write_branch's `a_skipSafetyCheck` parameter -- prefer that over disabling the
+		// whole feature once you've actually done the verification.
 		void check_patch_site_boundary(std::uintptr_t a_src, std::size_t a_len)
 		{
 			std::size_t consumed = 0;
@@ -54,7 +66,7 @@ namespace SKSE
 				hde64s     hs{};
 				const auto len = hde64_disasm(reinterpret_cast<const void*>(a_src + consumed), &hs);
 				if (len == 0 || (hs.flags & F_ERROR) != 0) {
-					log::warn(
+					log::debug(
 						"patch-site safety: failed to decode instruction at 0x{:X} (+0x{:X} into a "
 						"write_branch<{}> at 0x{:X}) -- skipping boundary check for this patch"sv,
 						a_src + consumed, consumed, a_len, a_src);
@@ -71,11 +83,12 @@ namespace SKSE
 
 			const auto badAddr = a_src + (consumed - lastLen);
 			const auto overwritten = a_len - (consumed - lastLen);
-			log::warn(
+			log::debug(
 				"patch-site safety: write_branch<{}> at 0x{:X} fully consumes {} instruction(s) then "
 				"partially overwrites {} of {} bytes of the instruction at 0x{:X} -- that address is "
 				"a real instruction boundary something else may target, not just this patch's own "
-				"trampoline. Writing anyway; consider relocating this patch to a longer instruction."sv,
+				"trampoline. Writing anyway; consider relocating this patch to a longer instruction "
+				"or passing a_skipSafetyCheck=true once verified safe."sv,
 				a_len, a_src, instrCount - 1, overwritten, lastLen, badAddr);
 		}
 #endif
@@ -184,7 +197,7 @@ namespace SKSE
 		return mem;
 	}
 
-	void Trampoline::write_5branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_opcode)
+	void Trampoline::write_5branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_opcode, bool a_skipSafetyCheck)
 	{
 #pragma pack(push, 1)
 		struct SrcAssembly
@@ -230,7 +243,9 @@ namespace SKSE
 		}
 
 #ifdef SKSE_SUPPORT_PATCH_SAFETY
-		detail::check_patch_site_boundary(a_src, sizeof(SrcAssembly));
+		if (!a_skipSafetyCheck) {
+			detail::check_patch_site_boundary(a_src, sizeof(SrcAssembly));
+		}
 #endif
 
 		SrcAssembly assembly;
@@ -244,7 +259,7 @@ namespace SKSE
 		mem->addr = static_cast<std::uint64_t>(a_dst);
 	}
 
-	void Trampoline::write_6branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_modrm)
+	void Trampoline::write_6branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_modrm, bool a_skipSafetyCheck)
 	{
 #pragma pack(push, 1)
 		struct Assembly
@@ -276,7 +291,9 @@ namespace SKSE
 		}
 
 #ifdef SKSE_SUPPORT_PATCH_SAFETY
-		detail::check_patch_site_boundary(a_src, sizeof(Assembly));
+		if (!a_skipSafetyCheck) {
+			detail::check_patch_site_boundary(a_src, sizeof(Assembly));
+		}
 #endif
 
 		Assembly assembly;

--- a/src/SKSE/Trampoline.cpp
+++ b/src/SKSE/Trampoline.cpp
@@ -32,45 +32,11 @@ namespace SKSE
 	namespace detail
 	{
 #ifdef SKSE_SUPPORT_PATCH_SAFETY
-		// A write_branch<N> patch is safe iff [a_src, a_src+a_len) lands exactly on
-		// instruction boundaries, or ends inside the single instruction it starts in. It's
-		// unsafe the moment it fully consumes one instruction and then partially overwrites
-		// the next -- that leaves corrupted, non-instruction bytes at an address that used
-		// to be (and, to anything that jumps/calls there, still looks like) a real
-		// instruction's start. Confirmed by an actual incident: EngineFixesSkyrim64 patched
-		// a 4-byte load with a 5-byte jmp, borrowing 1 byte of the following `test`
-		// instruction; that byte turned out to be independently reachable -- specifically as
-		// an indirect vtable dispatch target, not a direct CALL/JMP -- and the resulting
-		// corruption crashed a live game.
-		//
-		// A plain "search for code xrefs to this address" is not sufficient to verify a
-		// flagged site -- it's exactly what missed the real incident. Also check whether the
-		// boundary address is stored as a function-pointer value in any vtable (RTTI class
-		// layout / vtable dump): a vtable slot pointing
-		// mid-function into the boundary byte is a DATA reference, and most disassemblers
-		// only surface it as a code xref if the vtable array is already typed as function
-		// pointers. Example: for a class C with vtable slot C::vtbl[k] == badAddr, that's
-		// disqualifying even though nothing in the disassembly shows a CALL/JMP literal to
-		// badAddr -- the call arrives indirectly via `call [vtableReg + k*8]`.
-		//
-		// Log-only: a decode we can't trust (or a real unsafe site) still gets the intended
-		// patch written, matching how the rest of this codebase degrades -- log with
-		// context, never silently break an install that worked yesterday.
-		//
-		// A flagged site is a real structural risk (the boundary byte genuinely used to be
-		// a valid instruction start), not proof of an active bug -- the check has no way to
-		// confirm anything actually targets that byte (our real incident wasn't visible via
-		// a plain xref scan either, for the vtable reason above). Logged at `debug`, not
-		// `warn`: this codebase's own logger convention (see EngineFixesSkyrim64/src/main.cpp)
-		// sets Release builds -- what ships to players -- to `info` and above, and Debug
-		// builds to `debug` and above, so this is dev-visible by default and silent for end
-		// users without any extra plumbing here.
-		//
-		// A specific site a developer has manually verified safe (walked BOTH code xrefs
-		// and vtable slots for the boundary address, confirmed neither reaches it) can
-		// suppress this per call site via write_branch's `a_skipSafetyCheck` parameter --
-		// prefer that over disabling the whole feature once you've actually done the
-		// verification.
+		// A write_branch<N> patch is unsafe once it fully consumes one instruction and
+		// partially overwrites the next -- the resulting bytes can still be a live
+		// indirect-dispatch target even with no direct CALL/JMP to them. Log-only (never
+		// blocks the write); see write_branch's a_skipSafetyCheck to suppress a site
+		// you've manually verified safe.
 		void check_patch_site_boundary(std::uintptr_t a_src, std::size_t a_len)
 		{
 			std::size_t consumed = 0;

--- a/src/SKSE/Trampoline.cpp
+++ b/src/SKSE/Trampoline.cpp
@@ -33,12 +33,8 @@ namespace SKSE
 	namespace detail
 	{
 #ifdef SKSE_SUPPORT_PATCH_SAFETY
-		// Detects when a write_branch<N> patch partially overwrites the instruction after
-		// the one it targets -- those bytes can still be a live indirect-dispatch target.
-		// Never blocks the write either way; hands the actual verification (and its
-		// unset/match/mismatch logging) off to REL::VerifyBytes, which is independent of
-		// this detection -- a caller can pin/verify any byte range without ever going
-		// through this overlap scan.
+		// Detects a write_branch<N> patch overwriting part of the next instruction, then
+		// delegates verification to REL::VerifyBytes.
 		void check_patch_site_boundary(std::uintptr_t a_src, std::size_t a_len, std::uint64_t a_expectedPatchHash, std::source_location a_loc)
 		{
 			std::size_t consumed = 0;

--- a/src/SKSE/Trampoline.cpp
+++ b/src/SKSE/Trampoline.cpp
@@ -35,8 +35,15 @@ namespace SKSE
 		// Warns (never blocks) when a write_branch<N> patch partially overwrites the
 		// instruction after the one it targets -- those bytes can still be a live
 		// indirect-dispatch target. Suppress via write_branch's a_skipSafetyCheck.
-		void check_patch_site_boundary(std::uintptr_t a_src, std::size_t a_len)
+		void check_patch_site_boundary(std::uintptr_t a_src, std::size_t a_len, std::source_location a_loc)
 		{
+			// Basename only -- the full compiler path buries the one token that identifies
+			// the responsible patch (e.g. "actorvaluestorage_clear_race_crash.h").
+			std::string_view file{ a_loc.file_name() };
+			if (const auto sep = file.find_last_of("/\\"); sep != std::string_view::npos) {
+				file.remove_prefix(sep + 1);
+			}
+
 			std::size_t consumed = 0;
 			std::size_t instrCount = 0;
 			std::size_t lastLen = 0;
@@ -46,9 +53,9 @@ namespace SKSE
 				const auto len = hde64_disasm(reinterpret_cast<const void*>(a_src + consumed), &hs);
 				if (len == 0 || (hs.flags & F_ERROR) != 0) {
 					log::debug(
-						"patch-site safety: failed to decode instruction at 0x{:X} (+0x{:X} into a "
+						"patch-site safety [{}:{}]: failed to decode instruction at 0x{:X} (+0x{:X} into a "
 						"write_branch<{}> at 0x{:X}) -- skipping boundary check for this patch"sv,
-						a_src + consumed, consumed, a_len, a_src);
+						file, a_loc.line(), a_src + consumed, consumed, a_len, a_src);
 					return;
 				}
 				consumed += len;
@@ -63,14 +70,14 @@ namespace SKSE
 			const auto badAddr = a_src + (consumed - lastLen);
 			const auto overwritten = a_len - (consumed - lastLen);
 			log::debug(
-				"patch-site safety: write_branch<{}> at 0x{:X} fully consumes {} instruction(s) then "
+				"patch-site safety [{}:{}]: write_branch<{}> at 0x{:X} fully consumes {} instruction(s) then "
 				"partially overwrites {} of {} bytes of the instruction at 0x{:X} -- that address "
 				"used to be a valid instruction start. Before treating this site as safe, check for "
 				"anything targeting it directly: code xrefs (CALL/JMP) AND vtable slots holding it "
 				"as a function pointer (indirect vtable dispatch won't show as a code xref). If "
 				"clean, pass a_skipSafetyCheck=true to silence this; otherwise relocate the patch "
 				"onto a longer instruction. Writing anyway for now."sv,
-				a_len, a_src, instrCount - 1, overwritten, lastLen, badAddr);
+				file, a_loc.line(), a_len, a_src, instrCount - 1, overwritten, lastLen, badAddr);
 		}
 #endif
 
@@ -178,7 +185,7 @@ namespace SKSE
 		return mem;
 	}
 
-	void Trampoline::write_5branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_opcode, bool a_skipSafetyCheck)
+	void Trampoline::write_5branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_opcode, bool a_skipSafetyCheck, std::source_location a_loc)
 	{
 #pragma pack(push, 1)
 		struct SrcAssembly
@@ -225,7 +232,7 @@ namespace SKSE
 
 #ifdef SKSE_SUPPORT_PATCH_SAFETY
 		if (!a_skipSafetyCheck) {
-			detail::check_patch_site_boundary(a_src, sizeof(SrcAssembly));
+			detail::check_patch_site_boundary(a_src, sizeof(SrcAssembly), a_loc);
 		}
 #endif
 
@@ -240,7 +247,7 @@ namespace SKSE
 		mem->addr = static_cast<std::uint64_t>(a_dst);
 	}
 
-	void Trampoline::write_6branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_modrm, bool a_skipSafetyCheck)
+	void Trampoline::write_6branch(std::uintptr_t a_src, std::uintptr_t a_dst, std::uint8_t a_modrm, bool a_skipSafetyCheck, std::source_location a_loc)
 	{
 #pragma pack(push, 1)
 		struct Assembly
@@ -273,7 +280,7 @@ namespace SKSE
 
 #ifdef SKSE_SUPPORT_PATCH_SAFETY
 		if (!a_skipSafetyCheck) {
-			detail::check_patch_site_boundary(a_src, sizeof(Assembly));
+			detail::check_patch_site_boundary(a_src, sizeof(Assembly), a_loc);
 		}
 #endif
 

--- a/src/SKSE/Trampoline.cpp
+++ b/src/SKSE/Trampoline.cpp
@@ -1,5 +1,6 @@
 #include "SKSE/Trampoline.h"
 
+#include "REL/Verify.h"
 #include "SKSE/Logger.h"
 
 #include "REX/W32/KERNEL32.h"
@@ -32,40 +33,14 @@ namespace SKSE
 	namespace detail
 	{
 #ifdef SKSE_SUPPORT_PATCH_SAFETY
-		// FNV-1a 64-bit. Not a security hash -- just a cheap, deterministic change-detector
-		// so a_expectedPatchHash can tell "still the bytes I verified" from "something moved."
-		[[nodiscard]] std::uint64_t fnv1a64(std::uintptr_t a_addr, std::size_t a_len) noexcept
-		{
-			constexpr std::uint64_t offsetBasis = 0xCBF29CE484222325ULL;
-			constexpr std::uint64_t prime = 0x00000100000001B3ULL;
-
-			auto       hash = offsetBasis;
-			const auto bytes = reinterpret_cast<const std::uint8_t*>(a_addr);
-			for (std::size_t i = 0; i < a_len; ++i) {
-				hash ^= bytes[i];
-				hash *= prime;
-			}
-			return hash;
-		}
-
-		// Warns when a write_branch<N> patch partially overwrites the instruction after the
-		// one it targets -- those bytes can still be a live indirect-dispatch target. Never
-		// blocks the write either way.
-		//
-		// a_expectedPatchHash pins the check to a specific verified byte pattern (see
-		// SKSE::Trampoline::write_branch's doc comment): 0 means unset (today's behavior,
-		// always logs and prints the hash to capture), a match goes quiet (already verified,
-		// nothing to re-read), a mismatch escalates (something changed since verification --
-		// a different game binary, or a newly-installed patch colliding with this site).
+		// Detects when a write_branch<N> patch partially overwrites the instruction after
+		// the one it targets -- those bytes can still be a live indirect-dispatch target.
+		// Never blocks the write either way; hands the actual verification (and its
+		// unset/match/mismatch logging) off to REL::VerifyBytes, which is independent of
+		// this detection -- a caller can pin/verify any byte range without ever going
+		// through this overlap scan.
 		void check_patch_site_boundary(std::uintptr_t a_src, std::size_t a_len, std::uint64_t a_expectedPatchHash, std::source_location a_loc)
 		{
-			// Basename only -- the full compiler path buries the one token that identifies
-			// the responsible patch (e.g. "actorvaluestorage_clear_race_crash.h").
-			std::string_view file{ a_loc.file_name() };
-			if (const auto sep = file.find_last_of("/\\"); sep != std::string_view::npos) {
-				file.remove_prefix(sep + 1);
-			}
-
 			std::size_t consumed = 0;
 			std::size_t instrCount = 0;
 			std::size_t lastLen = 0;
@@ -74,6 +49,12 @@ namespace SKSE
 				hde64s     hs{};
 				const auto len = hde64_disasm(reinterpret_cast<const void*>(a_src + consumed), &hs);
 				if (len == 0 || (hs.flags & F_ERROR) != 0) {
+					// Basename only -- the full compiler path buries the one token that
+					// identifies the responsible patch (e.g. "actorvaluestorage_clear_race_crash.h").
+					std::string_view file{ a_loc.file_name() };
+					if (const auto sep = file.find_last_of("/\\"); sep != std::string_view::npos) {
+						file.remove_prefix(sep + 1);
+					}
 					log::debug(
 						"patch-site safety [{}:{}]: failed to decode instruction at 0x{:X} (+0x{:X} into a "
 						"write_branch<{}> at 0x{:X}) -- skipping boundary check for this patch"sv,
@@ -90,37 +71,7 @@ namespace SKSE
 			}
 
 			const auto badAddr = a_src + (consumed - lastLen);
-			const auto overwritten = a_len - (consumed - lastLen);
-			const auto hash = fnv1a64(badAddr, lastLen);
-
-			if (a_expectedPatchHash != 0 && a_expectedPatchHash == hash) {
-				log::trace(
-					"patch-site safety [{}:{}]: write_branch<{}> at 0x{:X} matches its pinned hash "
-					"0x{:X} -- already verified, nothing changed."sv,
-					file, a_loc.line(), a_len, a_src, hash);
-				return;
-			}
-
-			if (a_expectedPatchHash != 0 && a_expectedPatchHash != hash) {
-				log::warn(
-					"patch-site safety [{}:{}]: write_branch<{}> at 0x{:X} pinned hash 0x{:X} no longer "
-					"matches the live bytes at 0x{:X} (now 0x{:X}) -- the verification this site relied "
-					"on may no longer hold (different game binary, or another patch now overlaps this "
-					"site). Re-verify: code xrefs (CALL/JMP) AND vtable slots holding 0x{:X} as a "
-					"function pointer. Writing anyway for now."sv,
-					file, a_loc.line(), a_len, a_src, a_expectedPatchHash, badAddr, hash, badAddr);
-				return;
-			}
-
-			log::debug(
-				"patch-site safety [{}:{}]: write_branch<{}> at 0x{:X} fully consumes {} instruction(s) then "
-				"partially overwrites {} of {} bytes of the instruction at 0x{:X} (hash 0x{:X}) -- that "
-				"address used to be a valid instruction start. Before treating this site as safe, check "
-				"for anything targeting it directly: code xrefs (CALL/JMP) AND vtable slots holding it "
-				"as a function pointer (indirect vtable dispatch won't show as a code xref). If clean, "
-				"pass a_expectedPatchHash=0x{:X} to pin this verified state (re-checked every launch), "
-				"or relocate the patch onto a longer instruction. Writing anyway for now."sv,
-				file, a_loc.line(), a_len, a_src, instrCount - 1, overwritten, lastLen, badAddr, hash, hash);
+			REL::VerifyBytes(badAddr, lastLen, a_expectedPatchHash, "orphan tail past write_branch"sv, a_loc);
 		}
 #endif
 

--- a/src/SKSE/Trampoline.cpp
+++ b/src/SKSE/Trampoline.cpp
@@ -39,23 +39,38 @@ namespace SKSE
 		// to be (and, to anything that jumps/calls there, still looks like) a real
 		// instruction's start. Confirmed by an actual incident: EngineFixesSkyrim64 patched
 		// a 4-byte load with a 5-byte jmp, borrowing 1 byte of the following `test`
-		// instruction; that byte turned out to be independently reachable and the resulting
-		// corruption crashed a live game. Log-only: a decode we can't trust (or a real
-		// unsafe site) still gets the intended patch written, matching how the rest of this
-		// codebase degrades -- log with context, never silently break an install that
-		// worked yesterday.
+		// instruction; that byte turned out to be independently reachable -- specifically as
+		// an indirect vtable dispatch target, not a direct CALL/JMP -- and the resulting
+		// corruption crashed a live game.
+		//
+		// A plain "search for code xrefs to this address" is not sufficient to verify a
+		// flagged site -- it's exactly what missed the real incident. Also check whether the
+		// boundary address is stored as a function-pointer value in any vtable (RTTI class
+		// layout / vtable dump): a vtable slot pointing
+		// mid-function into the boundary byte is a DATA reference, and most disassemblers
+		// only surface it as a code xref if the vtable array is already typed as function
+		// pointers. Example: for a class C with vtable slot C::vtbl[k] == badAddr, that's
+		// disqualifying even though nothing in the disassembly shows a CALL/JMP literal to
+		// badAddr -- the call arrives indirectly via `call [vtableReg + k*8]`.
+		//
+		// Log-only: a decode we can't trust (or a real unsafe site) still gets the intended
+		// patch written, matching how the rest of this codebase degrades -- log with
+		// context, never silently break an install that worked yesterday.
 		//
 		// A flagged site is a real structural risk (the boundary byte genuinely used to be
 		// a valid instruction start), not proof of an active bug -- the check has no way to
 		// confirm anything actually targets that byte (our real incident wasn't visible via
-		// static xrefs either). Logged at `debug`, not `warn`: this codebase's own logger
-		// convention (see EngineFixesSkyrim64/src/main.cpp) sets Release builds -- what ships
-		// to players -- to `info` and above, and Debug builds to `debug` and above, so this
-		// is dev-visible by default and silent for end users without any extra plumbing here.
-		// A specific site a developer has manually verified safe (walked callers, confirmed
-		// no reachable entry into the boundary byte) can suppress this per call site via
-		// write_branch's `a_skipSafetyCheck` parameter -- prefer that over disabling the
-		// whole feature once you've actually done the verification.
+		// a plain xref scan either, for the vtable reason above). Logged at `debug`, not
+		// `warn`: this codebase's own logger convention (see EngineFixesSkyrim64/src/main.cpp)
+		// sets Release builds -- what ships to players -- to `info` and above, and Debug
+		// builds to `debug` and above, so this is dev-visible by default and silent for end
+		// users without any extra plumbing here.
+		//
+		// A specific site a developer has manually verified safe (walked BOTH code xrefs
+		// and vtable slots for the boundary address, confirmed neither reaches it) can
+		// suppress this per call site via write_branch's `a_skipSafetyCheck` parameter --
+		// prefer that over disabling the whole feature once you've actually done the
+		// verification.
 		void check_patch_site_boundary(std::uintptr_t a_src, std::size_t a_len)
 		{
 			std::size_t consumed = 0;
@@ -85,10 +100,12 @@ namespace SKSE
 			const auto overwritten = a_len - (consumed - lastLen);
 			log::debug(
 				"patch-site safety: write_branch<{}> at 0x{:X} fully consumes {} instruction(s) then "
-				"partially overwrites {} of {} bytes of the instruction at 0x{:X} -- that address is "
-				"a real instruction boundary something else may target, not just this patch's own "
-				"trampoline. Writing anyway; consider relocating this patch to a longer instruction "
-				"or passing a_skipSafetyCheck=true once verified safe."sv,
+				"partially overwrites {} of {} bytes of the instruction at 0x{:X} -- that address "
+				"used to be a valid instruction start. Before treating this site as safe, check for "
+				"anything targeting it directly: code xrefs (CALL/JMP) AND vtable slots holding it "
+				"as a function pointer (indirect vtable dispatch won't show as a code xref). If "
+				"clean, pass a_skipSafetyCheck=true to silence this; otherwise relocate the patch "
+				"onto a longer instruction. Writing anyway for now."sv,
 				a_len, a_src, instrCount - 1, overwritten, lastLen, badAddr);
 		}
 #endif

--- a/src/SKSE/Trampoline.cpp
+++ b/src/SKSE/Trampoline.cpp
@@ -45,12 +45,7 @@ namespace SKSE
 				hde64s     hs{};
 				const auto len = hde64_disasm(reinterpret_cast<const void*>(a_src + consumed), &hs);
 				if (len == 0 || (hs.flags & F_ERROR) != 0) {
-					// Basename only -- the full compiler path buries the one token that
-					// identifies the responsible patch (e.g. "actorvaluestorage_clear_race_crash.h").
-					std::string_view file{ a_loc.file_name() };
-					if (const auto sep = file.find_last_of("/\\"); sep != std::string_view::npos) {
-						file.remove_prefix(sep + 1);
-					}
+					const auto file = REL::detail::basename(a_loc);
 					log::debug(
 						"patch-site safety [{}:{}]: failed to decode instruction at 0x{:X} (+0x{:X} into a "
 						"write_branch<{}> at 0x{:X}) -- skipping boundary check for this patch"sv,

--- a/src/SKSE/Trampoline.cpp
+++ b/src/SKSE/Trampoline.cpp
@@ -32,11 +32,9 @@ namespace SKSE
 	namespace detail
 	{
 #ifdef SKSE_SUPPORT_PATCH_SAFETY
-		// A write_branch<N> patch is unsafe once it fully consumes one instruction and
-		// partially overwrites the next -- the resulting bytes can still be a live
-		// indirect-dispatch target even with no direct CALL/JMP to them. Log-only (never
-		// blocks the write); see write_branch's a_skipSafetyCheck to suppress a site
-		// you've manually verified safe.
+		// Warns (never blocks) when a write_branch<N> patch partially overwrites the
+		// instruction after the one it targets -- those bytes can still be a live
+		// indirect-dispatch target. Suppress via write_branch's a_skipSafetyCheck.
 		void check_patch_site_boundary(std::uintptr_t a_src, std::size_t a_len)
 		{
 			std::size_t consumed = 0;


### PR DESCRIPTION
## Summary
- `REL::VerifyBytes` (+ `REL::HashBytes`, `REL/Verify.h`) is a general-purpose hook-integrity primitive: hash a byte range, compare against a pinned expected hash, log unset/match/mismatch. No dependency on hde64 or any specific patch mechanism -- compiles unconditionally, callable on any byte range for any reason (a patch's own target bytes before writing, a downstream collateral range after writing, anything else worth tracking for silent drift).
- **Confirmed by an actual incident**, not a hypothetical: an EngineFixesSkyrim64 fix patched a 4-byte load with a 5-byte jmp, borrowing the first byte of the following `test` instruction. That byte turned out to be independently reachable elsewhere in the binary, and the corruption crashed a live deployed game.
- `Trampoline::write_branch<N>`'s boundary-overlap detector is the first consumer, not the feature itself: it decodes instructions past the patch's own footprint (vendors [hde64](https://github.com/TsudaKageyu/minhook/tree/master/src/hde), BSD-2-Clause, ~500 lines via `FetchContent` pinned to `v1.3.4`, populate-only so MinHook's own hooking library is never added as a subdirectory), and on finding an overlap hands the orphaned byte range to `REL::VerifyBytes` for pinning. `write_branch`/`write_call` grew an optional `a_expectedPatchHash` trailing param for this specific use, on top of the existing `a_skipSafetyCheck`.
- **UX-tested against a live 15-warning EngineFixesSkyrim64 install** (real SE run + headless-VR run): with hashes pinned, all currently-firing sites go silent; a deliberately corrupted hash re-escalates to a warn-level mismatch showing both the stale and live hash, then goes silent again once corrected. Unpinned (hash left at 0, the default), the check behaves exactly as before -- always logs, prints the computed hash so a caller can capture it.
- **Opt-out via `SKSE_SUPPORT_PATCH_SAFETY` (default `ON`)** gates only the hde64 boundary-overlap detector; `REL::VerifyBytes` itself is unconditional. The check only logs and still writes the intended patch on failure, so it can't newly break a build that works today.

## Verification
Pulled the exact bytes of both the real incident's original (bad) patch site and its redesigned (safe) replacement straight from Ghidra, and ran the check's algorithm against them in an isolated standalone program:
- Real bug bytes (4-byte load + partial `test`) → **UNSAFE** (correct)
- Redesigned fix bytes (7-byte load, patch ends inside it) → **SAFE** (correct)
- Exact-boundary case (5-byte instruction, 5-byte patch) → **SAFE** (correct)

## Test plan
- [x] `cmake --preset build-debug-clang-cl-vcpkg-all` and `-vr` build succeed with `SKSE_SUPPORT_PATCH_SAFETY=ON` (default)
- [x] Standalone verification against real incident bytes (see above)
- [x] Live SE + headless-VR run against a real EngineFixesSkyrim64 install: 15/15 currently-firing sites verified safe, hash-pinned, confirmed silent on match and re-escalating on a deliberately corrupted hash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional patch safety checks for branch and call modifications.
  * Added expected-byte verification using hash comparisons.
  * Added diagnostic reporting for unset, matching, and mismatched patch data.
  * Safety checks are enabled by default and can be bypassed when necessary.
* **Compatibility**
  * Existing branch and call patching usage remains supported through default parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->