### PR TITLE
docs: update repo refs for CommonLibSSE-NG rename

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -381,7 +381,7 @@ CommonLibSSE NG uses different abstraction patterns based on the type and comple
 - Use macro abstraction for repetitive complex patterns (data structures)
 - Document offset calculations and Address Library relationships
 - Standardize member accessor patterns using `RelocateMember`
-## CommonLibVR Code Conventions & Best Practices
+## CommonLibSSE-NG Code Conventions & Best Practices
 
 ### Virtual Function Implementation Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,7 +381,7 @@ CommonLibSSE NG uses different abstraction patterns based on the type and comple
 - Use macro abstraction for repetitive complex patterns (data structures)
 - Document offset calculations and Address Library relationships
 - Standardize member accessor patterns using `RelocateMember`
-## CommonLibVR Code Conventions & Best Practices
+## CommonLibSSE-NG Code Conventions & Best Practices
 
 ### Virtual Function Implementation Guidelines
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![C++23](https://img.shields.io/static/v1?label=standard&message=c%2B%2B23&color=blue&logo=c%2B%2B&&logoColor=white&style=flat)](https://en.cppreference.com/w/cpp/compiler_support)
 ![Platform](https://img.shields.io/static/v1?label=platform&message=windows&color=dimgray&style=flat&logo=windows)
-[![Latest Release](https://img.shields.io/github/v/release/alandtse/CommonLibVR?logo=pkgsrc&logoColor=white)](#use)
-[![Main CI](https://github.com/alandtse/CommonLibVR/actions/workflows/main_ci.yml/badge.svg?branch=ng)](https://github.com/alandtse/CommonLibVR/actions/workflows/main_ci.yml)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/alandtse/CommonLibVR)
+[![Latest Release](https://img.shields.io/github/v/release/alandtse/CommonLibSSE-NG?logo=pkgsrc&logoColor=white)](#use)
+[![Main CI](https://github.com/alandtse/CommonLibSSE-NG/actions/workflows/main_ci.yml/badge.svg?branch=ng)](https://github.com/alandtse/CommonLibSSE-NG/actions/workflows/main_ci.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/alandtse/CommonLibSSE-NG)
 
 CommonLibSSE NG is a fork of CharmedBaryon's CommonLibSSE-NG, itself a fork of CommonLibSSE, which tracks upstream updates but adds a number of enhancements.
 It supports Skyrim Special Edition (SE), Skyrim Anniversary Edition (AE), and Skyrim Virtual Reality (VR).
@@ -14,7 +14,7 @@ It supports Skyrim Special Edition (SE), Skyrim Anniversary Edition (AE), and Sk
 To develop a C++ project that uses CommonLibSSE, you'll want to have this code available for discovery, and included as a build dependency by your build manager. Below are examples using the `xmake` or `cmake` managers.
 
 > [!TIP]
-> For examples & templates see the wiki: https://github.com/alandtse/CommonLibVR/wiki/Projects-using-CommonLib
+> For examples & templates see the wiki: https://github.com/alandtse/CommonLibSSE-NG/wiki/Projects-using-CommonLib
 
 ### Getting the code: Git SubModule
 
@@ -32,7 +32,7 @@ Add this CommonLibSSE repo as a [git submodule](https://git-scm.com/book/en/v2/G
 and storing it in `lib/commonlibsse-ng` folder:
 
 ```powershell
-PS E:\Git\foo-bar> git submodule add -b ng https://github.com/alandtse/CommonLibVR.git lib/commonlibsse-ng
+PS E:\Git\foo-bar> git submodule add -b ng https://github.com/alandtse/CommonLibSSE-NG.git lib/commonlibsse-ng
 Cloning into 'E:/Git/foo-bar/lib/commonlibsse-ng'...
 remote: Enumerating objects: 66210, done.
 remote: Counting objects: 100% (2526/2526), done.

--- a/cmake/Prebuilt.cmake
+++ b/cmake/Prebuilt.cmake
@@ -143,7 +143,7 @@ function(commonlib_resolve_prebuilt out_dir)
         return()
     endif()
 
-    set(_base "https://github.com/alandtse/CommonLibVR/releases/download/${_tag}")
+    set(_base "https://github.com/alandtse/CommonLibSSE-NG/releases/download/${_tag}")
     set(_asset "commonlibsse-ng-prebuilt-${_tag}-all-msvc-cmake.zip")
     set(_zip "${_cache}.zip")
     file(DOWNLOAD "${_base}/${_asset}.sha256" "${_cache}.sha256" STATUS _s1)

--- a/docs/RuntimeDataAccessors.md
+++ b/docs/RuntimeDataAccessors.md
@@ -1,10 +1,10 @@
 # Runtime Data Accessors
 
-This document describes the helper macros and tooling for managing runtime data structures in CommonLibVR.
+This document describes the helper macros and tooling for managing runtime data structures in CommonLibSSE-NG.
 
 ## Overview
 
-CommonLibVR supports multiple Skyrim runtimes (SE, AE, VR) with different memory layouts. Runtime data accessors provide a consistent API to access data at runtime-specific offsets without manual `RelocateMember` calls.
+CommonLibSSE-NG supports multiple Skyrim runtimes (SE, AE, VR) with different memory layouts. Runtime data accessors provide a consistent API to access data at runtime-specific offsets without manual `RelocateMember` calls.
 
 ## Macro Reference
 

--- a/include/RE/M/MemoryManager.h
+++ b/include/RE/M/MemoryManager.h
@@ -125,7 +125,7 @@ namespace RE
 	// so the allocation matches the running runtime instead.
 	//
 	// Prefer this over malloc<T>() + memset for any self-allocating Create().
-	// See ButtonEvent/NiPointLight::Create(); guards against alandtse/CommonLibVR#120.
+	// See ButtonEvent/NiPointLight::Create(); guards against alandtse/CommonLibSSE-NG#120.
 	template <class T>
 	inline T* malloc_runtime(std::size_t a_flatSize, std::size_t a_vrSize)
 	{

--- a/scripts/build-all-presets.cmd
+++ b/scripts/build-all-presets.cmd
@@ -1,6 +1,6 @@
 @echo off
 setlocal enabledelayedexpansion
-REM Comprehensive build script for CommonLibVR
+REM Comprehensive build script for CommonLibSSE-NG
 REM Builds all presets and stops at first failure for faster LLM iteration
 REM
 REM Usage: build-all-presets.cmd [--clang]
@@ -73,7 +73,7 @@ if !ERRORLEVEL! NEQ 0 (
 
 echo.
 echo ========================================
-echo CommonLibVR Build Script [%COMPILER%]
+echo CommonLibSSE-NG Build Script [%COMPILER%]
 echo ========================================
 echo.
 

--- a/tests/prebuilt-consumer-cmake/CMakeLists.txt
+++ b/tests/prebuilt-consumer-cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Self-test for the CMake clean-tag auto-fetch: add_subdirectory the CommonLibVR repo
+# Self-test for the CMake clean-tag auto-fetch: add_subdirectory the CommonLibSSE-NG repo
 # with COMMONLIB_PREBUILT_DIR pointing at the just-assembled bundle, so the resolver in
 # cmake/Prebuilt.cmake exposes CommonLibSSE as an IMPORTED target. add_commonlibsse_plugin
 # then compiles a generated plugin TU against the prebuilt headers and links the prebuilt
@@ -11,7 +11,7 @@ project(prebuilt_consumer_cmake LANGUAGES CXX)
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../.." commonlib)
 
 add_commonlibsse_plugin(prebuilt_consumer_cmake
-	AUTHOR "CommonLibVR"
+	AUTHOR "CommonLibSSE-NG"
 	NAME "prebuilt_consumer_cmake"
 	VERSION 1.0.0)
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -131,7 +131,7 @@ target("commonlibsse-ng", function()
             local got = try { function()
                 import("net.http")
                 import("utils.archive")
-                local base = "https://github.com/alandtse/CommonLibVR/releases/download/" .. tag
+                local base = "https://github.com/alandtse/CommonLibSSE-NG/releases/download/" .. tag
                 local asset = "commonlibsse-ng-prebuilt-" .. tag .. "-all-msvc.7z"
                 local arch = os.tmpfile() .. ".7z"
                 http.download(base .. "/" .. asset, arch)


### PR DESCRIPTION
## Summary
GitHub repo moved from `alandtse/CommonLibVR` to
`alandtse/CommonLibSSE-NG` -- aligns the hosted name with what the
README already called the project ("CommonLibSSE NG", a fork of
CharmedBaryon's CommonLibSSE-NG). Sweeps every stale reference except
`CHANGELOG.md`, an auto-generated historical record whose old links
already redirect correctly -- rewriting past release notes to a name
that didn't exist yet at the time would misrepresent history.

**Functional fixes** (construct/point at real URLs, not cosmetic):
- `cmake/Prebuilt.cmake` and `xmake.lua`'s release-asset download URLs
- `README.md`'s badges, wiki link, and submodule example
- `MemoryManager.h`'s issue-link comment

**Prose-only renames** (project self-reference, no functional change):
- `CLAUDE.md` / `.claude/CLAUDE.md` section header
- `docs/RuntimeDataAccessors.md`
- `scripts/build-all-presets.cmd`'s banner text
- `tests/prebuilt-consumer-cmake/CMakeLists.txt`'s `AUTHOR` field

## Test plan
- [ ] No build/CI impact expected (docs/comments/URL strings only, no
      logic changes)
- [ ] Confirm the DeepWiki badge link resolves once DeepWiki indexes
      the renamed repo (unconfirmed at PR time -- it hadn't picked up
      the new name yet when checked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuM742GiWFKuK1c7DgwYTi