### PR TITLE
fix(imagespacemanager): fix SAOBlurH type

### DIFF
--- a/include/RE/I/ImageSpaceManager.h
+++ b/include/RE/I/ImageSpaceManager.h
@@ -312,6 +312,34 @@ namespace RE
 			bool                            taaEnabled;                            // 18
 		};
 
+		// Real type of the field misnamed BSImagespaceShaderISSAOBlurH below (SE/AE only;
+		// confirmed via disassembly the feeding allocation is 0x70 bytes, not
+		// sizeof(BSImagespaceShader) == 0x1A8). Populated once by ImageSpaceManager's SAO
+		// wiring step (a separate function on SE, inlined into InitializeEffects on AE)
+		// with pointers to the rest of the SAO chain plus SAO/DOF Display-menu ini
+		// defaults, incl. bSAOEnable:Display into enableSAO. Not confirmed for VR, whose
+		// wiring step constructs a differently-shaped object.
+		struct SAOEffectParams
+		{
+			ImageSpaceEffect* blurH;            // 00 - ISSAOBlurH (self)
+			ImageSpaceEffect* blurV;            // 08 - ISSAOBlurV
+			ImageSpaceEffect* cameraZ;          // 10 - ISSAOCameraZ
+			ImageSpaceEffect* compositeSAO;     // 18 - ISSAOCompositeSAO
+			ImageSpaceEffect* compositeFog;     // 20 - ISSAOCompositeFog
+			ImageSpaceEffect* compositeSAOFog;  // 28 - ISSAOCompositeSAOFog
+			ImageSpaceEffect* minify;           // 30 - ISMinify
+			ImageSpaceEffect* minifyContrast;   // 38 - ISMinifyContrast
+			ImageSpaceEffect* rawAO;            // 40 - ISSAORawAO
+			ImageSpaceEffect* rawAONoTemporal;  // 48 - ISSAORawAONoTemporal
+			bool              enableSAO;        // 50 - from bSAOEnable:Display (low byte of an 8-byte slot)
+			std::uint8_t      pad51[3];         // 51
+			std::uint32_t     unk54;            // 54 - always 0 at construction
+			std::uint64_t     unk58;            // 58 - always 0 at construction
+			std::uint64_t     unk60;            // 60 - always 0 at construction
+			std::uint64_t     unk68;            // 68 - always 0 at construction
+		};
+		static_assert(sizeof(SAOEffectParams) == 0x70);
+
 		struct RUNTIME_DATA
 		{
 #define RUNTIME_DATA_CONTENT                                                                                                                                                                     \
@@ -343,7 +371,7 @@ namespace RE
 	NiPointer<BSImagespaceShader>       BSImagespaceShaderISLightingComposite;           /* 1B0, VR 1D0 */                                                                                       \
 	NiPointer<BSImagespaceShader>       BSImagespaceShaderISPerlinNoiseCS;               /* 1B8, VR 1D8 */                                                                                       \
 	NiPointer<BSImagespaceShader>       BSImagespaceShaderReflectionsRayTracing;         /* 1C0, VR 1E8 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSAOBlurH;                    /* 1C8, VR 1F0 */                                                                                       \
+	SAOEffectParams*                    BSImagespaceShaderISSAOBlurH;                    /* 1C8, VR 1F0 -- see SAOEffectParams doc comment */                                                    \
 	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSAOBlurHCS;                  /* 1D0, VR 1F8 */                                                                                       \
 	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSILComposite;                /* 1D8, VR 200 */                                                                                       \
 	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSimpleColor;                 /* 1E0, VR 208 */                                                                                       \
@@ -361,51 +389,51 @@ namespace RE
 
 		struct VR_RUNTIME_DATA
 		{
-#define VR_RUNTIME_DATA_CONTENT                                                                                                                                                                          \
-	NiPointer<BSTriShape> VRunk58;                                                               /* VR 058 */                                                                                            \
-	NiPointer<BSTriShape> VRunk60;                                                               /* VR 060 */                                                                                            \
-	std::uint32_t         unk5C;                                                                 /* 05C, VR 68 */                                                                                        \
-	std::uint32_t         unk60;                                                                 /* 060, VR 6C */                                                                                        \
-	RENDER_TARGET         renderTarget;                                                          /* 064, VR 70 */                                                                                        \
-	std::uint32_t         unk68;                                                                 /* 068, VR 74 */                                                                                        \
-	std::uint32_t         unk6C;                                                                 /* 06C, VR 78 */                                                                                        \
-	std::uint32_t         unk70;                                                                 /* 070, VR 7C */                                                                                        \
-	float                 VRunk84;                                                               /* VR, 84*/                                                                                             \
-	float                 unk74;                                                                 /* 074, VR 80 */                                                                                        \
-	ImageSpaceTexture     unk78;                                                                 /* 078, VR 88 */                                                                                        \
-	NiColorA              refractionTint;                                                        /* 098, VR A8 */                                                                                        \
-	ImageSpaceBaseData*   currentBaseData;                                                       /* 0A8, VR B8 */                                                                                        \
-	ImageSpaceBaseData*   overrideBaseData;                                                      /* 0B0, VR C0 */                                                                                        \
-	ImageSpaceBaseData*   underwaterBaseData;                                                    /* 0B8, VR C8 */                                                                                        \
-	ImageSpaceBaseData*   consoleBaseData;                                                       /* 0C0, VR D0 */                                                                                        \
-	ImageSpaceData        data;                                                                  /* 0C8, VR D8 */                                                                                        \
-																								 /* the structure is unclear and varies for each, but at least the first entry is a BSImagespaceShader*/ \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderApplyReflections;                      /* 168, VR 178 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISApplyVolumetricLighting;             /* 170, VR 180 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISBasicCopy;                           /* 178, VR 188 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISBlur;                                /* 180, VR 190 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISVolumetricLightingBlurHCS;           /* 188, VR 198 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISCompositeVolumetricLighting;         /* 190, VR 1A0 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISCopySubRegionCS;                     /* 198, VR 1A8 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISDebugSnow;                           /* 1A0, VR 1B0 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISDownsampleHierarchicalDepthBufferCS; /* VR, 1B8 */                                                                                           \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISExp;                                 /* 1A8, VR 1C0 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISFullScreenVR;                        /* VR 1C8 */                                                                                            \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISLightingComposite;                   /* 1B0, VR 1D0 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISPerlinNoiseCS;                       /* 1B8, VR 1D8 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderTransformLvl7PreTest;                  /* VR 1E0 */                                                                                            \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderReflectionsRayTracing;                 /* 1C0, VR 1E8 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSAOBlurH;                            /* 1C8, VR 1F0 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSAOBlurHCS;                          /* 1D0, VR 1F8 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSILComposite;                        /* 1D8, VR 200 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSimpleColor;                         /* 1E0, VR 208 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSnowSSS;                             /* 1E8, VR 210 */                                                                                       \
-	UNK_BSImagespaceShaderISTemporalAA* BSImagespaceShaderISTemporalAA;                          /* 1F0, VR 218 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISUpsampleDynamicResolution;           /* 1F8, VR 220 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISWaterBlend;                          /* 200, VR 228 */                                                                                       \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISUnderwaterMask;                      /* 208, VR 230 */                                                                                       \
-	bool                                usesLDR;                                                 /* 210, VR 238 */                                                                                       \
-	bool                                unk211;                                                  /* 211, VR 239 */                                                                                       \
+#define VR_RUNTIME_DATA_CONTENT                                                                                                                                                                                                                                                            \
+	NiPointer<BSTriShape> VRunk58;                                                               /* VR 058 */                                                                                                                                                                              \
+	NiPointer<BSTriShape> VRunk60;                                                               /* VR 060 */                                                                                                                                                                              \
+	std::uint32_t         unk5C;                                                                 /* 05C, VR 68 */                                                                                                                                                                          \
+	std::uint32_t         unk60;                                                                 /* 060, VR 6C */                                                                                                                                                                          \
+	RENDER_TARGET         renderTarget;                                                          /* 064, VR 70 */                                                                                                                                                                          \
+	std::uint32_t         unk68;                                                                 /* 068, VR 74 */                                                                                                                                                                          \
+	std::uint32_t         unk6C;                                                                 /* 06C, VR 78 */                                                                                                                                                                          \
+	std::uint32_t         unk70;                                                                 /* 070, VR 7C */                                                                                                                                                                          \
+	float                 VRunk84;                                                               /* VR, 84*/                                                                                                                                                                               \
+	float                 unk74;                                                                 /* 074, VR 80 */                                                                                                                                                                          \
+	ImageSpaceTexture     unk78;                                                                 /* 078, VR 88 */                                                                                                                                                                          \
+	NiColorA              refractionTint;                                                        /* 098, VR A8 */                                                                                                                                                                          \
+	ImageSpaceBaseData*   currentBaseData;                                                       /* 0A8, VR B8 */                                                                                                                                                                          \
+	ImageSpaceBaseData*   overrideBaseData;                                                      /* 0B0, VR C0 */                                                                                                                                                                          \
+	ImageSpaceBaseData*   underwaterBaseData;                                                    /* 0B8, VR C8 */                                                                                                                                                                          \
+	ImageSpaceBaseData*   consoleBaseData;                                                       /* 0C0, VR D0 */                                                                                                                                                                          \
+	ImageSpaceData        data;                                                                  /* 0C8, VR D8 */                                                                                                                                                                          \
+																								 /* the structure is unclear and varies for each, but at least the first entry is a BSImagespaceShader*/                                                                                   \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderApplyReflections;                      /* 168, VR 178 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISApplyVolumetricLighting;             /* 170, VR 180 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISBasicCopy;                           /* 178, VR 188 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISBlur;                                /* 180, VR 190 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISVolumetricLightingBlurHCS;           /* 188, VR 198 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISCompositeVolumetricLighting;         /* 190, VR 1A0 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISCopySubRegionCS;                     /* 198, VR 1A8 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISDebugSnow;                           /* 1A0, VR 1B0 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISDownsampleHierarchicalDepthBufferCS; /* VR, 1B8 */                                                                                                                                                                             \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISExp;                                 /* 1A8, VR 1C0 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISFullScreenVR;                        /* VR 1C8 */                                                                                                                                                                              \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISLightingComposite;                   /* 1B0, VR 1D0 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISPerlinNoiseCS;                       /* 1B8, VR 1D8 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderTransformLvl7PreTest;                  /* VR 1E0 */                                                                                                                                                                              \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderReflectionsRayTracing;                 /* 1C0, VR 1E8 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSAOBlurH;                            /* 1C8, VR 1F0 -- SE/AE real type is SAOEffectParams* (see doc comment above), not this; VR's wiring step builds a differently-shaped object and this field's true type is unconfirmed */ \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSAOBlurHCS;                          /* 1D0, VR 1F8 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSILComposite;                        /* 1D8, VR 200 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSimpleColor;                         /* 1E0, VR 208 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSnowSSS;                             /* 1E8, VR 210 */                                                                                                                                                                         \
+	UNK_BSImagespaceShaderISTemporalAA* BSImagespaceShaderISTemporalAA;                          /* 1F0, VR 218 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISUpsampleDynamicResolution;           /* 1F8, VR 220 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISWaterBlend;                          /* 200, VR 228 */                                                                                                                                                                         \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISUnderwaterMask;                      /* 208, VR 230 */                                                                                                                                                                         \
+	bool                                usesLDR;                                                 /* 210, VR 238 */                                                                                                                                                                         \
+	bool                                unk211;                                                  /* 211, VR 239 */                                                                                                                                                                         \
 	NiPointer<NiAVObject>               underwaterSplitterGeom;                                  /* 218, VR 240 */
             VR_RUNTIME_DATA_CONTENT
 		};

--- a/include/RE/I/ImageSpaceManager.h
+++ b/include/RE/I/ImageSpaceManager.h
@@ -312,13 +312,13 @@ namespace RE
 			bool                            taaEnabled;                            // 18
 		};
 
-		// Real type of the field misnamed BSImagespaceShaderISSAOBlurH below (SE/AE only;
-		// confirmed via disassembly the feeding allocation is 0x70 bytes, not
+		// Real type of the field misnamed BSImagespaceShaderISSAOBlurH below (all three
+		// runtimes; confirmed via disassembly the feeding allocation is 0x70 bytes, not
 		// sizeof(BSImagespaceShader) == 0x1A8). Populated once by ImageSpaceManager's SAO
-		// wiring step (a separate function on SE, inlined into InitializeEffects on AE)
-		// with pointers to the rest of the SAO chain plus SAO/DOF Display-menu ini
-		// defaults, incl. bSAOEnable:Display into enableSAO. Not confirmed for VR, whose
-		// wiring step constructs a differently-shaped object.
+		// wiring step (a separate function on SE, inlined into InitializeEffects on AE;
+		// VR has its own equivalent function using effects[] indices shifted +0xF for its
+		// extra VR-specific effects) with pointers to the rest of the SAO chain plus
+		// SAO/DOF Display-menu ini defaults, incl. bSAOEnable:Display into enableSAO.
 		struct SAOEffectParams
 		{
 			ImageSpaceEffect* blurH;            // 00 - ISSAOBlurH (self)
@@ -389,51 +389,51 @@ namespace RE
 
 		struct VR_RUNTIME_DATA
 		{
-#define VR_RUNTIME_DATA_CONTENT                                                                                                                                                                                                                                                            \
-	NiPointer<BSTriShape> VRunk58;                                                               /* VR 058 */                                                                                                                                                                              \
-	NiPointer<BSTriShape> VRunk60;                                                               /* VR 060 */                                                                                                                                                                              \
-	std::uint32_t         unk5C;                                                                 /* 05C, VR 68 */                                                                                                                                                                          \
-	std::uint32_t         unk60;                                                                 /* 060, VR 6C */                                                                                                                                                                          \
-	RENDER_TARGET         renderTarget;                                                          /* 064, VR 70 */                                                                                                                                                                          \
-	std::uint32_t         unk68;                                                                 /* 068, VR 74 */                                                                                                                                                                          \
-	std::uint32_t         unk6C;                                                                 /* 06C, VR 78 */                                                                                                                                                                          \
-	std::uint32_t         unk70;                                                                 /* 070, VR 7C */                                                                                                                                                                          \
-	float                 VRunk84;                                                               /* VR, 84*/                                                                                                                                                                               \
-	float                 unk74;                                                                 /* 074, VR 80 */                                                                                                                                                                          \
-	ImageSpaceTexture     unk78;                                                                 /* 078, VR 88 */                                                                                                                                                                          \
-	NiColorA              refractionTint;                                                        /* 098, VR A8 */                                                                                                                                                                          \
-	ImageSpaceBaseData*   currentBaseData;                                                       /* 0A8, VR B8 */                                                                                                                                                                          \
-	ImageSpaceBaseData*   overrideBaseData;                                                      /* 0B0, VR C0 */                                                                                                                                                                          \
-	ImageSpaceBaseData*   underwaterBaseData;                                                    /* 0B8, VR C8 */                                                                                                                                                                          \
-	ImageSpaceBaseData*   consoleBaseData;                                                       /* 0C0, VR D0 */                                                                                                                                                                          \
-	ImageSpaceData        data;                                                                  /* 0C8, VR D8 */                                                                                                                                                                          \
-																								 /* the structure is unclear and varies for each, but at least the first entry is a BSImagespaceShader*/                                                                                   \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderApplyReflections;                      /* 168, VR 178 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISApplyVolumetricLighting;             /* 170, VR 180 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISBasicCopy;                           /* 178, VR 188 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISBlur;                                /* 180, VR 190 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISVolumetricLightingBlurHCS;           /* 188, VR 198 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISCompositeVolumetricLighting;         /* 190, VR 1A0 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISCopySubRegionCS;                     /* 198, VR 1A8 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISDebugSnow;                           /* 1A0, VR 1B0 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISDownsampleHierarchicalDepthBufferCS; /* VR, 1B8 */                                                                                                                                                                             \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISExp;                                 /* 1A8, VR 1C0 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISFullScreenVR;                        /* VR 1C8 */                                                                                                                                                                              \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISLightingComposite;                   /* 1B0, VR 1D0 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISPerlinNoiseCS;                       /* 1B8, VR 1D8 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderTransformLvl7PreTest;                  /* VR 1E0 */                                                                                                                                                                              \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderReflectionsRayTracing;                 /* 1C0, VR 1E8 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSAOBlurH;                            /* 1C8, VR 1F0 -- SE/AE real type is SAOEffectParams* (see doc comment above), not this; VR's wiring step builds a differently-shaped object and this field's true type is unconfirmed */ \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSAOBlurHCS;                          /* 1D0, VR 1F8 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSILComposite;                        /* 1D8, VR 200 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSimpleColor;                         /* 1E0, VR 208 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSnowSSS;                             /* 1E8, VR 210 */                                                                                                                                                                         \
-	UNK_BSImagespaceShaderISTemporalAA* BSImagespaceShaderISTemporalAA;                          /* 1F0, VR 218 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISUpsampleDynamicResolution;           /* 1F8, VR 220 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISWaterBlend;                          /* 200, VR 228 */                                                                                                                                                                         \
-	NiPointer<BSImagespaceShader>       BSImagespaceShaderISUnderwaterMask;                      /* 208, VR 230 */                                                                                                                                                                         \
-	bool                                usesLDR;                                                 /* 210, VR 238 */                                                                                                                                                                         \
-	bool                                unk211;                                                  /* 211, VR 239 */                                                                                                                                                                         \
+#define VR_RUNTIME_DATA_CONTENT                                                                                                                                                                          \
+	NiPointer<BSTriShape> VRunk58;                                                               /* VR 058 */                                                                                            \
+	NiPointer<BSTriShape> VRunk60;                                                               /* VR 060 */                                                                                            \
+	std::uint32_t         unk5C;                                                                 /* 05C, VR 68 */                                                                                        \
+	std::uint32_t         unk60;                                                                 /* 060, VR 6C */                                                                                        \
+	RENDER_TARGET         renderTarget;                                                          /* 064, VR 70 */                                                                                        \
+	std::uint32_t         unk68;                                                                 /* 068, VR 74 */                                                                                        \
+	std::uint32_t         unk6C;                                                                 /* 06C, VR 78 */                                                                                        \
+	std::uint32_t         unk70;                                                                 /* 070, VR 7C */                                                                                        \
+	float                 VRunk84;                                                               /* VR, 84*/                                                                                             \
+	float                 unk74;                                                                 /* 074, VR 80 */                                                                                        \
+	ImageSpaceTexture     unk78;                                                                 /* 078, VR 88 */                                                                                        \
+	NiColorA              refractionTint;                                                        /* 098, VR A8 */                                                                                        \
+	ImageSpaceBaseData*   currentBaseData;                                                       /* 0A8, VR B8 */                                                                                        \
+	ImageSpaceBaseData*   overrideBaseData;                                                      /* 0B0, VR C0 */                                                                                        \
+	ImageSpaceBaseData*   underwaterBaseData;                                                    /* 0B8, VR C8 */                                                                                        \
+	ImageSpaceBaseData*   consoleBaseData;                                                       /* 0C0, VR D0 */                                                                                        \
+	ImageSpaceData        data;                                                                  /* 0C8, VR D8 */                                                                                        \
+																								 /* the structure is unclear and varies for each, but at least the first entry is a BSImagespaceShader*/ \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderApplyReflections;                      /* 168, VR 178 */                                                                                       \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISApplyVolumetricLighting;             /* 170, VR 180 */                                                                                       \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISBasicCopy;                           /* 178, VR 188 */                                                                                       \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISBlur;                                /* 180, VR 190 */                                                                                       \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISVolumetricLightingBlurHCS;           /* 188, VR 198 */                                                                                       \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISCompositeVolumetricLighting;         /* 190, VR 1A0 */                                                                                       \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISCopySubRegionCS;                     /* 198, VR 1A8 */                                                                                       \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISDebugSnow;                           /* 1A0, VR 1B0 */                                                                                       \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISDownsampleHierarchicalDepthBufferCS; /* VR, 1B8 */                                                                                           \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISExp;                                 /* 1A8, VR 1C0 */                                                                                       \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISFullScreenVR;                        /* VR 1C8 */                                                                                            \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISLightingComposite;                   /* 1B0, VR 1D0 */                                                                                       \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISPerlinNoiseCS;                       /* 1B8, VR 1D8 */                                                                                       \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderTransformLvl7PreTest;                  /* VR 1E0 */                                                                                            \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderReflectionsRayTracing;                 /* 1C0, VR 1E8 */                                                                                       \
+	SAOEffectParams*                    BSImagespaceShaderISSAOBlurH;                            /* 1C8, VR 1F0 -- see SAOEffectParams doc comment above */                                              \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSAOBlurHCS;                          /* 1D0, VR 1F8 */                                                                                       \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSILComposite;                        /* 1D8, VR 200 */                                                                                       \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSimpleColor;                         /* 1E0, VR 208 */                                                                                       \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISSnowSSS;                             /* 1E8, VR 210 */                                                                                       \
+	UNK_BSImagespaceShaderISTemporalAA* BSImagespaceShaderISTemporalAA;                          /* 1F0, VR 218 */                                                                                       \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISUpsampleDynamicResolution;           /* 1F8, VR 220 */                                                                                       \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISWaterBlend;                          /* 200, VR 228 */                                                                                       \
+	NiPointer<BSImagespaceShader>       BSImagespaceShaderISUnderwaterMask;                      /* 208, VR 230 */                                                                                       \
+	bool                                usesLDR;                                                 /* 210, VR 238 */                                                                                       \
+	bool                                unk211;                                                  /* 211, VR 239 */                                                                                       \
 	NiPointer<NiAVObject>               underwaterSplitterGeom;                                  /* 218, VR 240 */
             VR_RUNTIME_DATA_CONTENT
 		};

--- a/include/RE/I/ImageSpaceManager.h
+++ b/include/RE/I/ImageSpaceManager.h
@@ -313,12 +313,9 @@ namespace RE
 		};
 
 		// Real type of the field misnamed BSImagespaceShaderISSAOBlurH below (all three
-		// runtimes; confirmed via disassembly the feeding allocation is 0x70 bytes, not
-		// sizeof(BSImagespaceShader) == 0x1A8). Populated once by ImageSpaceManager's SAO
-		// wiring step (a separate function on SE, inlined into InitializeEffects on AE;
-		// VR has its own equivalent function using effects[] indices shifted +0xF for its
-		// extra VR-specific effects) with pointers to the rest of the SAO chain plus
-		// SAO/DOF Display-menu ini defaults, incl. bSAOEnable:Display into enableSAO.
+		// runtimes; the feeding allocation is 0x70 bytes, not sizeof(BSImagespaceShader)
+		// == 0x1A8). Holds pointers to the rest of the SAO effect chain plus SAO/DOF
+		// Display-menu ini defaults, incl. bSAOEnable:Display into enableSAO.
 		struct SAOEffectParams
 		{
 			ImageSpaceEffect* blurH;            // 00 - ISSAOBlurH (self)


### PR DESCRIPTION
## Summary
`ImageSpaceManager::BSImagespaceShaderISSAOBlurH` was typed as
`NiPointer<BSImagespaceShader>`, but on all three runtimes it actually points
to a lightweight 0x70-byte composite-params struct built once by the SAO
wiring step -- not a real `BSImagespaceShader` instance.

## Verification
- Ghidra RE, all three runtimes (`SkyrimSE.exe`, `SkyrimSE.1170.exe`,
  `SkyrimVR.exe`): decompiled the constructing function on each and
  confirmed the feeding allocation is 0x70 bytes, not
  `sizeof(BSImagespaceShader) == 0x1A8`.
- Ground-truth struct-component check (not decompiler inference) on all
  three: field offsets are byte-identical -- `0x00..0x48` are 10 pointers
  into the rest of the SAO effect chain (looked up from `effects[]` and
  adjusted by a constant, `-0x90` on SE/AE, and VR's own equivalent
  function uses the same 10 indices as SE/AE shifted by a constant `+0xF`
  for its extra VR-specific effects), `0x50` is a dedicated `bool` sourced
  from `bSAOEnable:Display`, `0x54..0x6F` are reserved/always-zero at
  construction (documented as unknown, not guessed).
- VR was initially thought to build a genuinely different, real
  `ImageSpaceEffect`-derived object here, because Ghidra's decompiler
  auto-inferred `ImageSpaceEffect`-shaped field names for the constructing
  function's parameters (propagated from the field's then-declared
  `NiPointer<BSImagespaceShader>` type). Two checks disproved that:
  the object's allocation is 0x70 bytes, 32 bytes too small to hold a
  real `ImageSpaceEffect` (0x90 bytes); and the function's 10
  sibling-effect argument lookups use the exact same indices as SE/AE,
  shifted by a uniform `+0xF`. Confirmed via xref search there is exactly
  one write site to this field in each binary (the constructing function,
  called once from `InitializeEffects`), and no other function in any of
  the three binaries reads/writes it.

## Changes
- Add `SAOEffectParams` documenting the real, identical-across-runtimes
  layout.
- Retype the field (`RUNTIME_DATA_CONTENT` and `VR_RUNTIME_DATA_CONTENT`)
  to `SAOEffectParams*` on all three runtimes.

Companion fix on the open-shaders side:
https://github.com/alandtse/open-shaders/pull/332
