### PR TITLE
fix(vr): stop re-populating shared address table

### DIFF
--- a/include/REL/ID.h
+++ b/include/REL/ID.h
@@ -129,12 +129,15 @@ namespace REL
 
 		[[nodiscard]] static IDDatabase& get()
 		{
+			if (_initialized.load(std::memory_order_acquire)) {
+				return _instance;
+			}
+			std::unique_lock lock(_initLock);
 			if (_initialized.load(std::memory_order_relaxed)) {
 				return _instance;
 			}
-			[[maybe_unused]] std::unique_lock lock(_initLock);
 			_instance.load();
-			_initialized.store(true, std::memory_order_relaxed);
+			_initialized.store(true, std::memory_order_release);
 			return _instance;
 		}
 
@@ -500,7 +503,7 @@ namespace REL
 		[[nodiscard]] std::uintptr_t address() const
 		{
 			auto thisOffset = offset();
-			return thisOffset ? base() + offset() : 0;
+			return thisOffset ? base() + thisOffset : 0;
 		}
 
 		[[nodiscard]] std::size_t offset() const
@@ -572,7 +575,7 @@ namespace REL
 		[[nodiscard]] std::uintptr_t address() const
 		{
 			auto thisOffset = offset();
-			return thisOffset ? base() + offset() : 0;
+			return thisOffset ? base() + thisOffset : 0;
 		}
 
 		[[nodiscard]] std::size_t offset() const

--- a/src/REL/ID.cpp
+++ b/src/REL/ID.cpp
@@ -152,35 +152,36 @@ namespace REL
 		version = in.GetCell<std::string>(1, 0);
 		_vrAddressLibraryVersion = Version(version);
 		const auto byteSize = static_cast<std::size_t>(address_count * sizeof(mapping_t));
-		if (!_mmap.open(mapname, byteSize) &&
-			!_mmap.create(mapname, byteSize)) {
+		if (_mmap.open(mapname, byteSize)) {
+			_id2offset = { static_cast<mapping_t*>(_mmap.data()), static_cast<std::size_t>(address_count) };
+		} else if (_mmap.create(mapname, byteSize)) {
+			_id2offset = { static_cast<mapping_t*>(_mmap.data()), static_cast<std::size_t>(address_count) };
+			if (in.GetRowCount() > address_count + 1) {
+				return stl::report_and_error(
+					std::format("VR Address Library {} tried to exceed {} allocated entries."sv,
+						version, address_count),
+					a_failOnError);
+			} else if (in.GetRowCount() < address_count + 1) {
+				return stl::report_and_error(
+					std::format("VR Address Library {} loaded only {} entries but expected {}. Please redownload."sv,
+						version, in.GetRowCount() - 1, address_count),
+					a_failOnError);
+			}
+
+			std::size_t index = 1;
+			for (; index < in.GetRowCount(); ++index) {
+				id = in.GetCell<std::size_t>(0, index);
+				offset = in.GetCell<std::string>(1, index);
+				_id2offset[index - 1] = { static_cast<std::uint64_t>(id),
+					static_cast<std::uint64_t>(std::stoul(offset, nullptr, 16)) };
+			}
+
+			std::sort(_id2offset.begin(), _id2offset.end(), [](auto&& a_lhs, auto&& a_rhs) {
+				return a_lhs.id < a_rhs.id;
+			});
+		} else {
 			return stl::report_and_error("failed to create shared mapping"sv, a_failOnError);
 		}
-
-		_id2offset = { static_cast<mapping_t*>(_mmap.data()), static_cast<std::size_t>(address_count) };
-		if (in.GetRowCount() > address_count + 1) {
-			return stl::report_and_error(
-				std::format("VR Address Library {} tried to exceed {} allocated entries."sv,
-					version, address_count),
-				a_failOnError);
-		} else if (in.GetRowCount() < address_count + 1) {
-			return stl::report_and_error(
-				std::format("VR Address Library {} loaded only {} entries but expected {}. Please redownload."sv,
-					version, in.GetRowCount() - 1, address_count),
-				a_failOnError);
-		}
-
-		std::size_t index = 1;
-		for (; index < in.GetRowCount(); ++index) {
-			id = in.GetCell<std::size_t>(0, index);
-			offset = in.GetCell<std::string>(1, index);
-			_id2offset[index - 1] = { static_cast<std::uint64_t>(id),
-				static_cast<std::uint64_t>(std::stoul(offset, nullptr, 16)) };
-		}
-
-		std::sort(_id2offset.begin(), _id2offset.end(), [](auto&& a_lhs, auto&& a_rhs) {
-			return a_lhs.id < a_rhs.id;
-		});
 
 		return true;
 	}


### PR DESCRIPTION
## Summary
`IDDatabase::load_csv()` unconditionally re-parsed the CSV and re-sorted the shared `id -> offset` table on every load, even when it only attached to a section another DLL had already populated (via `OpenFileMappingW`). Since every VR SKSE plugin links CommonLibVR as a static library, each has its own private `IDDatabase` singleton but all share the same named memory section -- so any two plugins initializing near each other race a live sort/rewrite against a concurrent `lower_bound` read, intermittently failing to resolve an id that is genuinely present in the address library (`[C] Failed to find the id within the address library: <id>`, works fine most of the time, fails unpredictably).

`load_file()` (SE/AE) already avoids this: it only unpacks and sorts in the branch where it created the mapping, treating an attach to an existing section as read-only. This PR restructures `load_csv()` to match that exact branching, so VR gets the same proven single-writer guarantee flatrim has always had -- no new synchronization primitives, no behavior change for the non-racing path.

Also fixes two smaller, related issues found during review:
- `IDDatabase::get()`'s double-checked locking was missing the re-check of `_initialized` after acquiring `_initLock`, so a thread that lost the initial race would still redundantly reload and re-sort the table a second time.
- `RelocationID::address()` and `VariantID::address()` each called `offset()` twice per lookup instead of reusing the first result.

## Validation
- Runtime-verified in SkyrimVR: reproduced the original crash (intermittent `[C] Failed to find the id within the address library`) on the unfixed code across multiple relaunches. After this fix, ran two independent full relaunch cycles (~3 min each, Border/Camera post-processing enabled to exercise VR-only relocations) with zero recurrences and zero `[C]`/`[E]` log lines.
- Compiles and links clean as part of a full `CommunityShaders` build (open-shaders fork).
- Reviewed against two independent model opinions (concurrency-focused) before landing; both converged on the same root cause and confirmed this restructure (matching `load_file`'s existing pattern) is the correct minimal fix, without additional machinery (named mutex, version bump) that isn't warranted given the actual bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety during ID database initialization.
  * Reduced redundant address calculations for relocation and variant IDs.
  * Improved shared-memory mapping behavior when loading ID data, including clearer handling of existing and newly created mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->