### PR TITLE
feat(saveloadgame): name VR plugin-index fields

### DIFF
--- a/include/RE/B/BGSSaveLoadGame.h
+++ b/include/RE/B/BGSSaveLoadGame.h
@@ -99,9 +99,9 @@ namespace RE
 
 		struct VR_RUNTIME_DATA
 		{
-#define VR_RUNTIME_DATA_CONTENT              \
-	std::uint8_t pluginList[0xFF]; /* 000 */ \
-	std::uint8_t unk18[0xFF];      /* 0FF */
+#define VR_RUNTIME_DATA_CONTENT                                                                                    \
+	std::uint8_t saveToLoadOrderIndex[0xFF]; /* 000 - save index -> current load-order index, 0xFF if not found */ \
+	std::uint8_t loadOrderToSaveIndex[0xFF]; /* 0FF - reverse: load-order index -> save index */
 			VR_RUNTIME_DATA_CONTENT
 		};
 


### PR DESCRIPTION
`BGSSaveLoadGame::VR_RUNTIME_DATA`'s `pluginList`/`unk18` were opaque
255-byte buffers. Confirmed via `BGSSaveLoadGame::LoadMods` (VR
1.4.15): `pluginList` maps save-file plugin index -> current
session's load-order index (`0xFF` if not found in the current load
order); `unk18` is the reverse map, load-order index -> save-file
plugin index. Renamed to `saveToLoadOrderIndex`/
`loadOrderToSaveIndex`.

Verified clean builds on `all`/`vr`/`se` presets and the test suite
(`CommonLibSSETests`, 156 assertions / 34 cases, all pass).