### PR TITLE
feat(projectile): add BeamProjectile overrides

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -2132,6 +2132,7 @@ set(SOURCES
 	src/RE/B/BSXAudio2GameSound.cpp
 	src/RE/B/BSXFlags.cpp
 	src/RE/B/BarterMenu.cpp
+	src/RE/B/BeamProjectile.cpp
 	src/RE/B/BipedAnim.cpp
 	src/RE/B/BleedoutCameraState.cpp
 	src/RE/B/BookMenu.cpp

--- a/include/RE/B/BeamProjectile.h
+++ b/include/RE/B/BeamProjectile.h
@@ -59,6 +59,9 @@ namespace RE
 #ifndef ENABLE_SKYRIM_AE
 		BEAM_RUNTIME_DATA_CONTENT;
 #endif
+
+	private:
+		TES_HEAP_REDEFINE_NEW();
 	};
 #ifndef ENABLE_SKYRIM_AE
 	static_assert(sizeof(BeamProjectile) == 0x240);

--- a/src/RE/B/BeamProjectile.cpp
+++ b/src/RE/B/BeamProjectile.cpp
@@ -1,0 +1,43 @@
+#include "RE/B/BeamProjectile.h"
+
+using namespace REL;
+
+namespace RE
+{
+#ifndef SKYRIM_CROSS_VR
+	bool BeamProjectile::IsBeamProjectile()
+	{
+		return RelocateVirtual<decltype(&Projectile::IsBeamProjectile)>(0xA5, 0xA6, this);
+	}
+
+	void BeamProjectile::Process3D()
+	{
+		RelocateVirtual<decltype(&Projectile::Process3D)>(0xA9, 0xAA, this);
+	}
+
+	void BeamProjectile::UpdateImpl(float a_delta)
+	{
+		RelocateVirtual<decltype(&Projectile::UpdateImpl)>(0xAB, 0xAC, this, a_delta);
+	}
+
+	bool BeamProjectile::GetKillOnCollision()
+	{
+		return RelocateVirtual<decltype(&Projectile::GetKillOnCollision)>(0xB8, 0xB9, this);
+	}
+
+	void BeamProjectile::AddImpact(TESObjectREFR* a_ref, const NiPoint3& a_targetLoc, const NiPoint3& a_velocity, hkpCollidable* a_collidable, std::int32_t a_arg6, std::uint32_t a_arg7)
+	{
+		RelocateVirtual<decltype(&Projectile::AddImpact)>(0xBD, 0xBE, this, a_ref, a_targetLoc, a_velocity, a_collidable, a_arg6, a_arg7);
+	}
+
+	void BeamProjectile::Handle3DLoaded()
+	{
+		RelocateVirtual<decltype(&Projectile::Handle3DLoaded)>(0xC0, 0xC1, this);
+	}
+
+	bool BeamProjectile::ShouldUseDesiredTarget()
+	{
+		return RelocateVirtual<decltype(&Projectile::ShouldUseDesiredTarget)>(0xC1, 0xC2, this);
+	}
+#endif
+}


### PR DESCRIPTION
## Summary
`BeamProjectile.h` declared 14 overrides (dtor, `SaveGame`/`LoadGame`/
`InitLoadGame`/`FinishLoadGame`/`Revert`,
`IsBeamProjectile`/`Process3D`/`UpdateImpl`/`GetKillOnCollision`/
`AddImpact`/`Handle3DLoaded`/`ShouldUseDesiredTarget`, and its own
`BSProceduralGeomEvent` `ProcessEvent`) with **zero implementations
anywhere** in the codebase -- it compiled only because nothing
ODR-used them directly.

- The 7 that genuinely diverge between SE/AE and VR (shifted vtable
  slots, gated by `SKYRIM_CROSS_VR`) are implemented via
  `RelocateVirtual`, reusing `Projectile`'s own already-established
  slot numbers -- no new address-library ids needed.
- The other 7 (dtor, `SaveGame`/`LoadGame`/`InitLoadGame`/
  `FinishLoadGame`/`Revert`, and the `BSProceduralGeomEvent`
  `ProcessEvent`) are plain, unconditionally-virtual overrides that
  never shift -- real C++ virtual dispatch through the object's own
  runtime vtable already reaches the correct implementation with no
  CommonLib-authored body at all, so they're left as bare
  declarations (matching how `Projectile`/`Actor` already leave this
  same category of override undefined -- confirmed this links clean).

Also fixes the same diamond `operator delete` ambiguity
`ChainExplosion` hit (`BSTEventSource`/`BSTEventSink` add a second
unrelated polymorphic base), via `TES_HEAP_REDEFINE_NEW()`.

Note: `BSProceduralGeomEvent` itself remains a forward declaration --
the one consumer here never reads its payload, and no producer for it
exists in CommonLib yet (likely `BSProceduralLightningController`/
`Tasklet`, unexplored).

## Test plan
- [x] Builds clean locally on `debug-clang-cl-vcpkg-all`
      (SKYRIM_CROSS_VR), `-vr`, and `-se` presets.
- [ ] CI passes