### PR TITLE
fix(water): correct TESWaterReflections signature

### DIFF
--- a/include/RE/T/TESWaterReflections.h
+++ b/include/RE/T/TESWaterReflections.h
@@ -44,7 +44,9 @@ namespace RE
 
 		virtual ~TESWaterReflections() override { Dtor(); };  // 00
 
-		void Update();
+		// Returns whether this instance was actively processed this frame (== activeThisFrame),
+		// gated by a per-frame budget of cubeMapSides.size() (6).
+		bool UpdateActor();
 
 		// members
 		REX::EnumSet<Flags, std::uint16_t> flags;                  // 10

--- a/src/RE/T/TESWaterReflections.cpp
+++ b/src/RE/T/TESWaterReflections.cpp
@@ -2,9 +2,9 @@
 
 namespace RE
 {
-	void TESWaterReflections::Update()
+	bool TESWaterReflections::UpdateActor()
 	{
-		using func_t = decltype(&TESWaterReflections::Update);
+		using func_t = decltype(&TESWaterReflections::UpdateActor);
 		static REL::Relocation<func_t> func{ RELOCATION_ID(31373, 32160) };
 		return func(this);
 	}


### PR DESCRIPTION
## Summary
Decompile confirms RELOCATION_ID(31373, 32160) is really
`bool UpdateActor()`, not `void Update()` -- it returns whether the
instance was actively processed this frame (== `activeThisFrame`),
gated by a per-frame budget matching `cubeMapSides.size()` (6).
`skyrim_vr_address_library`'s `database.csv` already had the correct
name/signature for this id; only this header/source were stale.
Confirmed SE and VR are byte-for-byte structurally identical for this
function (no stereo/HMD-specific divergence).

Found while reviewing older `powerof3/dev` sync merges for RE
opportunities per project protocol.

## Test plan
- [ ] CI passes (signature-only change, no new logic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated water reflection processing to report whether it was actively handled during the current frame.
  * Added frame-budget-aware processing behavior based on available reflection map sides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->