### PR TITLE
ci: disable IPO in matrix, cancel superseded runs

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -16,6 +16,12 @@ on:
     branches: [ vr, ng, feature/* ]
   workflow_dispatch:
 
+# Cancel a PR's in-flight run when it's superseded by a new push -- the 20-job matrix
+# otherwise keeps occupying runner slots for a commit nobody cares about anymore.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test-vcpkg:
     runs-on: windows-latest
@@ -37,9 +43,12 @@ jobs:
     # Persist vcpkg-built dependency binaries in the GitHub Actions cache so the matrix
     # configs (and future runs) restore prebuilt .libs (spdlog, DirectXTK, …) instead of
     # recompiling them every time. Validated: a warm cache turns a dep build into a ~ms
-    # restore.
+    # restore. SCCACHE_GHA_ENABLED backs sccache (below) with the same cache service so
+    # CommonLib's own object files -- not just vcpkg deps -- are reused across runs, and
+    # across this workflow and prebuilt.yml's matching release-msvc-vcpkg-all build.
     env:
       VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -60,6 +69,9 @@ jobs:
         uses: TheMrMilchmann/setup-msvc-dev@v4.0.0
         with:
           arch: x64
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       # Pin vcpkg's download cache to a stable, cacheable path. vcpkg checks
       # this directory (by SHA512) before fetching any asset — port source
@@ -139,7 +151,11 @@ jobs:
         with:
           cmakeListsTxtPath: ${{ github.workspace }}/main/CMakeLists.txt
           configurePreset: build-${{ matrix.build-type }}-${{ matrix.compiler }}-vcpkg-${{ matrix.runtime }}
+          configurePresetAdditionalArgs: "['-DCOMMONLIB_ENABLE_IPO=OFF', '-DCMAKE_C_COMPILER_LAUNCHER=sccache', '-DCMAKE_CXX_COMPILER_LAUNCHER=sccache']"
           buildPreset: ${{ matrix.build-type }}-${{ matrix.compiler }}-vcpkg-${{ matrix.runtime }}
+
+      - name: sccache stats
+        run: sccache --show-stats
 
       - name: Unit tests
         timeout-minutes: 5

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -43,12 +43,9 @@ jobs:
     # Persist vcpkg-built dependency binaries in the GitHub Actions cache so the matrix
     # configs (and future runs) restore prebuilt .libs (spdlog, DirectXTK, …) instead of
     # recompiling them every time. Validated: a warm cache turns a dep build into a ~ms
-    # restore. SCCACHE_GHA_ENABLED backs sccache (below) with the same cache service so
-    # CommonLib's own object files -- not just vcpkg deps -- are reused across runs, and
-    # across this workflow and prebuilt.yml's matching release-msvc-vcpkg-all build.
+    # restore.
     env:
       VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
-      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -69,9 +66,6 @@ jobs:
         uses: TheMrMilchmann/setup-msvc-dev@v4.0.0
         with:
           arch: x64
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
 
       # Pin vcpkg's download cache to a stable, cacheable path. vcpkg checks
       # this directory (by SHA512) before fetching any asset — port source
@@ -151,11 +145,8 @@ jobs:
         with:
           cmakeListsTxtPath: ${{ github.workspace }}/main/CMakeLists.txt
           configurePreset: build-${{ matrix.build-type }}-${{ matrix.compiler }}-vcpkg-${{ matrix.runtime }}
-          configurePresetAdditionalArgs: "['-DCOMMONLIB_ENABLE_IPO=OFF', '-DCMAKE_C_COMPILER_LAUNCHER=sccache', '-DCMAKE_CXX_COMPILER_LAUNCHER=sccache']"
+          configurePresetAdditionalArgs: "['-DCOMMONLIB_ENABLE_IPO=OFF']"
           buildPreset: ${{ matrix.build-type }}-${{ matrix.compiler }}-vcpkg-${{ matrix.runtime }}
-
-      - name: sccache stats
-        run: sccache --show-stats
 
       - name: Unit tests
         timeout-minutes: 5

--- a/.github/workflows/prebuilt.yml
+++ b/.github/workflows/prebuilt.yml
@@ -43,6 +43,11 @@ on:
 permissions:
   contents: read
 
+# Cancel a PR's in-flight run when it's superseded by a new push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   xmake:
     name: xmake bundle + self-test
@@ -137,6 +142,10 @@ jobs:
       contents: write # only used when attach_tag is set
     env:
       VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+      # Same GHA-backed sccache as main_ci.yml, so this job's release-msvc-vcpkg-all
+      # build reuses object files main_ci.yml's matching matrix cell already compiled
+      # (and vice versa) instead of recompiling CommonLib's own source from scratch.
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -156,6 +165,9 @@ jobs:
         uses: TheMrMilchmann/setup-msvc-dev@v4.0.0
         with:
           arch: x64
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       # Pin vcpkg's download cache to a stable, cacheable path. vcpkg checks
       # this directory (by SHA512) before fetching any asset — port source
@@ -221,7 +233,7 @@ jobs:
           shell: pwsh
           command: |
             Set-Location "${{ github.workspace }}"
-            cmake --preset build-release-msvc-vcpkg-all -DREX_OPTION_INI=ON -DREX_OPTION_JSON=ON -DREX_OPTION_TOML=ON -DSKSE_SUPPORT_XBYAK=ON -DBUILD_TESTS=OFF
+            cmake --preset build-release-msvc-vcpkg-all -DREX_OPTION_INI=ON -DREX_OPTION_JSON=ON -DREX_OPTION_TOML=ON -DSKSE_SUPPORT_XBYAK=ON -DBUILD_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Build CommonLibSSE (all + rex_ini + rex_json + rex_toml + skse_xbyak, release)
         uses: lukka/run-cmake@v10
@@ -230,6 +242,9 @@ jobs:
           configurePreset: build-release-msvc-vcpkg-all
           configurePresetAdditionalArgs: "['-DREX_OPTION_INI=ON', '-DREX_OPTION_JSON=ON', '-DREX_OPTION_TOML=ON', '-DSKSE_SUPPORT_XBYAK=ON', '-DBUILD_TESTS=OFF']"
           buildPreset: release-msvc-vcpkg-all
+
+      - name: sccache stats
+        run: sccache --show-stats
 
       - name: Assemble bundle
         id: bundle

--- a/.github/workflows/prebuilt.yml
+++ b/.github/workflows/prebuilt.yml
@@ -142,10 +142,6 @@ jobs:
       contents: write # only used when attach_tag is set
     env:
       VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
-      # Same GHA-backed sccache as main_ci.yml, so this job's release-msvc-vcpkg-all
-      # build reuses object files main_ci.yml's matching matrix cell already compiled
-      # (and vice versa) instead of recompiling CommonLib's own source from scratch.
-      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -165,9 +161,6 @@ jobs:
         uses: TheMrMilchmann/setup-msvc-dev@v4.0.0
         with:
           arch: x64
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
 
       # Pin vcpkg's download cache to a stable, cacheable path. vcpkg checks
       # this directory (by SHA512) before fetching any asset — port source
@@ -233,7 +226,7 @@ jobs:
           shell: pwsh
           command: |
             Set-Location "${{ github.workspace }}"
-            cmake --preset build-release-msvc-vcpkg-all -DREX_OPTION_INI=ON -DREX_OPTION_JSON=ON -DREX_OPTION_TOML=ON -DSKSE_SUPPORT_XBYAK=ON -DBUILD_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+            cmake --preset build-release-msvc-vcpkg-all -DREX_OPTION_INI=ON -DREX_OPTION_JSON=ON -DREX_OPTION_TOML=ON -DSKSE_SUPPORT_XBYAK=ON -DBUILD_TESTS=OFF
 
       - name: Build CommonLibSSE (all + rex_ini + rex_json + rex_toml + skse_xbyak, release)
         uses: lukka/run-cmake@v10
@@ -242,9 +235,6 @@ jobs:
           configurePreset: build-release-msvc-vcpkg-all
           configurePresetAdditionalArgs: "['-DREX_OPTION_INI=ON', '-DREX_OPTION_JSON=ON', '-DREX_OPTION_TOML=ON', '-DSKSE_SUPPORT_XBYAK=ON', '-DBUILD_TESTS=OFF']"
           buildPreset: release-msvc-vcpkg-all
-
-      - name: sccache stats
-        run: sccache --show-stats
 
       - name: Assemble bundle
         id: bundle

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,10 +120,16 @@ source_group(
 	FILES ${SOURCES}
 )
 
-check_ipo_supported(RESULT USE_IPO OUTPUT IPO_OUTPUT)
+# IPO/LTCG substantially slows Release compile+link (MSVC's LTCG especially) for a
+# correctness-only CI matrix that ships no artifact. Off by default there
+# (-DCOMMONLIB_ENABLE_IPO=OFF); the real prebuilt/release builds keep it on.
+option(COMMONLIB_ENABLE_IPO "Enable interprocedural (link-time) optimization for Release builds" ON)
 
-if(USE_IPO)
-	set(CMAKE_INTERPROCEDURAL_OPTIMIZATION "$<$<CONFIG:RELEASE>:ON>")
+if(COMMONLIB_ENABLE_IPO)
+	check_ipo_supported(RESULT USE_IPO OUTPUT IPO_OUTPUT)
+	if(USE_IPO)
+		set(CMAKE_INTERPROCEDURAL_OPTIMIZATION "$<$<CONFIG:RELEASE>:ON>")
+	endif()
 endif()
 
 add_library(


### PR DESCRIPTION
## Summary
- `main_ci.yml`'s 20-job matrix's Release/MSVC cells were the run's
  critical path (up to ~17 min for the `Build` step alone), driven
  entirely by `CMAKE_INTERPROCEDURAL_OPTIMIZATION` (MSVC LTCG). That
  buys nothing here -- this workflow is a correctness-only test matrix
  that publishes no artifact; the real optimized binary is built
  separately by `prebuilt.yml`. New `COMMONLIB_ENABLE_IPO` CMake option
  (default `ON`, unchanged for `prebuilt.yml`/`release.yml`) lets
  `main_ci.yml` turn it off for its own Release builds only.
- Adds a `concurrency` cancel-in-progress group to both workflows, so a
  superseded push stops occupying runner slots instead of running its
  full matrix to completion alongside the new push's jobs.
- Tried wiring `sccache` into both workflows' MSVC/clang-cl builds too,
  but `sccache --show-stats` showed 100% non-cacheable calls (`/Fp`,
  `/Yc`) -- CommonLib uses `target_precompile_headers()`, and sccache
  has no support for MSVC/clang-cl precompiled headers
  (mozilla/sccache#978). Disabling PCH instead isn't the right trade
  either (that issue reports >20 min cold vs ~3 min with PCH for a
  comparable project), and no other C++ consumer checked in this
  ecosystem (open-shaders, FireHurtsNG, Skyrim-Upscaler, CommonLibF4)
  pairs PCH with a compiler cache. Reverted; this PR ships IPO-off +
  concurrency only.

## Results (validated on this PR's own CI runs)
- Main CI: ~40 min baseline -> ~30 min (both post-sccache-revert runs
  landed at 29:58 and 31:15), entirely from the IPO change.
- `prebuilt.yml`'s `cmake` and `xmake` self-tests both still pass with
  IPO untouched (that workflow doesn't set `COMMONLIB_ENABLE_IPO`, so
  it keeps building the real optimized artifact).
- All 26 checks green, including the full 20-cell matrix.

## Test plan
- [x] CI matrix passes (validates `COMMONLIB_ENABLE_IPO=OFF` still
      produces a working `CommonLibSSETests.exe` for every
      runtime/compiler/build-type cell)
- [x] `prebuilt.yml`'s `cmake` and `xmake` jobs still produce working
      self-tested bundles
- [x] Confirmed the `concurrency` group is valid YAML and doesn't
      break either workflow (didn't get to observe an actual
      cancellation, since no run was superseded mid-flight during
      testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuM742GiWFKuK1c7DgwYTi
