### PR TITLE
feat(shadow): add BSShaderAccumulator RENDER_MODE enum

### DIFF
--- a/include/RE/B/BSShaderAccumulator.h
+++ b/include/RE/B/BSShaderAccumulator.h
@@ -2,6 +2,7 @@
 
 #include "RE/N/NiAlphaAccumulator.h"
 #include "RE/N/NiColor.h"
+#include "REX/REX/EnumSet.h"
 
 namespace RE
 {
@@ -13,21 +14,21 @@ namespace RE
 	public:
 		enum class RENDER_MODE : std::uint32_t
 		{
-			kNormal = 0,
-			kShadowMask = 12,
-			kShadowMapPlain = 13,
-			kShadowMapClamped = 14,
-			kShadowMapPb = 15,
-			kShadowMapCube = 17,
-			kLocalMap = 18,
-			kLodLandscapePass = 20,
-			kWaterReflectionPass = 21,
-			kBloodDecalPass = 22,
-			kAlphaTransparencyShadowPass = 23,
-			kSunGlintRefractionPass = 24,
-			kVolumetricLightingPass = 25,
-			kOcclusion = 26,
-			kPrecipitationOcclusionMap = 28
+			kNormal = 0x00,
+			kShadowMask = 0x0C,
+			kShadowMapPlain = 0x0D,
+			kShadowMapClamped = 0x0E,
+			kShadowMapPb = 0x0F,
+			kShadowMapCube = 0x11,
+			kLocalMap = 0x12,
+			kLodLandscapePass = 0x14,
+			kWaterReflectionPass = 0x15,
+			kBloodDecalPass = 0x16,
+			kAlphaTransparencyShadowPass = 0x17,
+			kSunGlintRefractionPass = 0x18,
+			kVolumetricLightingPass = 0x19,
+			kOcclusion = 0x1A,
+			kPrecipitationOcclusionMap = 0x1C
 		};
 
 		class SunOcclusionTest
@@ -59,7 +60,7 @@ namespace RE
 		// add
 		virtual void FinishAccumulatingPreResolveDepth(std::uint32_t flags);   // 2A
 		virtual void FinishAccumulatingPostResolveDepth(std::uint32_t flags);  // 2B
-		virtual void Unk_2C() = 0;                                             // 2C
+		virtual void FinishAccumulatingSunGlint() = 0;                         // 2C
 
 		struct RUNTIME_DATA
 		{
@@ -96,7 +97,7 @@ namespace RE
 	bool             currentActive;            /* 140 */ \
 	std::uint8_t     pad141[0x7];              /* 141 */ \
 	ShadowSceneNode* activeShadowSceneNode;    /* 148 */ \
-	std::uint32_t    renderMode;               /* 150 */ \
+	RENDER_MODE      renderMode;               /* 150 */ \
 	std::uint8_t     pad154[0x4];              /* 154 */ \
 	void*            unk158;                   /* 158 */ \
 	void*            unk160;                   /* 160 */ \

--- a/include/RE/B/BSShaderManager.h
+++ b/include/RE/B/BSShaderManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "RE/B/BSShaderAccumulator.h"
 #include "RE/N/NiBound.h"
 #include "RE/N/NiColor.h"
 #include "RE/N/NiPoint2.h"
@@ -24,11 +25,7 @@ namespace RE
 			kTotal = 5,
 		};
 
-		enum etRenderMode
-		{
-			BSSM_RENDER_NORMAL = 0,
-			BSSM_RENDER_PRECIPITATION_OCCLUSION_MAP = 28,
-		};
+		using etRenderMode = BSShaderAccumulator::RENDER_MODE;
 
 		class State
 		{


### PR DESCRIPTION
## Summary
- Document BSShaderAccumulator::renderMode shadow technique enum values (0xD plain, 0xE +Clamped, 0xF +Pb).

## Verification
- Verified clean build across all 5 build presets (build-all-presets.cmd).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized render-mode handling across shader components.
  - Added strongly typed render-pass and masking modes for improved consistency and safety.
  - Updated render-mode APIs to use the shared mode definitions while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->