### PR TITLE
feat(havok): add BGSAcousticSpace::Deactivate

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -2037,6 +2037,7 @@ set(SOURCES
 	src/RE/A/ArmorRatingVisitorBase.cpp
 	src/RE/A/Array.cpp
 	src/RE/A/AutoVanityState.cpp
+	src/RE/B/BGSAcousticSpace.cpp
 	src/RE/B/BGSAttackData.cpp
 	src/RE/B/BGSBaseAlias.cpp
 	src/RE/B/BGSBipedObjectForm.cpp

--- a/include/RE/B/BGSAcousticSpace.h
+++ b/include/RE/B/BGSAcousticSpace.h
@@ -30,6 +30,14 @@ namespace RE
 		void        UnClone3D(TESObjectREFR* a_ref) override;  // 41
 		NiAVObject* Clone3D(TESObjectREFR* a_ref) override;    // 4A - { return 0; }
 
+		// add
+
+		// Switches away from this acoustic space: fades out its looping sound (or stops it
+		// outright if the game is paused), transitions any active reverb, and clears the
+		// process-wide "current acoustic space" pointer. A no-op if this isn't the currently
+		// active acoustic space.
+		void Deactivate();
+
 		// members
 		BGSSoundDescriptorForm* loopingSound;  // 30 - SNAM
 		TESRegion*              soundRegion;   // 38 - RDAT - interiors only

--- a/src/RE/B/BGSAcousticSpace.cpp
+++ b/src/RE/B/BGSAcousticSpace.cpp
@@ -1,0 +1,11 @@
+#include "RE/B/BGSAcousticSpace.h"
+
+namespace RE
+{
+	void BGSAcousticSpace::Deactivate()
+	{
+		using func_t = decltype(&BGSAcousticSpace::Deactivate);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(34309, 35131) };
+		return func(this);
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `BGSAcousticSpace::Deactivate()` -- switches away from an
  acoustic space: fades out (or stops, if paused) its looping sound,
  transitions any active reverb, and clears the process-wide "current
  acoustic space" pointer.
- A real, non-virtual bound method (`RELOCATION_ID`), not a vtable
  override.

## Verification
- Confirmed via Ghidra decompile across SE, AE, and VR -- identical
  behavior in each.
- Address-library id 34309/35131 registered in
  [alandtse/skyrim_vr_address_library#152](https://github.com/alandtse/skyrim_vr_address_library/pull/152).

## Context
Found while doing a full RE pass on `BGSAcousticSpaceListener`
(follow-up to #237) -- `Deactivate` is the shared cleanup step several
of that class's own internal handle-set operations
(`RemoveCollidable`, a full-listener-reset on cell Havok-detach) call
into. Exposing it directly since it's low-risk and plausibly useful to
anything managing custom ambiance/interior transitions.
