### PR TITLE
fix(region): resolve TES gridBufferDistance floats

### DIFF
--- a/include/RE/T/TES.h
+++ b/include/RE/T/TES.h
@@ -88,27 +88,21 @@ namespace RE
 
 		struct RUNTIME_DATA
 		{
-#define RUNTIME_DATA_CONTENT                   \
-	std::uint8_t  unk128;            /* 128 */ \
-	bool          showLANDborders;   /* 129 */ \
-	std::uint8_t  unk12A;            /* 12A */ \
-	std::uint8_t  unk12B;            /* 12B */ \
-	std::uint8_t  unk12C;            /* 12C */ \
-	std::uint8_t  unk12D;            /* 12D */ \
-	std::uint8_t  unk12E;            /* 12E */ \
-	std::uint8_t  unk12F;            /* 12F */ \
-	std::uint16_t unk130;            /* 130 */ \
-	std::uint8_t  unk132;            /* 132 */ \
-	std::uint8_t  unk133;            /* 133 */ \
-	bool          unk134;            /* 134 */ \
-	bool          unk135;            /* 135 */ \
-	bool          unk136;            /* 136 */ \
-	bool          runningCellTests;  /* 137 */ \
-	bool          runningCellTests2; /* 138 */ \
-	bool          unk139;            /* 139 */ \
-	bool          unk13A;            /* 13A */ \
-	bool          unk13B;            /* 13B */ \
-	bool          allowUnusedPurge;  /* 13C */ \
+#define RUNTIME_DATA_CONTENT                     \
+	std::uint8_t  unk128;              /* 128 */ \
+	bool          showLANDborders;     /* 129 */ \
+	std::uint8_t  unk12A;              /* 12A */ \
+	std::uint8_t  unk12B;              /* 12B */ \
+	std::uint8_t  unk12C;              /* 12C */ \
+	std::uint8_t  unk12D;              /* 12D */ \
+	std::uint8_t  unk12E;              /* 12E */ \
+	std::uint8_t  unk12F;              /* 12F */ \
+	std::uint16_t unk130;              /* 130 */ \
+	std::uint8_t  unk132;              /* 132 */ \
+	std::uint8_t  unk133;              /* 133 */ \
+	float         gridBufferDistanceX; /* 134 */ \
+	float         gridBufferDistanceY; /* 138 */ \
+	bool          allowUnusedPurge;    /* 13C */ \
 	std::byte     pad13D[3];
             RUNTIME_DATA_CONTENT
 		};
@@ -117,21 +111,15 @@ namespace RE
 		// 1130 and later
 		struct AE_RUNTIME_DATA
 		{
-#define AE_RUNTIME_DATA_CONTENT                \
-	std::uint32_t unk128;            /* 128 */ \
-	std::uint32_t landBorderMode;    /* 12C */ \
-	std::uint32_t borderColorAGBR;   /* 130 */ \
-	bool          unk134;            /* 134 */ \
-	bool          unk135;            /* 135 */ \
-	bool          unk136;            /* 136 */ \
-	bool          runningCellTests;  /* 137 */ \
-	bool          runningCellTests2; /* 138 */ \
-	bool          unk139;            /* 139 */ \
-	bool          unk13A;            /* 13A */ \
-	bool          unk13B;            /* 13B */ \
-	bool          allowUnusedPurge;  /* 13C */ \
-	std::byte     pad13D[3];         /* 13D */ \
-	std::uint64_t unk140;            /* 140 - actual offset change is somewhere near showLandBorder */
+#define AE_RUNTIME_DATA_CONTENT                  \
+	std::uint32_t unk128;              /* 128 */ \
+	std::uint32_t landBorderMode;      /* 12C */ \
+	std::uint32_t borderColorAGBR;     /* 130 */ \
+	float         gridBufferDistanceX; /* 134 */ \
+	float         gridBufferDistanceY; /* 138 */ \
+	bool          allowUnusedPurge;    /* 13C */ \
+	std::byte     pad13D[3];           /* 13D */ \
+	std::uint64_t unk140;              /* 140 - actual offset change is somewhere near showLandBorder */
 			AE_RUNTIME_DATA_CONTENT
 		};
 		static_assert(sizeof(AE_RUNTIME_DATA) == 0x20);


### PR DESCRIPTION
## Summary
`TES::sub_140152030` (a per-position cell-grid update function,
behaviorally identical in SE/AE/VR) writes then reads back two 4-byte
floats spanning `TES+0x134..0x13B` -- world X/Y position vs. the
current grid cell's half-cell boundary, used in a real reload-trigger
comparison.

This overlaps po3's established `runningCellTests`/`runningCellTests2`
bool names at `0x137`/`0x138`. Scanned all 111 `TES`-namespace
functions in SE for any genuine 1-byte bool read at either offset and
found none, so those names were a position-matching mistake, not a
real dual-purpose/aliased region.

Replaces the 8 wrongly-typed bools spanning `0x134-0x13B` with the two
real floats, `gridBufferDistanceX`/`gridBufferDistanceY`, in both
`RUNTIME_DATA` and `AE_RUNTIME_DATA` (identical layout in both,
`static_assert`s unchanged since both are 8-byte-for-8-byte swaps).

Found while reviewing older `powerof3/dev` sync merges for RE
opportunities per project protocol.

## Test plan
- [ ] CI passes (struct layout size preserved, just retyped)