### PR TITLE
feat(explosion): port IExplosionFactory interface

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -1298,6 +1298,7 @@ set(SOURCES
 	include/RE/I/ICellAttachDetachEventSource.h
 	include/RE/I/ID.h
 	include/RE/I/IDEvent.h
+	include/RE/I/IExplosionFactory.h
 	include/RE/I/IFormFactory.h
 	include/RE/I/IFreezeQuery.h
 	include/RE/I/IFuncCallQuery.h

--- a/include/RE/I/IExplosionFactory.h
+++ b/include/RE/I/IExplosionFactory.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace RE
+{
+	class BGSExplosion;
+	class Explosion;
+
+	class IExplosionFactory
+	{
+	public:
+		inline static constexpr auto RTTI = RTTI_IExplosionFactory;
+		inline static constexpr auto VTABLE = VTABLE_IExplosionFactory;
+
+		virtual ~IExplosionFactory();  // 00
+
+		// add
+		virtual Explosion* Create(BGSExplosion* a_form) = 0;  // 01
+	};
+	static_assert(sizeof(IExplosionFactory) == 0x8);
+}

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -1300,6 +1300,7 @@
 #include "RE/I/ICellAttachDetachEventSource.h"
 #include "RE/I/ID.h"
 #include "RE/I/IDEvent.h"
+#include "RE/I/IExplosionFactory.h"
 #include "RE/I/IFormFactory.h"
 #include "RE/I/IFreezeQuery.h"
 #include "RE/I/IFuncCallQuery.h"


### PR DESCRIPTION
## Summary
Ports `RE::IExplosionFactory`, the abstract factory interface both
`Explosion`'s and `ChainExplosion`'s concrete form factories implement
(`ConcreteExplosionFactory_Explosion_0_`/`_ChainExplosion_1_`):

- `virtual Explosion* Create(BGSExplosion* a_form) = 0;` -- covariant
  in overriders (e.g. `ChainExplosion*`). The second parameter isn't
  visible in Ghidra's own decompiled signature for the ChainExplosion
  factory's override (it silently drops an unused-in-body incoming
  register); raw disassembly shows RDX saved to RBX at function entry
  and restored right before the constructor call, confirming it's a
  real second argument.
- The dtor is a plain, unconditionally-virtual override that never
  shifts between SE/AE/VR -- real C++ virtual dispatch through the
  object's own runtime vtable already reaches the correct
  implementation with no CommonLib-authored body at all (matching how
  `Actor` already leaves this same category of override undefined),
  so there's no `.cpp` for this interface.

No longer depends on any other PR.

## Test plan
- [x] Builds clean locally on `debug-clang-cl-vcpkg-all`
      (SKYRIM_CROSS_VR), `-vr`, and `-se` presets.
- [ ] CI passes