### PR TITLE
feat(lightning): name fields, fix VR layout bug

### DIFF
--- a/include/RE/B/BSProceduralLightningController.h
+++ b/include/RE/B/BSProceduralLightningController.h
@@ -1,7 +1,12 @@
 #pragma once
 
+#include "RE/B/BSDynamicTriShape.h"
 #include "RE/B/BSFixedString.h"
+#include "RE/B/BSProceduralLightningTasklet.h"
+#include "RE/B/BSTArray.h"
 #include "RE/N/NiInterpController.h"
+#include "RE/N/NiInterpolator.h"
+#include "RE/N/NiSmartPointer.h"
 #include "REL/RuntimeDataAccessors.h"
 
 namespace RE
@@ -43,25 +48,90 @@ namespace RE
 		void                 GuaranteeTimeRange(float a_startTime, float a_endTime) override;                                                                                                                                         // 3A
 		bool                 InterpolatorIsCorrectType(NiInterpolator* a_interpolator, std::uint16_t a_index) const override;                                                                                                         // 3B
 
+		// geometry/cachedBounds are unshifted in VR; VR inserts extra fields
+		// right after cachedBounds, so interpolators onward shifts.
+		struct RUNTIME_DATA
+		{
+#define RUNTIME_DATA_CONTENT                                                                                                        \
+	std::uint8_t                  padE4[0x24];             /* E4 - unidentified */                                                  \
+	NiPointer<NiInterpolator>     interpolators[9];        /* 108 - matches GetInterpolatorIndex's 9-entry table */                 \
+	std::uint8_t                  pad150[0x18];            /* 150 - unidentified */                                                 \
+	float                         duration;                /* 168 */                                                                \
+	float                         progress;                /* 16C - duration / (a per-frame helper's return value) */               \
+	std::uint8_t                  pad170[2];               /* 170 */                                                                \
+	bool                          needsRegeneration;       /* 172 - gates full branch-mesh regen in the mesh builder */             \
+	bool                          regenerationSkipped;     /* 173 - 0 after a fresh regen, 1 on the fallback path */                \
+	std::uint8_t                  pad174[4];               /* 174 */                                                                \
+	std::uint64_t                 taskGroupHandle;         /* 178 - real type is BSTaskletGroup (has RTTI/VTABLE, no header yet) */ \
+	BSProceduralLightningTasklet* tasklet;                 /* 180 - refcounted internally; not an NiObject, so no NiPointer */      \
+	bool                          interpolator0EventCache; /* 188 - last-frame cached event query from interpolators[0] */          \
+	bool                          interpolator1EventCache; /* 189 - last-frame cached event query from interpolators[1] */          \
+	std::uint8_t                  pad18A[6];               /* 18A */
+            RUNTIME_DATA_CONTENT
+		};
+		static_assert(sizeof(RUNTIME_DATA) == 0xB0);
+
+		// Compared via BSProceduralGeometry::Lightning::operator== in IsEqual and
+		// serialized as a pair in SaveBinary/LoadBinary; 4th field unconfirmed.
+		struct Lightning
+		{
+			std::uint16_t a;     // 0 - compared/serialized
+			std::uint16_t b;     // 2 - compared/serialized
+			std::uint16_t c;     // 4 - compared/serialized
+			std::uint16_t pad6;  // 6 - unconfirmed; observed 8-byte stride between instances
+		};
+		static_assert(sizeof(Lightning) == 0x8);
+
 		struct VR_RUNTIME_DATA
 		{
-#define VR_RUNTIME_DATA_CONTENT \
-	std::uint8_t unk[0x18];  // 190 - VR-only extra tail; not yet identified
-			VR_RUNTIME_DATA_CONTENT;
+#define VR_RUNTIME_DATA_CONTENT                                                                                                     \
+	float                         prevBounds[3];           /* E4 - not yet identified */                                            \
+	float                         extents[3];              /* F0 - not yet identified */                                            \
+	std::uint8_t                  padFC[0x1C];             /* FC - unidentified */                                                  \
+	NiPointer<NiObject>           unk118;                  /* 118 - refcounted; not yet identified beyond NiObject */               \
+	NiPointer<NiInterpolator>     interpolators[9];        /* 120 - matches GetInterpolatorIndex's 9-entry table */                 \
+	Lightning                     lightning[2];            /* 168 - BSProceduralGeometry::Lightning pair */                         \
+	float                         unk178;                  /* 178 - written by interpolators[7]'s GetValue call */                  \
+	std::uint8_t                  pad17C[4];               /* 17C - unidentified */                                                 \
+	float                         duration;                /* 180 */                                                                \
+	float                         progress;                /* 184 */                                                                \
+	std::uint8_t                  pad188[2];               /* 188 */                                                                \
+	bool                          needsRegeneration;       /* 18A - gates full branch-mesh regen in the mesh builder */             \
+	bool                          regenerationSkipped;     /* 18B - 0 after a fresh regen, 1 on the fallback path */                \
+	std::uint8_t                  pad18C[4];               /* 18C */                                                                \
+	std::uint64_t                 taskGroupHandle;         /* 190 - real type is BSTaskletGroup (has RTTI/VTABLE, no header yet) */ \
+	BSProceduralLightningTasklet* tasklet;                 /* 198 */                                                                \
+	bool                          interpolator0EventCache; /* 1A0 - last-frame cached event query from interpolators[0] */          \
+	bool                          interpolator1EventCache; /* 1A1 - last-frame cached event query from interpolators[1] */          \
+	std::uint8_t                  pad1A2[6];               /* 1A2 */
+            VR_RUNTIME_DATA_CONTENT
 		};
-		static_assert(sizeof(VR_RUNTIME_DATA) == 0x18);
+		static_assert(sizeof(VR_RUNTIME_DATA) == 0xC8);
 
-		VR_RUNTIME_DATA_ACCESSOR(VR_RUNTIME_DATA, GetVRRuntimeData, 0x190);
+		RUNTIME_DATA_ACCESSOR(RUNTIME_DATA, 0xE4, 0x0);
+		VR_ONLY_POINTER_ACCESSOR(VR_RUNTIME_DATA, GetVRRuntimeData, 0xE4);
 
 		// members
-		std::uint8_t unk48[0x148];  // 48 - own state (interpolators, event source, geometry/tasklet pointers, animation keyframe bookkeeping); not yet broken out field-by-field
-#if defined(EXCLUSIVE_SKYRIM_VR)
-		VR_RUNTIME_DATA_CONTENT;  // 190
+		BSTArray<std::uint8_t>       unkArray1;    // 48 - observed always empty; element type unresolved
+		BSTArray<std::uint8_t>       unkArray2;    // 60 - observed always empty; element type unresolved
+		BSTArray<std::uint8_t>       unkArray3;    // 78 - observed always empty; element type unresolved
+		std::uint64_t                unk90;        // 90 - observed always zero
+		bool                         unk98;        // 98 - observed always zero
+		std::uint8_t                 pad99[7];     // 99 - unidentified
+		NiPointer<BSDynamicTriShape> geometry;     // A0 - lightning-bolt mesh geometry; unshifted in VR
+		std::uint8_t                 padA8[0x2C];  // A8 - lightning-path working buffer (point/vertex/branch
+												   //      pointers); owned alloc freed in dtor; feeds cachedBounds
+		float cachedBounds[4];                     // D4 - cached bounding-sphere/transform snapshot; unshifted in VR
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+		RUNTIME_DATA_CONTENT;  // E4
+#elif defined(EXCLUSIVE_SKYRIM_VR)
+		VR_RUNTIME_DATA_CONTENT;  // E4
 #endif
 
 	private:
 		void Dtor();
 	};
+#undef RUNTIME_DATA_CONTENT
 #undef VR_RUNTIME_DATA_CONTENT
-	STATIC_ASSERT_SIZE(BSProceduralLightningController, 0x190, 0x190, 0x1A8, 0x190);
+	STATIC_ASSERT_SIZE(BSProceduralLightningController, 0x190, 0x190, 0x1A8, 0xE8);
 }

--- a/include/RE/B/BSProceduralLightningTasklet.h
+++ b/include/RE/B/BSProceduralLightningTasklet.h
@@ -25,36 +25,57 @@ namespace RE
 		std::uint8_t  pad19[3];     // 19
 		std::uint32_t unk1C;        // 1C
 		std::uint8_t  unk20[0x60];  // 20 - own container/array bookkeeping; not yet identified
-		void*         unk80;        // 80
-		std::uint32_t unk84;        // 84
-		std::uint16_t unk8C;        // 8C
-		std::uint8_t  pad8E[2];     // 8E
-		std::uint32_t unk90;        // 90
-		std::uint32_t unk94;        // 94
-		std::uint32_t unk98;        // 98
-		std::uint32_t unk9C;        // 9C
-		void*         unkA0;        // A0
-		std::uint32_t unkA8;        // A8
-		bool          unkAC;        // AC
-		std::uint8_t  padAD[3];     // AD
+
+		// VR inserts 0x18 unidentified bytes at this offset instead of appending
+		// a trailing tail, shifting every field after it by +0x18.
+		struct RUNTIME_DATA
+		{
+#define RUNTIME_DATA_CONTENT                                                                                         \
+	void*         linkedObject; /* 80 - refcounted pointer, reassigned via a dedicated helper */                     \
+	std::uint16_t unk88;        /* 88 - real offset (compiled position, not 84 -- unk80 is a full 8-byte pointer) */ \
+	std::uint8_t  pad8A[2];     /* 8A */                                                                             \
+	std::uint16_t unk8C;        /* 8C */                                                                             \
+	std::uint8_t  pad8E[2];     /* 8E */                                                                             \
+	float         floatData[4]; /* 90 - same bytes as the old unk90/94/98/9C, confirmed float not uint32_t */        \
+	void*         unkA0;        /* A0 */                                                                             \
+	std::uint32_t unkA8;        /* A8 */                                                                             \
+	bool          unkAC;        /* AC */                                                                             \
+	std::uint8_t  padAD[3];     /* AD */
+            RUNTIME_DATA_CONTENT
+		};
+		static_assert(sizeof(RUNTIME_DATA) == 0x30);
 
 		struct VR_RUNTIME_DATA
 		{
-#define VR_RUNTIME_DATA_CONTENT \
-	std::uint8_t unk[0x18];  // B0 - VR-only extra tail; not yet identified
-			VR_RUNTIME_DATA_CONTENT;
+#define VR_RUNTIME_DATA_CONTENT                                                      \
+	std::uint8_t  unk80[0x18];  /* 80 - VR-only inserted data; not yet identified */ \
+	void*         linkedObject; /* 98 */                                             \
+	std::uint16_t unk88;        /* A0 */                                             \
+	std::uint8_t  pad8A[2];     /* A2 */                                             \
+	std::uint16_t unk8C;        /* A4 */                                             \
+	std::uint8_t  pad8E[2];     /* A6 */                                             \
+	float         floatData[4]; /* A8 */                                             \
+	void*         unkA0;        /* B8 */                                             \
+	std::uint32_t unkA8;        /* C0 */                                             \
+	bool          unkAC;        /* C4 */                                             \
+	std::uint8_t  padAD[3];     /* C5 */
+            VR_RUNTIME_DATA_CONTENT
 		};
-		static_assert(sizeof(VR_RUNTIME_DATA) == 0x18);
+		static_assert(sizeof(VR_RUNTIME_DATA) == 0x48);
 
-		VR_RUNTIME_DATA_ACCESSOR(VR_RUNTIME_DATA, GetVRRuntimeData, 0xB0);
+		RUNTIME_DATA_ACCESSOR(RUNTIME_DATA, 0x80, 0x0);
+		VR_ONLY_POINTER_ACCESSOR(VR_RUNTIME_DATA, GetVRRuntimeData, 0x80);
 
-#if defined(EXCLUSIVE_SKYRIM_VR)
-		VR_RUNTIME_DATA_CONTENT;  // B0
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+		RUNTIME_DATA_CONTENT;  // 80
+#elif defined(EXCLUSIVE_SKYRIM_VR)
+		VR_RUNTIME_DATA_CONTENT;  // 80
 #endif
 
 	private:
 		void Dtor();
 	};
+#undef RUNTIME_DATA_CONTENT
 #undef VR_RUNTIME_DATA_CONTENT
-	STATIC_ASSERT_SIZE(BSProceduralLightningTasklet, 0xB0, 0xB0, 0xC8, 0xB0);
+	STATIC_ASSERT_SIZE(BSProceduralLightningTasklet, 0xB0, 0xB0, 0xC8, 0x80);
 }


### PR DESCRIPTION
feat(lightning)!: name fields, fix VR layout bug

RE walk across SE 1.5.97/AE 1.6.1170/VR 1.4.15 for
BSProceduralLightningController and BSProceduralLightningTasklet,
derived from their own methods (Update, the NiInterpController
overrides, LoadBinary/SaveBinary, Func2/Func3/Dtor), not size alone.

Controller: geometry (BSDynamicTriShape*), cachedBounds (float[4]),
interpolators (NiPointer<NiInterpolator>[9], matches
GetInterpolatorIndex's 9-entry table), duration/progress,
needsRegeneration/regenerationSkipped (mesh-regen gate + fallback
flag consumed by the mesh builder), interpolator0/1EventCache
(last-frame cached blend-interpolator event queries), taskGroupHandle
(BSTaskletManager::CreateTaskGroup output; real type is
BSTaskletGroup, which has RTTI/VTABLE but no header yet), and tasklet
(the owned BSProceduralLightningTasklet*, kept as a raw pointer since
BSTaskletData doesn't implement NiObject's DecRefCount interface
NiPointer requires). Three BSTArray-shaped fields at 0x48/0x60/0x78
are declared but observed empty in every reachable code path, so
their element type is unresolved; a lightning-path working buffer at
0xA8 feeds cachedBounds but is only partially typed.

VR inserts fields mid-struct instead of appending a tail: Controller
at offset 0x168 (interpolators shifts to 0x120; prevBounds/extents/an
unidentified refcounted pointer are inserted after cachedBounds), and
Tasklet at offset 0x80. Both use the established
RUNTIME_DATA/VR_RUNTIME_DATA dual-struct pattern with
VR_ONLY_POINTER_ACCESSOR, matching NiCamera/PlayerCamera's own
genuinely-diverging-layout cases.

Tasklet: fixed a layout bug, not just a missing name -- unk84
(uint32_t) claimed offset 0x84, but since unk80 is a full 8-byte
pointer its real offset is 0x88, and it's a 2-byte ushort with 2
separate unaccounted bytes after it. unk90/94/98/9C regrouped into a
float[4]. linkedObject remains void* -- no concrete type found after
checking Func2, a controller back-reference, and generic refcount
patterns.

Verified clean builds on all/vr/se/flatrim presets and the test
suite (CommonLibSSETests, 156 assertions / 34 cases, all pass).