### PR TITLE
feat(scene): add BGSSceneAction vfuncs and PlayerRegionState members

### DIFF
--- a/include/RE/B/BGSAcousticSpaceListener.h
+++ b/include/RE/B/BGSAcousticSpaceListener.h
@@ -4,6 +4,8 @@
 
 namespace RE
 {
+	class hkpCollidable;
+
 	class BGSAcousticSpaceListener : public hkpEntityListener
 	{
 	public:
@@ -14,8 +16,6 @@ namespace RE
 
 		// override (hkpEntityListener)
 		void EntityRemovedCallback(hkpEntity* a_entity) override;  // 02
-
-		class hkpCollidable;
 
 		// add
 		virtual void RemoveCollidable(const hkpCollidable* a_collidable);  // 06

--- a/include/RE/B/BGSAcousticSpaceListener.h
+++ b/include/RE/B/BGSAcousticSpaceListener.h
@@ -18,8 +18,9 @@ namespace RE
 		void EntityDeletedCallback(hkpEntity* a_entity) override;  // 05 - { return; }
 
 		// add
-		virtual void RemoveCollidable(hkpEntity* a_entity);                      // 06
-		virtual void AddCollidable(hkpEntity* a_entityA, hkpEntity* a_entityB);  // 07
+		virtual void RemoveCollidable(hkpEntity* a_entity);                             // 06
+		virtual void AddCollidable(hkpEntity* a_entityA, hkpEntity* a_entityB);         // 07
+		virtual void HandleCollidableExit(hkpEntity* a_entityA, hkpEntity* a_entityB);  // 08 - fired by bhkAcousticSpacePhantomCallbackShape's phantom-exit callback (paired with AddCollidable's phantom-enter callback); param types inferred by symmetry with AddCollidable, not independently confirmed
 
 		struct Entry
 		{

--- a/include/RE/B/BGSAcousticSpaceListener.h
+++ b/include/RE/B/BGSAcousticSpaceListener.h
@@ -15,9 +15,11 @@ namespace RE
 		// override (hkpEntityListener)
 		void EntityRemovedCallback(hkpEntity* a_entity) override;  // 02
 
+		class hkpCollidable;
+
 		// add
-		virtual void Unk_06(void);  // 06 - removes an entry from an internal handle set
-		virtual void Unk_07(void);  // 07 - inserts an entry into the same handle set
+		virtual void RemoveCollidable(const hkpCollidable* a_collidable);  // 06
+		virtual void AddCollidable(const hkpCollidable* a_collidable);     // 07
 
 		// members
 		std::uint8_t unk08[0x48];  // 08 - not yet RE'd

--- a/include/RE/B/BGSAcousticSpaceListener.h
+++ b/include/RE/B/BGSAcousticSpaceListener.h
@@ -21,8 +21,22 @@ namespace RE
 		virtual void RemoveCollidable(const hkpCollidable* a_collidable);  // 06
 		virtual void AddCollidable(const hkpCollidable* a_collidable);     // 07
 
+		struct Entry
+		{
+			std::uint32_t refHandle;  // 00
+			std::uint32_t refCount;   // 04
+			std::uint64_t pad08;      // 08
+		};
+		static_assert(sizeof(Entry) == 0x10);
+
 		// members
-		std::uint8_t unk08[0x48];  // 08 - not yet RE'd
+		void*         unk08;        // 08
+		std::uint32_t count;        // 10
+		std::uint32_t capacity;     // 14
+		std::uint32_t numBuckets;   // 18
+		std::uint32_t pad1C;        // 1C
+		Entry*        entries;      // 20
+		std::uint8_t  unk28[0x28];  // 28
 	};
 	static_assert(sizeof(BGSAcousticSpaceListener) == 0x50);
 }

--- a/include/RE/B/BGSAcousticSpaceListener.h
+++ b/include/RE/B/BGSAcousticSpaceListener.h
@@ -4,8 +4,6 @@
 
 namespace RE
 {
-	class hkpCollidable;
-
 	class BGSAcousticSpaceListener : public hkpEntityListener
 	{
 	public:
@@ -18,8 +16,8 @@ namespace RE
 		void EntityRemovedCallback(hkpEntity* a_entity) override;  // 02
 
 		// add
-		virtual void RemoveCollidable(const hkpCollidable* a_collidable);  // 06
-		virtual void AddCollidable(const hkpCollidable* a_collidable);     // 07
+		virtual void RemoveCollidable(hkpEntity* a_entity);                      // 06
+		virtual void AddCollidable(hkpEntity* a_entityA, hkpEntity* a_entityB);  // 07
 
 		struct Entry
 		{

--- a/include/RE/B/BGSAcousticSpaceListener.h
+++ b/include/RE/B/BGSAcousticSpaceListener.h
@@ -13,7 +13,9 @@ namespace RE
 		~BGSAcousticSpaceListener() override;  // 00
 
 		// override (hkpEntityListener)
+		void EntityAddedCallback(hkpEntity* a_entity) override;    // 01 - { return; }
 		void EntityRemovedCallback(hkpEntity* a_entity) override;  // 02
+		void EntityDeletedCallback(hkpEntity* a_entity) override;  // 05 - { return; }
 
 		// add
 		virtual void RemoveCollidable(hkpEntity* a_entity);                      // 06

--- a/include/RE/B/BGSSceneAction.h
+++ b/include/RE/B/BGSSceneAction.h
@@ -5,6 +5,7 @@
 namespace RE
 {
 	class BGSLoadGameBuffer;
+	class BGSSaveFormBuffer;
 	class TESFile;
 
 	class BGSSceneAction
@@ -31,27 +32,25 @@ namespace RE
 		virtual ~BGSSceneAction();  // 00
 
 		// add
-		virtual bool               LoadSceneAction(TESFile* a_mod);                     // 01
-		virtual void               Unk_02(void);                                        // 02
-		virtual void               Unk_03(void);                                        // 03 - { return; }
-		virtual void               ClearFlags();                                        // 04 - { flags = kNone; }
-		[[nodiscard]] virtual bool Loops() const;                                       // 05 - { return false; }
-		[[nodiscard]] virtual bool FacesTarget() const;                                 // 06 - { return true; }
-		[[nodiscard]] virtual Type GetType() const = 0;                                 // 07
-		virtual void               Unk_08(void);                                        // 08 - { return 0; }
-		virtual void               LoadBuffer(void* a_arg1, BGSLoadGameBuffer* a_buf);  // 09
-		class BGSSaveFormBuffer;
-
-		virtual void                        SaveBuffer(BGSSaveFormBuffer* a_buf);  // 0A
-		virtual void                        ClearActiveFlags();                    // 0B - { unk14 &= 0xFC; }
-		virtual void                        Unk_0C(void);                          // 0C - { return; }
-		virtual void                        Unk_0D(void);                          // 0D
-		[[nodiscard]] virtual EmotionType   GetEmotionType() const;                // 0E - { return kNeutral; }
-		[[nodiscard]] virtual std::uint32_t GetEmotionValue() const;               // 0F - { return 0; }
-		virtual void                        Unk_10(void);                          // 10 - { unk14 |= 1; }
-		virtual void                        Unk_11(void);                          // 11
-		virtual void                        Unk_12(void);                          // 12 - { return; }
-		virtual void                        Unk_13(void);                          // 13 - { return; }
+		virtual bool                        LoadSceneAction(TESFile* a_mod);                     // 01
+		virtual void                        Unk_02(void);                                        // 02
+		virtual void                        Unk_03(void);                                        // 03 - { return; }
+		virtual void                        ClearFlags();                                        // 04 - { flags = kNone; }
+		[[nodiscard]] virtual bool          Loops() const;                                       // 05 - { return false; }
+		[[nodiscard]] virtual bool          FacesTarget() const;                                 // 06 - { return true; }
+		[[nodiscard]] virtual Type          GetType() const = 0;                                 // 07
+		virtual void                        Unk_08(void);                                        // 08 - { return 0; }
+		virtual void                        LoadBuffer(void* a_arg1, BGSLoadGameBuffer* a_buf);  // 09
+		virtual void                        SaveBuffer(BGSSaveFormBuffer* a_buf);                // 0A
+		virtual void                        ClearActiveFlags();                                  // 0B - { unk14 &= 0xFC; }
+		virtual void                        Unk_0C(void);                                        // 0C - { return; }
+		virtual void                        Unk_0D(void);                                        // 0D
+		[[nodiscard]] virtual EmotionType   GetEmotionType() const;                              // 0E - { return kNeutral; }
+		[[nodiscard]] virtual std::uint32_t GetEmotionValue() const;                             // 0F - { return 0; }
+		virtual void                        Unk_10(void);                                        // 10 - { unk14 |= 1; }
+		virtual void                        Unk_11(void);                                        // 11
+		virtual void                        Unk_12(void);                                        // 12 - { return; }
+		virtual void                        Unk_13(void);                                        // 13 - { return; }
 
 		// members
 		std::uint32_t                     actorID;     // 08 - ALID

--- a/include/RE/B/BGSSceneAction.h
+++ b/include/RE/B/BGSSceneAction.h
@@ -31,25 +31,27 @@ namespace RE
 		virtual ~BGSSceneAction();  // 00
 
 		// add
-		virtual bool                        LoadSceneAction(TESFile* a_mod);                     // 01
-		virtual void                        Unk_02(void);                                        // 02
-		virtual void                        Unk_03(void);                                        // 03 - { return; }
-		virtual void                        ClearFlags();                                        // 04 - { flags = kNone; }
-		[[nodiscard]] virtual bool          Loops() const;                                       // 05 - { return false; }
-		[[nodiscard]] virtual bool          FacesTarget() const;                                 // 06 - { return true; }
-		[[nodiscard]] virtual Type          GetType() const = 0;                                 // 07
-		virtual void                        Unk_08(void);                                        // 08 - { return 0; }
-		virtual void                        LoadBuffer(void* a_arg1, BGSLoadGameBuffer* a_buf);  // 09
-		virtual void                        Unk_0A(void);                                        // 0A
-		virtual void                        Unk_0B(void);                                        // 0B - { unk14 &= 0xFC; }
-		virtual void                        Unk_0C(void);                                        // 0C - { return; }
-		virtual void                        Unk_0D(void);                                        // 0D
-		[[nodiscard]] virtual EmotionType   GetEmotionType() const;                              // 0E - { return kNeutral; }
-		[[nodiscard]] virtual std::uint32_t GetEmotionValue() const;                             // 0F - { return 0; }
-		virtual void                        Unk_10(void);                                        // 10 - { unk14 |= 1; }
-		virtual void                        Unk_11(void);                                        // 11
-		virtual void                        Unk_12(void);                                        // 12 - { return; }
-		virtual void                        Unk_13(void);                                        // 13 - { return; }
+		virtual bool               LoadSceneAction(TESFile* a_mod);                     // 01
+		virtual void               Unk_02(void);                                        // 02
+		virtual void               Unk_03(void);                                        // 03 - { return; }
+		virtual void               ClearFlags();                                        // 04 - { flags = kNone; }
+		[[nodiscard]] virtual bool Loops() const;                                       // 05 - { return false; }
+		[[nodiscard]] virtual bool FacesTarget() const;                                 // 06 - { return true; }
+		[[nodiscard]] virtual Type GetType() const = 0;                                 // 07
+		virtual void               Unk_08(void);                                        // 08 - { return 0; }
+		virtual void               LoadBuffer(void* a_arg1, BGSLoadGameBuffer* a_buf);  // 09
+		class BGSSaveFormBuffer;
+
+		virtual void                        SaveBuffer(BGSSaveFormBuffer* a_buf);  // 0A
+		virtual void                        ClearActiveFlags();                    // 0B - { unk14 &= 0xFC; }
+		virtual void                        Unk_0C(void);                          // 0C - { return; }
+		virtual void                        Unk_0D(void);                          // 0D
+		[[nodiscard]] virtual EmotionType   GetEmotionType() const;                // 0E - { return kNeutral; }
+		[[nodiscard]] virtual std::uint32_t GetEmotionValue() const;               // 0F - { return 0; }
+		virtual void                        Unk_10(void);                          // 10 - { unk14 |= 1; }
+		virtual void                        Unk_11(void);                          // 11
+		virtual void                        Unk_12(void);                          // 12 - { return; }
+		virtual void                        Unk_13(void);                          // 13 - { return; }
 
 		// members
 		std::uint32_t                     actorID;     // 08 - ALID

--- a/include/RE/B/BGSSceneActionDialogue.h
+++ b/include/RE/B/BGSSceneActionDialogue.h
@@ -23,8 +23,8 @@ namespace RE
 		bool          FacesTarget() const override;                                 // 06 - { return (flags >> 15) & 1; }
 		Type          GetType() const override;                                     // 07 - { return kDialogue; }
 		void          LoadBuffer(void* a_arg1, BGSLoadGameBuffer* a_buf) override;  // 09
-		void          Unk_0A(void) override;                                        // 0A
-		void          Unk_0B(void) override;                                        // 0B
+		void          SaveBuffer(BGSSaveFormBuffer* a_buf) override;                // 0A
+		void          ClearActiveFlags() override;                                  // 0B
 		void          Unk_0C(void) override;                                        // 0C
 		EmotionType   GetEmotionType() const override;                              // 0E - { return emotionType; }
 		std::uint32_t GetEmotionValue() const override;                             // 0F - { return emotionValue; }

--- a/include/RE/B/BGSSceneActionPackage.h
+++ b/include/RE/B/BGSSceneActionPackage.h
@@ -22,8 +22,8 @@ namespace RE
 		Type GetType() const override;                                     // 07 - { return kPackage; }
 		void Unk_08(void) override;                                        // 08
 		void LoadBuffer(void* a_arg1, BGSLoadGameBuffer* a_buf) override;  // 09
-		void Unk_0A(void) override;                                        // 0A
-		void Unk_0B(void) override;                                        // 0B
+		void SaveBuffer(BGSSaveFormBuffer* a_buf) override;                // 0A
+		void ClearActiveFlags() override;                                  // 0B
 		void Unk_10(void) override;                                        // 10
 		void Unk_11(void) override;                                        // 11
 		void Unk_12(void) override;                                        // 12

--- a/include/RE/B/BGSSceneActionTimer.h
+++ b/include/RE/B/BGSSceneActionTimer.h
@@ -18,8 +18,8 @@ namespace RE
 		void ClearFlags() override;                                        // 04 - { BGSSceneAction::ClearFlags(); }
 		Type GetType() const override;                                     // 07 - { return kTimer; }
 		void LoadBuffer(void* a_arg1, BGSLoadGameBuffer* a_buf) override;  // 09
-		void Unk_0A(void) override;                                        // 0A
-		void Unk_0B(void) override;                                        // 0B
+		void SaveBuffer(BGSSaveFormBuffer* a_buf) override;                // 0A
+		void ClearActiveFlags() override;                                  // 0B
 		void Unk_0D(void) override;                                        // 0D
 		void Unk_11(void) override;                                        // 11
 		void Unk_13(void) override;                                        // 13

--- a/include/RE/P/PlayerRegionState.h
+++ b/include/RE/P/PlayerRegionState.h
@@ -1,12 +1,15 @@
 #pragma once
 
 #include "RE/B/BGSActorCellEvent.h"
+#include "RE/B/BSTArray.h"
 #include "RE/B/BSTEvent.h"
 #include "RE/B/BSTSingleton.h"
 
 namespace RE
 {
 	class BGSMusicType;
+	class TESRegion;
+	class TESRegionDataSound;
 
 	class PlayerRegionState :
 		public BSTEventSink<BGSActorCellEvent>,
@@ -28,15 +31,15 @@ namespace RE
 		}
 
 		// members
-		BSTArray<void*>                    unk10;  // 10
-		BSTArray<void*>                    unk28;  // 28
-		bool                               unk40;  // 40
-		bool                               unk41;  // 41
-		std::uint16_t                      pad42;  // 42
-		std::uint32_t                      pad44;  // 44
-		TESRegion*                         unk48;  // 48
-		BGSMusicType*                      unk50;  // 50
-		BSTEventSource<BGSActorCellEvent>* unk58;  // 58
+		BSTArray<TESRegionDataSound*>      soundData;             // 10
+		BSTArray<TESRegion*>               regions;               // 28
+		bool                               inSoundRegion;         // 40
+		bool                               unk41;                 // 41
+		std::uint16_t                      pad42;                 // 42
+		std::uint32_t                      pad44;                 // 44
+		TESRegion*                         currentRegion;         // 48
+		BGSMusicType*                      currentMusicType;      // 50
+		BSTEventSource<BGSActorCellEvent>* actorCellEventSource;  // 58
 	};
 	static_assert(sizeof(PlayerRegionState) == 0x60);
 }


### PR DESCRIPTION
## Summary
Follow-up RE additions extending powerof3/dev sync:

### Changes
1. **BGSSceneAction & Derived Classes**:
   - Named SaveBuffer (0x0A) and ClearActiveFlags (0x0B) virtual function slots across BGSSceneAction, BGSSceneActionDialogue, BGSSceneActionPackage, and BGSSceneActionTimer.
2. **PlayerRegionState**:
   - Named members soundData (0x10), regions (0x28), inSoundRegion (0x40), currentRegion (0x48), currentMusicType (0x50), and actorCellEventSource (0x58).

### Cross-Runtime Compatibility
Verified bit-identical layout and virtual table indices across SE, AE, and VR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced previously unidentified interface methods with descriptive names for collidable management, save-buffer handling, and active-state clearing.
  * Improved type information for player region and audio state tracking, including current regions, sound data, music type, and related event state.
  * Added structural validation to improve reliability and consistency across supported systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->