### PR TITLE
feat(tes): name RUNTIME_DATA2 fields

### DIFF
--- a/include/RE/T/TES.h
+++ b/include/RE/T/TES.h
@@ -8,6 +8,7 @@
 #include "RE/M/MaterialIDs.h"
 #include "RE/N/NiPoint3.h"
 #include "RE/N/NiSmartPointer.h"
+#include "RE/N/NiSourceTexture.h"
 #include "REL/RuntimeDataAccessors.h"
 #include "SKSE/Version.h"
 
@@ -22,12 +23,14 @@ namespace RE
 	class BSTempNodeManager;
 	class GridCellArray;
 	class ImageSpaceModifierInstance;
+	class LoadedAreaBound;
 	class NavMeshInfoMap;
 	class NiAVObject;
 	class NiDirectionalLight;
 	class NiFogProperty;
 	class NiNode;
 	class PlayerCharacter;
+	class QueuedFile;
 	class Sky;
 	class TESLandTexture;
 	class TESNPC;
@@ -126,52 +129,52 @@ namespace RE
 
 		struct RUNTIME_DATA2
 		{
-#define RUNTIME_DATA2_CONTENT                                                              \
-	TESWorldSpace*                                  worldSpace;      /* 140 */             \
-	BSSimpleList<BSTTuple<TESNPC*, std::uint16_t>*> deadCount;       /* 148 */             \
-	void*                                           unk158;          /* 158 - smart ptr */ \
-	void*                                           unk160;          /* 160 - smart ptr */ \
-	void*                                           unk168;          /* 168 - smart ptr */ \
-	void*                                           unk170;          /* 170 - smart ptr */ \
-	std::uint64_t                                   unk178;          /* 178 */             \
-	std::uint64_t                                   unk180;          /* 180 */             \
-	std::uint64_t                                   unk188;          /* 188 */             \
-	std::uint64_t                                   unk190;          /* 190 */             \
-	std::uint64_t                                   unk198;          /* 198 */             \
-	std::uint64_t                                   unk1A0;          /* 1A0 */             \
-	std::uint64_t                                   unk1A8;          /* 1A8 */             \
-	std::uint64_t                                   unk1B0;          /* 1B0 */             \
-	std::uint64_t                                   unk1B8;          /* 1B8 */             \
-	std::uint64_t                                   unk1C0;          /* 1C0 */             \
-	std::uint64_t                                   unk1C8;          /* 1C8 */             \
-	std::uint64_t                                   unk1D0;          /* 1D0 */             \
-	std::uint64_t                                   unk1D8;          /* 1D8 */             \
-	std::uint64_t                                   unk1E0;          /* 1E0 */             \
-	std::uint64_t                                   unk1E8;          /* 1E8 */             \
-	std::uint64_t                                   unk1F0;          /* 1F0 */             \
-	std::uint64_t                                   unk1F8;          /* 1F8 */             \
-	std::uint64_t                                   unk200;          /* 200 */             \
-	std::uint64_t                                   unk208;          /* 208 */             \
-	std::uint64_t                                   unk210;          /* 210 */             \
-	std::uint64_t                                   unk218;          /* 218 */             \
-	std::uint64_t                                   unk220;          /* 220 */             \
-	PlayerCharacter*                                playerCharacter; /* 228 */             \
-	std::uint64_t                                   unk230;          /* 230 */             \
-	std::uint64_t                                   unk238;          /* 238 */             \
-	std::uint64_t                                   unk240;          /* 240 */             \
-	std::uint64_t                                   unk248;          /* 248 */             \
-	std::uint64_t                                   unk250;          /* 250 */             \
-	std::uint64_t                                   unk258;          /* 258 */             \
-	std::uint64_t                                   unk260;          /* 260 */             \
-	std::uint64_t                                   unk268;          /* 268 */             \
-	std::uint64_t                                   unk270;          /* 270 */             \
-	std::uint64_t                                   unk278;          /* 278 */             \
-	std::uint64_t                                   unk280;          /* 280 */             \
-	std::uint64_t                                   unk288;          /* 288 */             \
-	SystemEventAdapter                              unk290;          /* 290 */             \
-	std::uint64_t                                   unk2A0;          /* 2A0 */             \
-	NavMeshInfoMap*                                 unk2A8;          /* 2A8 */             \
-	std::uint64_t                                   unk2B0;          /* 2B0 */
+#define RUNTIME_DATA2_CONTENT                                                                                                                                                 \
+	TESWorldSpace*                                  worldSpace;                        /* 140 */                                                                              \
+	BSSimpleList<BSTTuple<TESNPC*, std::uint16_t>*> deadCount;                         /* 148 */                                                                              \
+	QueuedFile*                                     queuedFaceGenAddonHandle;          /* 158 - refcounted; queues facegen addon-node model/texture swaps */                  \
+	NiPointer<NiSourceTexture>                      bloodDecalTexture;                 /* 160 - lazily loaded "Effects\\blooddecal.dds" */                                    \
+	QueuedFile*                                     queuedFormDataHandle;              /* 168 - refcounted; purpose beyond the handle itself unresolved */                    \
+	QueuedFile*                                     queuedBloodSprayWaterSplashHandle; /* 170 - refcounted; registers blood-spray/water-splash NIFs */                        \
+	std::uint64_t                                   unk178;                            /* 178 */                                                                              \
+	std::uint64_t                                   unk180;                            /* 180 */                                                                              \
+	std::uint64_t                                   unk188;                            /* 188 */                                                                              \
+	std::uint64_t                                   unk190;                            /* 190 */                                                                              \
+	std::uint64_t                                   unk198;                            /* 198 */                                                                              \
+	std::uint64_t                                   unk1A0;                            /* 1A0 */                                                                              \
+	std::uint64_t                                   unk1A8;                            /* 1A8 */                                                                              \
+	std::uint64_t                                   unk1B0;                            /* 1B0 */                                                                              \
+	std::uint64_t                                   unk1B8;                            /* 1B8 */                                                                              \
+	std::uint64_t                                   unk1C0;                            /* 1C0 */                                                                              \
+	std::uint64_t                                   unk1C8;                            /* 1C8 */                                                                              \
+	std::uint64_t                                   unk1D0;                            /* 1D0 */                                                                              \
+	std::uint64_t                                   unk1D8;                            /* 1D8 */                                                                              \
+	std::uint64_t                                   unk1E0;                            /* 1E0 */                                                                              \
+	std::uint64_t                                   unk1E8;                            /* 1E8 */                                                                              \
+	std::uint64_t                                   unk1F0;                            /* 1F0 */                                                                              \
+	std::uint64_t                                   unk1F8;                            /* 1F8 */                                                                              \
+	std::uint64_t                                   unk200;                            /* 200 */                                                                              \
+	std::uint64_t                                   unk208;                            /* 208 */                                                                              \
+	std::uint64_t                                   unk210;                            /* 210 */                                                                              \
+	std::uint64_t                                   unk218;                            /* 218 */                                                                              \
+	std::uint64_t                                   unk220;                            /* 220 */                                                                              \
+	PlayerCharacter*                                playerCharacter;                   /* 228 */                                                                              \
+	std::uint64_t                                   unk230;                            /* 230 */                                                                              \
+	std::uint64_t                                   unk238;                            /* 238 */                                                                              \
+	std::uint64_t                                   unk240;                            /* 240 */                                                                              \
+	std::uint64_t                                   unk248;                            /* 248 */                                                                              \
+	std::uint64_t                                   unk250;                            /* 250 */                                                                              \
+	std::uint64_t                                   unk258;                            /* 258 */                                                                              \
+	std::uint64_t                                   unk260;                            /* 260 */                                                                              \
+	std::uint64_t                                   unk268;                            /* 268 */                                                                              \
+	std::uint64_t                                   unk270;                            /* 270 */                                                                              \
+	std::uint64_t                                   unk278;                            /* 278 - ctor zeroes only bytes 27C-283; real sub-object boundary unresolved */        \
+	std::uint64_t                                   unk280;                            /* 280 - ctor sets only bytes 284-285 to 0x100; real sub-object boundary unresolved */ \
+	void*                                           unk288;                            /* 288 - head of a callback-keyed clone/cache linked list, not a scalar */             \
+	SystemEventAdapter                              unk290;                            /* 290 */                                                                              \
+	std::uint64_t                                   unk2A0;                            /* 2A0 - ctor zeroes only the low 4 bytes; may be two 4-byte sub-fields */             \
+	NavMeshInfoMap*                                 unk2A8;                            /* 2A8 - lazily constructed on first access */                                         \
+	LoadedAreaBound*                                loadedAreaBound;                   /* 2B0 - refcounted */
             RUNTIME_DATA2_CONTENT
 		};
 		static_assert(sizeof(RUNTIME_DATA2) == 0x178);


### PR DESCRIPTION
feat(tes): name RUNTIME_DATA2 fields

RE'd across SE 1.5.97/AE 1.6.1170/VR 1.4.15 (identical field order
and content in all three; AE shifts by the already-known +8 base
offset only). Named 6 of ~30 unnamed fields, cross-checked via 104
TES*-signature functions:

- `queuedFaceGenAddonHandle`/`queuedFormDataHandle`/
  `queuedBloodSprayWaterSplashHandle` (0x158/0x168/0x170) -- refcounted
  `QueuedFile*` handles, confirmed via the alloc+release idiom and
  their model/texture-swap registration call sites.
- `bloodDecalTexture` (0x160) -- confirmed via a decompiled path
  build for "Effects\blooddecal.dds" feeding `BSTextureDB_Demand`.
- `loadedAreaBound` (0x2B0) -- was `uint64_t`, a real type-correction:
  ctor constructs it via the standard refcounted-object swap idiom,
  and a later function calls two methods on it directly as `this`.
- `unk288` -- also a `uint64_t`-to-`void*` type correction: it's the
  head of a callback-keyed clone/cache linked list (insert/lookup/
  cleanup all decompiled), not a scalar. Exact node struct/name still
  unresolved, so left as `void*` with a descriptive comment rather
  than a guessed struct.

`unk278`/`unk280`/`unk2A0` get comments (not renames) noting the
constructor only touches sub-byte-ranges within their declared 8-byte
width -- proof the real sub-object boundaries don't match the current
field split, though the real layout is still unresolved.

The remaining ~24 fields (0x178-0x270) are genuinely exhausted: no
consumer found across every TES public method, the ctor/dtor, both
BSTEventSink overrides, and ~90 unnamed TES::sub_* functions. Known
gap: code reaching these fields through a de-typed pointer, or via
the 660 unwalked direct references to the gTES global, wouldn't
surface in this search -- left as unk* rather than guessed.

Verified clean builds on all/vr/se/ae/flatrim presets and the full
test suite (156 assertions / 34 cases, all pass).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved internal resource handling with more precise tracking for queued files, textures, and loaded area data.
  * Updated runtime data definitions to better reflect the types and relationships of managed resources.
  * Refined blood decal texture and area-bound resource references for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->