### PR TITLE
fix(streambase): correct AE/SE/VR flags offset

### DIFF
--- a/include/RE/S/StreamBase.h
+++ b/include/RE/S/StreamBase.h
@@ -2,6 +2,7 @@
 
 #include "RE/E/ErrorCodes.h"
 #include "RE/M/MemoryManager.h"
+#include "REL/RuntimeDataAccessors.h"
 
 namespace RE
 {
@@ -40,13 +41,52 @@ namespace RE
 			std::uint32_t      IncRef();
 			[[nodiscard]] bool IsWritable() const;
 
+			// AE-only; compiler-widened zero padding from totalSize's store, not
+			// real data, but still shifts the ref-count field's offset below.
+			struct AE_RUNTIME_DATA
+			{
+#define AE_RUNTIME_DATA_CONTENT \
+	std::uint32_t pad0C;  // 0C - confirmed always-zero, not real data
+				AE_RUNTIME_DATA_CONTENT
+			};
+			static_assert(sizeof(AE_RUNTIME_DATA) == 0x4);
+
+			AE_ONLY_POINTER_ACCESSOR(AE_RUNTIME_DATA, GetAERuntimeData, 0xC);
+
+			// AE's pad0C shifts flags's real offset from 0xC (SE/VR) to 0x10 (AE);
+			// use GetFlags(), not the bare member, so cross-runtime builds resolve correctly.
+			[[nodiscard]] inline std::uint32_t& GetFlags() noexcept
+			{
+				if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {
+					return *reinterpret_cast<std::uint32_t*>(reinterpret_cast<std::uint8_t*>(this) + 0x10);
+				} else {
+					return *reinterpret_cast<std::uint32_t*>(reinterpret_cast<std::uint8_t*>(this) + 0xC);
+				}
+			}
+
+			[[nodiscard]] inline const std::uint32_t& GetFlags() const noexcept
+			{
+				if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {
+					return *reinterpret_cast<const std::uint32_t*>(reinterpret_cast<const std::uint8_t*>(this) + 0x10);
+				} else {
+					return *reinterpret_cast<const std::uint32_t*>(reinterpret_cast<const std::uint8_t*>(this) + 0xC);
+				}
+			}
+
 			// members
 			std::uint32_t totalSize;  // 08
 #ifdef ENABLE_SKYRIM_AE
-			std::uint32_t unk0C;  // 0C
+			AE_RUNTIME_DATA_CONTENT;
 #endif
-			std::uint32_t flags;  // 10
+#if defined(ENABLE_SKYRIM_AE) && !defined(EXCLUSIVE_SKYRIM_AE)
+			// This build mixes AE with SE and/or VR, so a single fixed offset for
+			// this field can't be correct for every runtime -- direct access is
+			// disabled here; only GetFlags() resolves the real per-runtime offset.
+		private:
+#endif
+			std::uint32_t flags;  // 10 (0xC on SE/VR; see GetFlags())
 		};
+#undef AE_RUNTIME_DATA_CONTENT
 #ifdef ENABLE_SKYRIM_AE
 		static_assert(sizeof(StreamBase) == 0x18);
 #else

--- a/include/REL/RuntimeDataAccessors.h
+++ b/include/REL/RuntimeDataAccessors.h
@@ -122,6 +122,29 @@
 		}                                                               \
 	}
 
+// Generates GetXXX() pointer accessor for AE-only inline data present since AE's
+// initial release (returns nullptr on SE/VR). For AE data reached via a stored
+// pointer member, or added partway through AE's own version lifecycle, hand-roll
+// instead (see CombatController/BGSSaveLoadManager/TES's GetAERuntimeData).
+// Params: StructType, FuncName, AEOffset
+#define AE_ONLY_POINTER_ACCESSOR(StructType, FuncName, AEOffset)     \
+	[[nodiscard]] inline StructType* FuncName() noexcept             \
+	{                                                                \
+		if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {              \
+			return &REL::RelocateMember<StructType>(this, AEOffset); \
+		} else {                                                     \
+			return nullptr;                                          \
+		}                                                            \
+	}                                                                \
+	[[nodiscard]] inline const StructType* FuncName() const noexcept \
+	{                                                                \
+		if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {              \
+			return &REL::RelocateMember<StructType>(this, AEOffset); \
+		} else {                                                     \
+			return nullptr;                                          \
+		}                                                            \
+	}
+
 // ========================================
 // Pointer Member Accessors
 // ========================================

--- a/src/RE/S/StreamBase.cpp
+++ b/src/RE/S/StreamBase.cpp
@@ -5,24 +5,28 @@ namespace RE
 	namespace BSResource
 	{
 		StreamBase::StreamBase() :
-			totalSize(0),
-			flags(0)
-		{}
+			totalSize(0)
+		{
+			GetFlags() = 0;
+		}
 
 		StreamBase::StreamBase(const StreamBase& a_rhs) :
-			totalSize(a_rhs.totalSize),
-			flags(a_rhs.flags & ~kRefCountMask)
-		{}
+			totalSize(a_rhs.totalSize)
+		{
+			GetFlags() = a_rhs.GetFlags() & ~kRefCountMask;
+		}
 
 		StreamBase::StreamBase(StreamBase&& a_rhs) :
-			totalSize(a_rhs.totalSize),
-			flags(a_rhs.flags & ~kRefCountMask)
-		{}
+			totalSize(a_rhs.totalSize)
+		{
+			GetFlags() = a_rhs.GetFlags() & ~kRefCountMask;
+		}
 
 		StreamBase::StreamBase(std::uint32_t a_totalSize) :
-			totalSize(a_totalSize),
-			flags(0)
-		{}
+			totalSize(a_totalSize)
+		{
+			GetFlags() = 0;
+		}
 
 		std::uint64_t StreamBase::DoGetKey() const
 		{
@@ -36,7 +40,7 @@ namespace RE
 
 		std::uint32_t StreamBase::DecRef()
 		{
-			stl::atomic_ref myFlags{ flags };
+			stl::atomic_ref myFlags{ GetFlags() };
 			std::uint32_t   expected;
 			do {
 				expected = myFlags;
@@ -46,7 +50,7 @@ namespace RE
 
 		std::uint32_t StreamBase::IncRef()
 		{
-			stl::atomic_ref myFlags{ flags };
+			stl::atomic_ref myFlags{ GetFlags() };
 			std::uint32_t   expected;
 			do {
 				expected = myFlags;
@@ -56,7 +60,7 @@ namespace RE
 
 		bool StreamBase::IsWritable() const
 		{
-			return static_cast<bool>(flags & kWritable);
+			return static_cast<bool>(GetFlags() & kWritable);
 		}
 	}
 }


### PR DESCRIPTION
fix(streambase): correct AE/SE/VR flags offset

Split out of #255 — this is a different bug axis (AE-vs-SE/VR offset
shift, not VR-exclusive data) and a genuinely live bug touching
actively-used refcounting code, so it gets its own bisectable PR.

`StreamBase::pad0C` is gated by `ENABLE_SKYRIM_AE`, which is also true
in `flatrim` (SE+AE) and `all` (SE+AE+VR) cross-runtime builds. This
shifts the real offset of the actively-used `flags` ref-count field
from `0xC` (SE/VR) to `0x10` (AE) at compile time, but the previous
bare member access read/wrote it at a single fixed offset regardless
of which runtime is actually running.

Confirmed via Ghidra decompilation across all three real binaries
(SE 1.5.97, AE 1.6.1170, VR 1.4.15): SE and VR are identical at `0x10`
total with `flags@0xC` and no gap; AE is `0x18` total with
`pad0C@0xC` and `flags@0x10` — a clean AE-vs-(SE+VR) split, not a
version-gated one. Any `flatrim`/`all` build was corrupting
refcounting/writability whenever it actually processed a real SE or
VR stream object at runtime.

Added `GetFlags()`/`GetAERuntimeData()` accessors that branch on the
actual detected `REL::Module::IsAE()`, and switched every internal
call site (constructors, `IncRef`, `DecRef`, `IsWritable`) to use
them. `flags` is also made private whenever `ENABLE_SKYRIM_AE` is
combined with SE and/or VR in the same build (`flatrim`/`all`) — the
single fixed offset a bare member declaration requires can't be
correct for every runtime in that config, so direct access is a
compile error there instead of a silent wrong read. It stays a plain
public member in single-runtime builds, where its offset is always
unambiguous. Not marked as a breaking change: the direct-access path
this closes was never correct in a cross-runtime build to begin with
(it silently misread the wrong offset), so nothing that previously
worked stops working — code relying on it was already broken.

Verified clean builds on `all`/`vr`/`se`/`flatrim` presets.

**Follow-up RE (2026-07-28):** exhaustively RE'd `unk0C` itself per
an explicit no-budget-limit directive, across 5 independent AE
constructors. It's not real data -- it's compiler-widened zero
padding from a single 8-byte store of the 4-byte `totalSize`
argument, never written independently. Renamed to `pad0C`; the
`flags`-offset-shift fix above is unaffected since the byte range
still needs to be reserved either way.

`GetFlags()`/`GetAERuntimeData()` used `if constexpr` with a trailing
fallback `return` instead of `else`; in an AE-exclusive build the
condition is compile-time true, making the fallback genuinely
unreachable and tripping MSVC's `/WX`-as-error C4702. Switched both
to `if/else`, matching this file's own `AsVRWandEvent`-style pattern
used elsewhere in the codebase.

Extracted `GetAERuntimeData()`'s hand-rolled body into a new shared
`AE_ONLY_POINTER_ACCESSOR` macro in `RuntimeDataAccessors.h`, as a
sibling to the existing `SE_ONLY_POINTER_ACCESSOR`/
`VR_ONLY_POINTER_ACCESSOR`. This is a distinct shape from the three
other `GetAERuntimeData()`s in the codebase (`CombatController`,
`BGSSaveLoadManager`, `TES`), which dereference a stored pointer
member and are version-gated for AE fields added partway through
AE's own lifecycle; StreamBase's is inline-embedded data present
since AE's initial release, matching the address-of-computed-offset
shape those two sibling macros already use. Left those three as-is
(unrelated files, different shape, not touched by this fix).
