### PR TITLE
fix(lightning): VR runtime accessor for cross-VR safety

### DIFF
--- a/include/RE/B/BSProceduralLightningTasklet.h
+++ b/include/RE/B/BSProceduralLightningTasklet.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "RE/B/BSTaskletData.h"
+#include "REL/RuntimeDataAccessors.h"
 
 namespace RE
 {
@@ -36,12 +37,24 @@ namespace RE
 		std::uint32_t unkA8;        // A8
 		bool          unkAC;        // AC
 		std::uint8_t  padAD[3];     // AD
-#ifdef ENABLE_SKYRIM_VR
-		std::uint8_t unkVRB0[0x18];  // B0 - VR-only extra tail; not yet identified
+
+		struct VR_RUNTIME_DATA
+		{
+#define VR_RUNTIME_DATA_CONTENT \
+	std::uint8_t unk[0x18];  // B0 - VR-only extra tail; not yet identified
+			VR_RUNTIME_DATA_CONTENT;
+		};
+		static_assert(sizeof(VR_RUNTIME_DATA) == 0x18);
+
+		VR_RUNTIME_DATA_ACCESSOR(VR_RUNTIME_DATA, GetVRRuntimeData, 0xB0);
+
+#if defined(EXCLUSIVE_SKYRIM_VR)
+		VR_RUNTIME_DATA_CONTENT;  // B0
 #endif
 
 	private:
 		void Dtor();
 	};
-	STATIC_ASSERT_SIZE(BSProceduralLightningTasklet, 0xB0, 0xB0, 0xC8);
+#undef VR_RUNTIME_DATA_CONTENT
+	STATIC_ASSERT_SIZE(BSProceduralLightningTasklet, 0xB0, 0xB0, 0xC8, 0xB0);
 }


### PR DESCRIPTION
Follow-up to #252's review comment on cross-VR gating. The VR-only
tail was a raw `#ifdef ENABLE_SKYRIM_VR` member, which is also
defined in cross-VR ("all") builds, silently growing the struct past
the SE/AE layout there. Switches to `VR_RUNTIME_DATA_ACCESSOR`
(NiCamera's established pattern) so the compiled struct stays
SE/AE-sized in cross-VR builds and the tail is reached only via
`RelocateMember`. Adds the missing `AllSize` arg to
`STATIC_ASSERT_SIZE`, which had been silently skipped before.

Verified clean builds on `all`/`vr`/`se` presets.