### PR TITLE
feat(projectile): add BeamProjectileImpactEvent

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -481,6 +481,7 @@ set(SOURCES
 	include/RE/B/BaseFormComponent.h
 	include/RE/B/BaseHandleReaderWriter.h
 	include/RE/B/BeamProjectile.h
+	include/RE/B/BeamProjectileImpactEvent.h
 	include/RE/B/BipedAnim.h
 	include/RE/B/BipedObjects.h
 	include/RE/B/BleedoutCameraState.h

--- a/include/RE/B/BeamProjectile.h
+++ b/include/RE/B/BeamProjectile.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "RE/B/BSTEvent.h"
+#include "RE/B/BeamProjectileImpactEvent.h"
 #include "RE/F/FormTypes.h"
 #include "RE/P/Projectile.h"
 #include "REL/RuntimeDataAccessors.h"
@@ -8,7 +9,6 @@
 namespace RE
 {
 	class BSProceduralGeomEvent;
-	struct BeamProjectileImpactEvent;
 
 	class BeamProjectile :
 		public Projectile,                                 // 000

--- a/include/RE/B/BeamProjectileImpactEvent.h
+++ b/include/RE/B/BeamProjectileImpactEvent.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "RE/N/NiPoint3.h"
+
+namespace RE
+{
+	class BeamProjectile;
+
+	struct BeamProjectileImpactEvent
+	{
+	public:
+		// members
+		BeamProjectile* source;     // 00
+		NiPoint3        impactPos;  // 08
+	};
+	static_assert(sizeof(BeamProjectileImpactEvent) == 0x18);
+}

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -483,6 +483,7 @@
 #include "RE/B/BaseFormComponent.h"
 #include "RE/B/BaseHandleReaderWriter.h"
 #include "RE/B/BeamProjectile.h"
+#include "RE/B/BeamProjectileImpactEvent.h"
 #include "RE/B/BipedAnim.h"
 #include "RE/B/BipedObjects.h"
 #include "RE/B/BleedoutCameraState.h"


### PR DESCRIPTION
## Summary
Replaces the forward-only `struct BeamProjectileImpactEvent;`
declaration with a real definition: a `BeamProjectile* source` plus a
`NiPoint3` impact position (`0x18` bytes total after alignment
padding).

Confirmed via disassembly of both sides independently: the firing
site (`BeamProjectile::AddImpact`, builds the event on the stack as
`this` followed by the target location) and a consumer
(`ChainExplosion::ProcessEvent`), which reads the same three float
offsets (`0x08`/`0x0C`/`0x10`) the firing site writes.

## Test plan
- [x] Builds clean locally on `debug-clang-cl-vcpkg-all`
      (SKYRIM_CROSS_VR), `-vr`, and `-se` presets.
- [ ] CI passes