### PR TITLE
feat: add BSTask header

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -437,6 +437,7 @@ set(SOURCES
 	include/RE/B/BSTSingleton.h
 	include/RE/B/BSTSmartPointer.h
 	include/RE/B/BSTTuple.h
+	include/RE/B/BSTask.h
 	include/RE/B/BSTaskletData.h
 	include/RE/B/BSTempEffect.h
 	include/RE/B/BSTempEffectDebris.h

--- a/include/RE/B/BSTask.h
+++ b/include/RE/B/BSTask.h
@@ -35,7 +35,7 @@ namespace RE
 		};
 		static_assert(sizeof(VR_RUNTIME_DATA) == 0xC);
 
-		RUNTIME_DATA_ACCESSOR(RUNTIME_DATA, 0x18, 0x0);
+		RUNTIME_DATA_ACCESSOR(RUNTIME_DATA, 0x18, 0x20);
 		VR_ONLY_POINTER_ACCESSOR(VR_RUNTIME_DATA, GetVRRuntimeData, 0x18);
 
 		// members

--- a/include/RE/B/BSTask.h
+++ b/include/RE/B/BSTask.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "REL/RuntimeDataAccessors.h"
+
+namespace RE
+{
+	class BSTask
+	{
+	public:
+		inline static constexpr auto RTTI = RTTI_BSTask;
+		inline static constexpr auto VTABLE = VTABLE_BSTask;
+
+		virtual ~BSTask() = default;       // 00
+		virtual void Unk_01() { return; }  // 01
+		virtual void Unk_02() { return; }  // 02
+		virtual void Unk_03() { return; }  // 03
+		virtual void Unk_04() { return; }  // 04
+
+		// VR inserts 8 unidentified bytes here instead of appending a trailing
+		// tail, shifting the following field by +8.
+		struct RUNTIME_DATA
+		{
+#define RUNTIME_DATA_CONTENT \
+	std::int32_t threadDepthMarker; /* 18 - set from a TLS slot during construction */
+			RUNTIME_DATA_CONTENT
+		};
+		static_assert(sizeof(RUNTIME_DATA) == 0x4);
+
+		struct VR_RUNTIME_DATA
+		{
+#define VR_RUNTIME_DATA_CONTENT                                                                                       \
+	std::uint8_t unk18[8];          /* 18 - VR-only insertion; byte 0 is zeroed at construction, rest unidentified */ \
+	std::int32_t threadDepthMarker; /* 20 - set from a TLS slot during construction */
+			VR_RUNTIME_DATA_CONTENT
+		};
+		static_assert(sizeof(VR_RUNTIME_DATA) == 0xC);
+
+		RUNTIME_DATA_ACCESSOR(RUNTIME_DATA, 0x18, 0x0);
+		VR_ONLY_POINTER_ACCESSOR(VR_RUNTIME_DATA, GetVRRuntimeData, 0x18);
+
+		// members
+		std::int32_t  refCount;  // 08
+		std::uint32_t unk0C;     // 0C
+		std::uint8_t  unk10[2];  // 10
+		std::uint8_t  priority;  // 12 - task priority/type byte
+		std::uint8_t  unk13[5];  // 13
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+		RUNTIME_DATA_CONTENT;  // 18
+#elif defined(EXCLUSIVE_SKYRIM_VR)
+		VR_RUNTIME_DATA_CONTENT;  // 18
+#endif
+	};
+#undef RUNTIME_DATA_CONTENT
+#undef VR_RUNTIME_DATA_CONTENT
+	STATIC_ASSERT_SIZE(BSTask, 0x20, 0x28);
+}

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -439,6 +439,7 @@
 #include "RE/B/BSTSingleton.h"
 #include "RE/B/BSTSmartPointer.h"
 #include "RE/B/BSTTuple.h"
+#include "RE/B/BSTask.h"
 #include "RE/B/BSTaskletData.h"
 #include "RE/B/BSTempEffect.h"
 #include "RE/B/BSTempEffectDebris.h"


### PR DESCRIPTION
## Summary
- RE'd across SE 1.5.97/AE 1.6.1170/VR 1.4.15 while chasing `QueuedFile`'s SE/AE-vs-VR size delta
- VR inserts 8 unidentified zeroed bytes at offset 0x18 (confirmed via raw pcode on the ctor, not just typed decompile), shifting the TLS-derived `threadDepthMarker` field from 0x18 (SE/AE) to 0x20 (VR); `sizeof(BSTask)` is 0x20 SE/AE, 0x28 VR
- 5-slot vtable: only slot 0 (destructor) has direct evidence; slots 1-4 are unconfirmed stubs
- `refCount` (0x08) confirmed via the atomic incref/decref idiom at every release site; `priority` (0x12) confirmed via the identical `(priority<<16) | ...` write at all 3 `TES` queuing call sites

## Test plan
- [x] Built vr/se/ae/flatrim/all presets clean
- [x] `CommonLibSSETests.exe`: all 156 assertions in 34 test cases pass