### PR TITLE
feat(explosion): port ChainExplosion class

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -538,6 +538,7 @@ set(SOURCES
 	include/RE/C/Calendar.h
 	include/RE/C/CalibrationOptionMenu.h
 	include/RE/C/CalmEffect.h
+	include/RE/C/ChainExplosion.h
 	include/RE/C/CharEvent.h
 	include/RE/C/Character.h
 	include/RE/C/ChestsLooted.h
@@ -2140,6 +2141,7 @@ set(SOURCES
 	src/RE/B/bhkRigidBody.cpp
 	src/RE/C/CFilter.cpp
 	src/RE/C/Calendar.cpp
+	src/RE/C/ChainExplosion.cpp
 	src/RE/C/ChestsLooted.cpp
 	src/RE/C/ChildSelectorBase.cpp
 	src/RE/C/CollisionLayers.cpp

--- a/include/RE/C/ChainExplosion.h
+++ b/include/RE/C/ChainExplosion.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "RE/B/BSTEvent.h"
+#include "RE/B/BeamProjectile.h"
+#include "RE/E/Explosion.h"
+
+namespace RE
+{
+	class ChainExplosion :
+		public Explosion,                               // 00
+		public BSTEventSink<BeamProjectileImpactEvent>  // 140
+	{
+	public:
+		inline static constexpr auto RTTI = RTTI_ChainExplosion;
+		inline static constexpr auto VTABLE = VTABLE_ChainExplosion;
+
+		~ChainExplosion() override;  // 00
+
+#ifndef SKYRIM_CROSS_VR
+		// override (Explosion)
+		void Initialize() override;           // A2
+		void Update(float a_delta) override;  // A3
+		void FindTargets() override;          // A4 - { return; }
+#endif
+
+		// override (BSTEventSink<BeamProjectileImpactEvent>)
+		BSEventNotifyControl ProcessEvent(const BeamProjectileImpactEvent* a_event, BSTEventSource<BeamProjectileImpactEvent>* a_eventSource) override;  // 01
+
+		// members
+		std::uint8_t unk148[0x58];  // 148 - chain-link bookkeeping (next-target handle, a component pointer, a bound BGSDestructibleObjectForm*, and per-link effectiveness floats); not yet broken out field-by-field
+
+	private:
+		TES_HEAP_REDEFINE_NEW();
+	};
+	STATIC_ASSERT_SIZE(ChainExplosion, 0x1A0, 0x1A8, 0x1A0);
+}

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -540,6 +540,7 @@
 #include "RE/C/Calendar.h"
 #include "RE/C/CalibrationOptionMenu.h"
 #include "RE/C/CalmEffect.h"
+#include "RE/C/ChainExplosion.h"
 #include "RE/C/CharEvent.h"
 #include "RE/C/Character.h"
 #include "RE/C/ChestsLooted.h"

--- a/src/RE/C/ChainExplosion.cpp
+++ b/src/RE/C/ChainExplosion.cpp
@@ -1,0 +1,23 @@
+#include "RE/C/ChainExplosion.h"
+
+using namespace REL;
+
+namespace RE
+{
+#ifndef SKYRIM_CROSS_VR
+	void ChainExplosion::Initialize()
+	{
+		RelocateVirtual<decltype(&Explosion::Initialize)>(0xA2, 0xA3, this);
+	}
+
+	void ChainExplosion::Update(float a_delta)
+	{
+		RelocateVirtual<decltype(&Explosion::Update)>(0xA3, 0xA4, this, a_delta);
+	}
+
+	void ChainExplosion::FindTargets()
+	{
+		RelocateVirtual<decltype(&Explosion::FindTargets)>(0xA4, 0xA5, this);
+	}
+#endif
+}


### PR DESCRIPTION
## Summary
Ports `RE::ChainExplosion` (a subclass of `Explosion`, also
implementing `BSTEventSink<BeamProjectileImpactEvent>`), RE'd via
Ghidra across SE/AE/VR:

- `Initialize`/`Update`/`FindTargets` genuinely diverge between SE/AE
  and VR (shifted vtable slots, gated by `SKYRIM_CROSS_VR`), so they're
  implemented via `RelocateVirtual`, reusing `Explosion`'s own
  already-established slot numbers (`FindTargets` is a no-op -- chain
  targets are resolved by the chain-update logic in `Update` instead).
- The dtor and `ProcessEvent` (its
  `BSTEventSink<BeamProjectileImpactEvent>` override) are plain,
  unconditionally-virtual overrides that never shift -- real C++
  virtual dispatch through the object's own runtime vtable already
  reaches the correct implementation with no CommonLib-authored body
  at all, so they're left as bare declarations (matching how `Actor`
  already leaves this same category of override undefined).
- Size confirmed via `MemoryManager::AllocateIMemoryHeap` ground
  truth: SE `0x1A0`, AE `0x1A8`, VR `0x1A0` (matches `Explosion`'s own
  size plus a flat `0x60` for the added base + own data).
- The class's ~88-byte tail of own fields is left as an unbroken byte
  blob for now (partially decompiled -- a chain-target handle, a
  destructible-form pointer, and a couple of effectiveness floats
  were identified, but not confidently typed yet).

None of this needs new address-library ids; doesn't depend on any
other PR.

## Test plan
- [x] Builds clean locally on `debug-clang-cl-vcpkg-all`
      (SKYRIM_CROSS_VR), `-vr`, and `-se` presets.
- [ ] CI passes