### PR TITLE
feat(saveloadmanager): name/retype AE fields

### DIFF
--- a/include/RE/B/BGSSaveLoadManager.h
+++ b/include/RE/B/BGSSaveLoadManager.h
@@ -137,16 +137,16 @@ namespace RE
 		// 1130 and later
 		struct AE_RUNTIME_DATA
 		{
-#define AE_RUNTIME_DATA_CONTENT                                                               \
-	std::uint16_t                                                           unk2B0; /* 2B0 */ \
-	std::uint16_t                                                           unk2B2; /* 2B2 */ \
-	std::uint64_t                                                           unk2B8; /* 2B8 */ \
-	BSTArray<void*>                                                         unk2C0; /* 2C0 */ \
-	BSTArray<void*>                                                         unk2D8; /* 2D8 */ \
-	std::uint8_t                                                            unk2F0; /* 2F0 */ \
-	Thread                                                                  thread; /* 2F8 */ \
-	BSTCommonStaticMessageQueue<BSTSmartPointer<bgs::saveload::Request>, 8> unk370; /* 370 */ \
-	uint64_t                                                                unk3D0; /* 3D0 */
+#define AE_RUNTIME_DATA_CONTENT                                                                                                                                   \
+	std::uint16_t                                                           unk2B0;           /* 2B0 */                                                           \
+	std::uint16_t                                                           unk2B2;           /* 2B2 */                                                           \
+	BGSSaveLoadFileEntry*                                                   pendingSaveEntry; /* 2B8 - single cached/pending entry, separate from saveGameList */ \
+	BSTArray<BSFixedString>                                                 unk2C0;           /* 2C0 - element type confirmed; contents unresolved */             \
+	BSTArray<BSFixedString>                                                 unk2D8;           /* 2D8 - element type confirmed; contents unresolved */             \
+	std::uint8_t                                                            unk2F0;           /* 2F0 */                                                           \
+	Thread                                                                  thread;           /* 2F8 */                                                           \
+	BSTCommonStaticMessageQueue<BSTSmartPointer<bgs::saveload::Request>, 8> unk370;           /* 370 */                                                           \
+	uint64_t                                                                unk3D0;           /* 3D0 */
             AE_RUNTIME_DATA_CONTENT
 		};
 		static_assert(offsetof(AE_RUNTIME_DATA, thread) == 0x48);

--- a/include/RE/B/BGSSaveLoadManager.h
+++ b/include/RE/B/BGSSaveLoadManager.h
@@ -141,8 +141,8 @@ namespace RE
 	std::uint16_t                                                           unk2B0;           /* 2B0 */                                                           \
 	std::uint16_t                                                           unk2B2;           /* 2B2 */                                                           \
 	BGSSaveLoadFileEntry*                                                   pendingSaveEntry; /* 2B8 - single cached/pending entry, separate from saveGameList */ \
-	BSTArray<BSFixedString>                                                 unk2C0;           /* 2C0 - element type confirmed; contents unresolved */             \
-	BSTArray<BSFixedString>                                                 unk2D8;           /* 2D8 - element type confirmed; contents unresolved */             \
+	BSTArray<BSFixedString>                                                 unk2C0;           /* 2C0 */                                                           \
+	BSTArray<BSFixedString>                                                 unk2D8;           /* 2D8 */                                                           \
 	std::uint8_t                                                            unk2F0;           /* 2F0 */                                                           \
 	Thread                                                                  thread;           /* 2F8 */                                                           \
 	BSTCommonStaticMessageQueue<BSTSmartPointer<bgs::saveload::Request>, 8> unk370;           /* 370 */                                                           \
@@ -211,12 +211,12 @@ namespace RE
 		std::uint32_t                   unk2A4;                   // 2A4
 		std::uint64_t                   unk2A8;                   // 2A8
 #if defined(EXCLUSIVE_SKYRIM_AE)                                  // AE 1130 specific change
-		std::uint16_t   unk2B0;                                   // 2B0
-		std::uint16_t   unk2B2;                                   // 2B2
-		std::uint64_t   unk2B8;                                   // 2B8
-		BSTArray<void*> unk2C0;                                   // 2C0
-		BSTArray<void*> unk2D8;                                   // 2D8
-		std::uint8_t    unk2F0;                                   // 2F0
+		std::uint16_t           unk2B0;                           // 2B0
+		std::uint16_t           unk2B2;                           // 2B2
+		BGSSaveLoadFileEntry*   pendingSaveEntry;                 // 2B8
+		BSTArray<BSFixedString> unk2C0;                           // 2C0
+		BSTArray<BSFixedString> unk2D8;                           // 2D8
+		std::uint8_t            unk2F0;                           // 2F0
 #endif
 #if !defined(SKYRIM_CROSS_VR)
 		RUNTIME_DATA_CONTENT;


### PR DESCRIPTION
feat(saveloadmanager): name/retype AE fields

RE'd in AE 1.6.1170 (this block is AE-exclusive, no SE/VR
counterpart). Walked all 43 BGSSaveLoadManager*-signature methods,
Thread's methods, and the BGSSaveLoadManagerEvent sink -- 2 of 6
unnamed fields resolved:

- `unk2B8` (was `uint64_t`) -> `BGSSaveLoadFileEntry* pendingSaveEntry`.
  The teardown routine releases 6 consecutive BSFixedStrings at this
  pointer's target before freeing it at size 0x78 -- matches
  BGSSaveLoadFileEntry's first 6 members and its own sizeof exactly.
- `unk2C0`/`unk2D8` (were `BSTArray<void*>`) ->
  `BSTArray<BSFixedString>`.
  Both are torn down through the identical instantiation of a
  templated array-release helper that calls the real
  `BSFixedString::Release` per element -- confirms the element type,
  though no push/populate site was found so their semantic purpose
  stays unresolved (comment reflects this).

`unk2B0`/`unk2B2`/`unk2F0` remain genuinely exhausted -- not
referenced by any of the checked functions, including 3 that failed
decompilation and were checked via raw-instruction operand scan
instead.

Verified clean builds on all/vr/se/ae/flatrim presets and the full
test suite (156 assertions / 34 cases, all pass).
