### PR TITLE
ci: cancel superseded consumer-test runs

### DIFF
--- a/.github/workflows/test-consumer.yml
+++ b/.github/workflows/test-consumer.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ ng ]
 
+# Cancel a superseded run (a new push to the same PR, or a newer merge to ng) instead of
+# letting a ~16-20 min job finish testing a commit nobody will look at anymore.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-as-dependency:
     name: Test CommonLib as Dependency


### PR DESCRIPTION
## Summary
`test-consumer.yml` had no `concurrency` group, unlike `main_ci.yml`
and `prebuilt.yml` (fixed in #240). Confirmed the gap with real data:
merging #242 then #243 three minutes apart let #242's ~16-20 min
"Test CommonLib as Dependency" run finish to completion before
immediately becoming irrelevant.

Doesn't change release safety either way -- `release.yml` doesn't
gate on any CI conclusion today (no branch protection on `ng`, the
release job only `needs: debounce`), and the PR-time check run (a
separate `github.ref`) is unaffected by cancelling the post-merge
push-triggered run.

## Test plan
- [ ] CI passes (workflow-config-only change)