### PR TITLE
feat: add LoadedAreaBound header

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -1408,6 +1408,7 @@ set(SOURCES
 	include/RE/L/LoadGameMissingContentCallBack.h
 	include/RE/L/LoadStorageWrapper.h
 	include/RE/L/LoadWaitSpinner.h
+	include/RE/L/LoadedAreaBound.h
 	include/RE/L/LoadingMenu.h
 	include/RE/L/LoadingMenuData.h
 	include/RE/L/LocalMapCamera.h

--- a/include/RE/L/LoadedAreaBound.h
+++ b/include/RE/L/LoadedAreaBound.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "RE/N/NiPoint3.h"
+#include "RE/N/NiRefObject.h"
+#include "RE/N/NiSmartPointer.h"
+#include "REL/Relocation.h"
+
+namespace RE
+{
+	class TESObjectCELL;
+
+	// Tracks the currently-loaded exterior cell and up to 6 neighbor cells,
+	// maintaining a combined AABB and toggling bhkRigidBody collision-response
+	// flags for refs entering/leaving the loaded bound as the player moves.
+	class LoadedAreaBound : public NiRefObject
+	{
+	public:
+		inline static constexpr auto RTTI = RTTI_LoadedAreaBound;
+		inline static constexpr auto VTABLE = VTABLE_LoadedAreaBound;
+
+		~LoadedAreaBound() override;  // 00
+
+		// On cell change, recomputes the AABB from a_cell and propagates it to
+		// the neighbor cells' Havok worlds; on nullptr, calls Clear() instead.
+		void SetCurrentCell(TESObjectCELL* a_cell)
+		{
+			using func_t = decltype(&LoadedAreaBound::SetCurrentCell);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(25415, 25946) };
+			func(this, a_cell);
+		}
+
+		// Releases the neighbor-cell/entry state and resets cachedCell/counts.
+		void Clear()
+		{
+			using func_t = decltype(&LoadedAreaBound::Clear);
+			static REL::Relocation<func_t> func{ RELOCATION_ID(25416, 25947) };
+			func(this);
+		}
+
+		// members
+		NiPointer<NiRefObject> neighborCells[6];  // 10 - suspected NiPointer<TESObjectCELL>[6]; pointee type unconfirmed
+		TESObjectCELL*         cachedCell;        // 40
+		std::uint8_t           flags;             // 48 - bit0 gates a "playable"-cell special case
+		std::uint8_t           unk49[0xB];        // 49
+		std::uint32_t          unk54;             // 54 - count; mirrors unk58/unk5C after a clear
+		std::uint32_t          unk58;             // 58
+		std::uint32_t          unk5C;             // 5C
+		void*                  bucketArray;       // 60 - embedded hash/scatter-table; ctor sets a static "empty" sentinel
+		std::uint8_t           unk68[8];          // 68
+		void*                  entries;           // 70 - heap array of 0x18-byte entries (refcounted sub-pointer at +0x10); tracks toggled bhkRigidBody handles
+		NiPoint3               boundsMin;         // 78
+		NiPoint3               boundsMax;         // 84
+		float                  marginX;           // 90 - per-axis padding constant, passed in at construction
+		float                  marginY;           // 94
+		float                  marginZ;           // 98
+		float                  marginW;           // 9C
+	};
+	static_assert(sizeof(LoadedAreaBound) == 0xA0);
+}

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -1410,6 +1410,7 @@
 #include "RE/L/LoadGameMissingContentCallBack.h"
 #include "RE/L/LoadStorageWrapper.h"
 #include "RE/L/LoadWaitSpinner.h"
+#include "RE/L/LoadedAreaBound.h"
 #include "RE/L/LoadingMenu.h"
 #include "RE/L/LoadingMenuData.h"
 #include "RE/L/LocalMapCamera.h"


### PR DESCRIPTION
feat: add LoadedAreaBound header

RE'd across SE 1.5.97/AE 1.6.1170/VR 1.4.15 -- identical layout and
0xA0 size in all three, no divergence (rare for a fully-stable,
non-VR-specific-offset case). Discovered as a forward-declared-only
type referenced by TES::loadedAreaBound during the recent
TES::RUNTIME_DATA2 pass (#264).

Confirmed non-virtual public NiRefObject subclass (2-slot vtable:
scalar-deleting dtor, inherited NiRefObject::Delete, no new virtuals).
Tracks the currently-loaded exterior cell plus up to 6 neighbor cells,
maintaining a combined AABB and toggling bhkRigidBody collision
flags as the player moves -- confirmed via the ctor's full field
layout and two decompiled methods (a cell-update entry point and a
clear/reset routine), cross-checked against SE/AE.

Left three areas honestly unresolved rather than guessed: the 6-slot
smart-pointer array's pointee type (strong circumstantial evidence
for TESObjectCELL, not a confirmed type anchor), an embedded
hash/scatter-table at 0x48-0x7F (behaves like a set of toggled
bhkRigidBody handles, concrete element type/container identity
unresolved), and the two real non-virtual methods themselves (not
declared in the header -- no address-library id resolved yet for
either).

Follow-on candidates surfaced but not chased, for a future pass:
- Two more TES-region callers of the clear/reset routine, likely
  cell-detach/world-reset logic, worth naming.
- One unnamed function in the same compiland calling into this
  class's collision-toggle logic -- may be an unlabeled method.
- The embedded container's insert/lookup logic, which could resolve
  to a known BSTHashMap/BSTSet-style template instead of a bespoke
  structure with a dedicated pass.
- Several large Havok-heavy helper functions (broadphase/collision
  toggle against bhkWorld/ahkpWorld) referenced but not fully walked.

Verified clean builds on all/vr/se/ae/flatrim presets and the full
test suite (156 assertions / 34 cases, all pass). Does not touch
TES.h since #264 (which introduces the LoadedAreaBound forward decl)
hasn't merged yet -- wiring TES::loadedAreaBound to this real type is
a follow-up once that lands.

Adds callable relocation thunks for `SetCurrentCell(TESObjectCELL*)`
and `Clear()`, using real SE/AE/VR addresses and address-library ids
resolved this pass (SE 25415/25416, AE 25946/25947), registered in
alandtse/skyrim_vr_address_library#156. Anchored on the confirmed
ctor/dtor addresses across all three runtimes, then cross-checked by
decompiling both methods directly in SE/AE and confirming identical
logic/field offsets to VR (accounting for the extra VR field already
noted in the layout).


**Correction (CodeRabbit, same pass):** `neighborCells` used
`BSTSmartPointer<NiRefObject>`, but that template calls
`IncRef()`/`DecRef()` while `NiRefObject` only exposes
`IncRefCount()`/`DecRefCount()` -- a real interface mismatch that a
plain build doesn't catch, since the array's own destructor/copy
logic is never instantiated unless something actually constructs or
destroys a `LoadedAreaBound`. Switched to `NiPointer<NiRefObject>`,
which uses the matching `*Count()` interface; verified by explicitly
force-instantiating the template (`template class
NiPointer<NiRefObject>;`) in a throwaway build, then reverting that
instrumentation once confirmed clean.
