### PR TITLE
fix: ShowInventoryChangeMessage condition

### DIFF
--- a/src/RE/S/SendHUDMessage.cpp
+++ b/src/RE/S/SendHUDMessage.cpp
@@ -23,10 +23,11 @@ namespace RE
 		if (!a_object || !a_count) {
 			return;
 		}
+		a_count = std::abs(a_count);
 
 		const auto        objectName = (a_objectName && a_objectName[0]) ? a_objectName : a_object->GetName();
 		const auto        phrase = a_added ? *"sAddItemtoInventory"_gs : *"sRemoveItemfromInventory"_gs;
-		const std::string message = a_count >= 1 ? std::format("{} {}", objectName, phrase) : std::format("{} ({}) {}", objectName, a_count, phrase);
+		const std::string message = a_count == 1 ? std::format("{} {}", objectName, phrase) : std::format("{} ({}) {}", objectName, a_count, phrase);
 
 		ShowHUDMessage(message.c_str());
 

--- a/src/RE/S/SendHUDMessage.cpp
+++ b/src/RE/S/SendHUDMessage.cpp
@@ -24,8 +24,8 @@ namespace RE
 			return;
 		}
 
-		const auto        objectName = (a_objectName && a_objectName[0]) ? a_objectName : a_object->GetName();
-		const auto        phrase = a_added ? *"sAddItemtoInventory"_gs : *"sRemoveItemfromInventory"_gs;
+		const auto objectName = (a_objectName && a_objectName[0]) ? a_objectName : a_object->GetName();
+		const auto phrase = a_added ? *"sAddItemtoInventory"_gs : *"sRemoveItemfromInventory"_gs;
 		a_count = std::abs(a_count);
 		const std::string message = a_count == 1 ? std::format("{} {}", objectName, phrase) : std::format("{} ({}) {}", objectName, a_count, phrase);
 

--- a/src/RE/S/SendHUDMessage.cpp
+++ b/src/RE/S/SendHUDMessage.cpp
@@ -23,10 +23,10 @@ namespace RE
 		if (!a_object || !a_count) {
 			return;
 		}
-		a_count = std::abs(a_count);
 
 		const auto        objectName = (a_objectName && a_objectName[0]) ? a_objectName : a_object->GetName();
 		const auto        phrase = a_added ? *"sAddItemtoInventory"_gs : *"sRemoveItemfromInventory"_gs;
+		a_count = std::abs(a_count);
 		const std::string message = a_count == 1 ? std::format("{} {}", objectName, phrase) : std::format("{} ({}) {}", objectName, a_count, phrase);
 
 		ShowHUDMessage(message.c_str());

--- a/src/RE/S/SendHUDMessage.cpp
+++ b/src/RE/S/SendHUDMessage.cpp
@@ -26,8 +26,9 @@ namespace RE
 
 		const auto objectName = (a_objectName && a_objectName[0]) ? a_objectName : a_object->GetName();
 		const auto phrase = a_added ? *"sAddItemtoInventory"_gs : *"sRemoveItemfromInventory"_gs;
-		a_count = std::abs(a_count);
-		const std::string message = a_count == 1 ? std::format("{} {}", objectName, phrase) : std::format("{} ({}) {}", objectName, a_count, phrase);
+		// Widen before abs(): abs(INT32_MIN) is UB, since +INT32_MAX+1 doesn't fit back in int32_t.
+		const auto        count = std::abs(static_cast<std::int64_t>(a_count));
+		const std::string message = count == 1 ? std::format("{} {}", objectName, phrase) : std::format("{} ({}) {}", objectName, count, phrase);
 
 		ShowHUDMessage(message.c_str());
 


### PR DESCRIPTION
Just a small fixation to fix the message display condition.
Also added the option to input a negative number for a_count (for removal functions). Could also just leave it user-side to non-negative it before passing it to the function, but since the type is int32_t I thought might as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inventory-change notifications to correctly distinguish single-item changes from multiple-item changes.
  * Inventory quantities now display as positive values in HUD messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->