### PR TITLE
fix(playercharacter): vr event sources

### DIFF
--- a/include/RE/P/PlayerCharacter.h
+++ b/include/RE/P/PlayerCharacter.h
@@ -750,11 +750,11 @@ namespace RE
 		void UpdateVRComfortCheck();
 		void UsePoisonFromInventory(AlchemyItem* a_poison);
 
-		RUNTIME_CAST_ACCESSOR_VERSIONED(BSTEventSource<BGSActorCellEvent>, AsBGSActorCellEventSource, SKSE::RUNTIME_SSE_1_6_629, 0x2D0, 0x2D8)
+		RUNTIME_CAST_ACCESSOR_VERSIONED_VR(BSTEventSource<BGSActorCellEvent>, AsBGSActorCellEventSource, SKSE::RUNTIME_SSE_1_6_629, 0x2D0, 0x2E8, 0x2D8)
 
-		RUNTIME_CAST_ACCESSOR_VERSIONED(BSTEventSource<BGSActorDeathEvent>, AsBGSActorDeathEventSource, SKSE::RUNTIME_SSE_1_6_629, 0x328, 0x330)
+		RUNTIME_CAST_ACCESSOR_VERSIONED_VR(BSTEventSource<BGSActorDeathEvent>, AsBGSActorDeathEventSource, SKSE::RUNTIME_SSE_1_6_629, 0x328, 0x340, 0x330)
 
-		RUNTIME_CAST_ACCESSOR_VERSIONED(BSTEventSource<PositionPlayerEvent>, AsPositionPlayerEventSource, SKSE::RUNTIME_SSE_1_6_629, 0x380, 0x388)
+		RUNTIME_CAST_ACCESSOR_VERSIONED_VR(BSTEventSource<PositionPlayerEvent>, AsPositionPlayerEventSource, SKSE::RUNTIME_SSE_1_6_629, 0x380, 0x398, 0x388)
 
 		RUNTIME_CAST_ACCESSOR_VERSIONED(BSTEventSink<MenuOpenCloseEvent>, AsMenuOpenCloseEventSink, SKSE::RUNTIME_SSE_1_6_629, 0x2B0, 0x2B8)
 

--- a/include/REL/RuntimeDataAccessors.h
+++ b/include/REL/RuntimeDataAccessors.h
@@ -170,17 +170,17 @@
 
 // Versioned runtime-aware base class cast accessor (SE/VR/AE)
 // Usage: RUNTIME_CAST_ACCESSOR_VERSIONED_VR(MagicTarget, AsMagicTarget, SKSE::RUNTIME_SSE_1_6_629, 0x98, 0xA0, 0xA8)
-#define RUNTIME_CAST_ACCESSOR_VERSIONED_VR(StructType, FuncName, Version, SEOffset, VROffset, AEOffset)    \
-	[[nodiscard]] inline StructType* FuncName() noexcept                                                   \
-	{                                                                                                      \
-		if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {                                                    \
-			return &REL::RelocateMemberIfNewer<StructType>(Version, this, SEOffset, AEOffset);             \
-		}                                                                                                  \
-		return &REL::RelocateMember<StructType>(this, SEOffset, VROffset);                                 \
-	}                                                                                                      \
-	[[nodiscard]] inline const StructType* FuncName() const noexcept                                       \
-	{                                                                                                      \
-		return const_cast<std::remove_const_t<std::remove_pointer_t<decltype(this)>>*>(this)->FuncName();  \
+#define RUNTIME_CAST_ACCESSOR_VERSIONED_VR(StructType, FuncName, Version, SEOffset, VROffset, AEOffset)   \
+	[[nodiscard]] inline StructType* FuncName() noexcept                                                  \
+	{                                                                                                     \
+		if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {                                                   \
+			return &REL::RelocateMemberIfNewer<StructType>(Version, this, SEOffset, AEOffset);            \
+		}                                                                                                 \
+		return &REL::RelocateMember<StructType>(this, SEOffset, VROffset);                                \
+	}                                                                                                     \
+	[[nodiscard]] inline const StructType* FuncName() const noexcept                                      \
+	{                                                                                                     \
+		return const_cast<std::remove_const_t<std::remove_pointer_t<decltype(this)>>*>(this)->FuncName(); \
 	}
 
 // ========================================

--- a/include/REL/RuntimeDataAccessors.h
+++ b/include/REL/RuntimeDataAccessors.h
@@ -168,6 +168,21 @@
 		return const_cast<std::remove_const_t<std::remove_pointer_t<decltype(this)>>*>(this)->FuncName(); \
 	}
 
+// Versioned runtime-aware base class cast accessor (SE/VR/AE)
+// Usage: RUNTIME_CAST_ACCESSOR_VERSIONED_VR(MagicTarget, AsMagicTarget, SKSE::RUNTIME_SSE_1_6_629, 0x98, 0xA0, 0xA8)
+#define RUNTIME_CAST_ACCESSOR_VERSIONED_VR(StructType, FuncName, Version, SEOffset, VROffset, AEOffset)    \
+	[[nodiscard]] inline StructType* FuncName() noexcept                                                   \
+	{                                                                                                      \
+		if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {                                                    \
+			return &REL::RelocateMemberIfNewer<StructType>(Version, this, SEOffset, AEOffset);             \
+		}                                                                                                  \
+		return &REL::RelocateMember<StructType>(this, SEOffset, VROffset);                                 \
+	}                                                                                                      \
+	[[nodiscard]] inline const StructType* FuncName() const noexcept                                       \
+	{                                                                                                      \
+		return const_cast<std::remove_const_t<std::remove_pointer_t<decltype(this)>>*>(this)->FuncName();  \
+	}
+
 // ========================================
 // Three-Runtime Accessors (SE/AE/VR)
 // ========================================

--- a/include/REL/RuntimeDataAccessors.h
+++ b/include/REL/RuntimeDataAccessors.h
@@ -168,21 +168,6 @@
 		return const_cast<std::remove_const_t<std::remove_pointer_t<decltype(this)>>*>(this)->FuncName(); \
 	}
 
-// Versioned runtime-aware base class cast accessor (SE/VR/AE)
-// Usage: RUNTIME_CAST_ACCESSOR_VERSIONED_VR(MagicTarget, AsMagicTarget, SKSE::RUNTIME_SSE_1_6_629, 0x98, 0xA0, 0xA8)
-#define RUNTIME_CAST_ACCESSOR_VERSIONED_VR(StructType, FuncName, Version, SEOffset, VROffset, AEOffset)   \
-	[[nodiscard]] inline StructType* FuncName() noexcept                                                  \
-	{                                                                                                     \
-		if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {                                                   \
-			return &REL::RelocateMemberIfNewer<StructType>(Version, this, SEOffset, AEOffset);            \
-		}                                                                                                 \
-		return &REL::RelocateMember<StructType>(this, SEOffset, VROffset);                                \
-	}                                                                                                     \
-	[[nodiscard]] inline const StructType* FuncName() const noexcept                                      \
-	{                                                                                                     \
-		return const_cast<std::remove_const_t<std::remove_pointer_t<decltype(this)>>*>(this)->FuncName(); \
-	}
-
 // ========================================
 // Three-Runtime Accessors (SE/AE/VR)
 // ========================================
@@ -212,4 +197,22 @@
 			return REL::RelocateMemberIfNewer<StructType>(Version, this, SEOffset, AEOffset);          \
 		}                                                                                              \
 		return REL::RelocateMember<StructType>(this, SEOffset, VROffset);                              \
+	}
+
+// Versioned runtime-aware base class cast accessor for members with different offsets in SE, AE, and VR
+// Usage: RUNTIME_CAST_ACCESSOR_VERSIONED_VR(MagicTarget, AsMagicTarget, SKSE::RUNTIME_SSE_1_6_629, 0x98, 0xA0, 0xA8)
+// Parameters: (StructType, FuncName, Version, SEOffset, VROffset, AEOffset) -- same shape as
+// RUNTIME_MEMBER_ACCESSOR_VERSIONED above, just returning a pointer (for base-class cast accessors)
+// instead of a reference.
+#define RUNTIME_CAST_ACCESSOR_VERSIONED_VR(StructType, FuncName, Version, SEOffset, VROffset, AEOffset)   \
+	[[nodiscard]] inline StructType* FuncName() noexcept                                                  \
+	{                                                                                                     \
+		if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {                                                   \
+			return &REL::RelocateMemberIfNewer<StructType>(Version, this, SEOffset, AEOffset);            \
+		}                                                                                                 \
+		return &REL::RelocateMember<StructType>(this, SEOffset, VROffset);                                \
+	}                                                                                                     \
+	[[nodiscard]] inline const StructType* FuncName() const noexcept                                      \
+	{                                                                                                     \
+		return const_cast<std::remove_const_t<std::remove_pointer_t<decltype(this)>>*>(this)->FuncName(); \
 	}


### PR DESCRIPTION
It was crashing for VR users in my mod when I used `AsBGSActorCellEventSource`
This fix and analyses are AI generated, while I am coding c++ mods, I am doing it with AI agents and not very proficient in c++. So please review carefully and you can scrap this changes to your liking :)

## The Problem
In Skyrim VR, the memory layout for `RE::PlayerCharacter` contains three additional `BSTEventSink` base classes. This structure change shifts the offsets of all subsequent event sources compared to Special Edition. 
Previously, `PlayerCharacter`'s event source accessors (like `AsBGSActorCellEventSource`) were using the `RUNTIME_CAST_ACCESSOR_VERSIONED` macro, which only accepts two offset arguments (Old/SE and New/AE). Because Skyrim VR's module version is older than AE, the macro incorrectly fell back to the Old/SE offset (e.g., `0x2D0`). 
This caused the accessor to return a pointer pointing directly into the middle of the VR event sink vtables rather than the actual `BSTEventSource`. When consumers (like SKSE plugins) attempted to call `AddEventSink()`, the game would misinterpret `SkyrimVR.exe`'s `.rdata` section as an array of event listeners, scanning gigabytes of memory until throwing an `EXCEPTION_ACCESS_VIOLATION` crash.

## The Fix
1. **Introduced a 3-Offset Macro**: Added a new `RUNTIME_CAST_ACCESSOR_VERSIONED_VR` macro to `RuntimeDataAccessors.h` that supports providing three distinct offsets: SE, VR, and AE. It preserves the pointer-returning signature expected by event source cast accessors.
2. **Updated Accessors**: Updated the following accessors in `PlayerCharacter.h` to use the new macro and pass the correct VR offsets:
   - `AsBGSActorCellEventSource`
   - `AsBGSActorDeathEventSource`
   - `AsPositionPlayerEventSource`
   - 
## Offset Source
The correct VR offsets were already documented in the inline comments of `include/RE/P/PlayerCharacter.h` (e.g., `VR 2E8` for `BGSActorCellEvent`). I extracted those documented values and officially wired them into the new macro:
- `BGSActorCellEvent`: `0x2E8`
- `BGSActorDeathEvent`: `0x340`
- `PositionPlayerEvent`: `0x398`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime compatibility for VR builds when accessing player-character event sources.
  * Added version-aware handling for VR and Anniversary Edition runtime layouts.
  * Preserved access to actor cell, actor death, and player position event data across supported runtime versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->