### PR TITLE
feat(tes): add SetCurrentCell

### DIFF
--- a/include/RE/T/TES.h
+++ b/include/RE/T/TES.h
@@ -86,6 +86,14 @@ namespace RE
 		NiAVObject*     Pick(bhkPickData& a_pickData);
 		void            PurgeBufferedCells();
 
+		// Post-load finalization: clears the cached LoadedAreaBound and fixes
+		// up stale high-process-actor cell/animgraph references.
+		void FinishLoad();
+
+		// Core interior/exterior cell-transition engine backing every cell
+		// attach/detach (interior enter/exit, coc, worldspace load).
+		void SetCurrentCell(TESObjectCELL* a_cell, const NiPoint3& a_position, float a_unk4);
+
 		struct RUNTIME_DATA
 		{
 #define RUNTIME_DATA_CONTENT                     \

--- a/include/RE/T/TES.h
+++ b/include/RE/T/TES.h
@@ -86,10 +86,6 @@ namespace RE
 		NiAVObject*     Pick(bhkPickData& a_pickData);
 		void            PurgeBufferedCells();
 
-		// Post-load finalization: clears the cached LoadedAreaBound and fixes
-		// up stale high-process-actor cell/animgraph references.
-		void FinishLoad();
-
 		// Core interior/exterior cell-transition engine backing every cell
 		// attach/detach (interior enter/exit, coc, worldspace load).
 		void SetCurrentCell(TESObjectCELL* a_cell, const NiPoint3& a_position, float a_unk4);

--- a/src/RE/T/TES.cpp
+++ b/src/RE/T/TES.cpp
@@ -211,13 +211,6 @@ namespace RE
 		return func(this);
 	}
 
-	void TES::FinishLoad()
-	{
-		using func_t = decltype(&TES::FinishLoad);
-		static REL::Relocation<func_t> func{ RELOCATION_ID(13230, 13381) };
-		return func(this);
-	}
-
 	void TES::SetCurrentCell(TESObjectCELL* a_cell, const NiPoint3& a_position, float a_unk4)
 	{
 		using func_t = decltype(&TES::SetCurrentCell);

--- a/src/RE/T/TES.cpp
+++ b/src/RE/T/TES.cpp
@@ -210,4 +210,18 @@ namespace RE
 		static REL::Relocation<func_t> func{ RELOCATION_ID(13159, 13299) };
 		return func(this);
 	}
+
+	void TES::FinishLoad()
+	{
+		using func_t = decltype(&TES::FinishLoad);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(13230, 13381) };
+		return func(this);
+	}
+
+	void TES::SetCurrentCell(TESObjectCELL* a_cell, const NiPoint3& a_position, float a_unk4)
+	{
+		using func_t = decltype(&TES::SetCurrentCell);
+		static REL::Relocation<func_t> func{ RELOCATION_ID(13171, 13316) };
+		return func(this, a_cell, a_position, a_unk4);
+	}
 }


### PR DESCRIPTION
## Summary

- `TES::SetCurrentCell(TESObjectCELL*, const NiPoint3&, float)` — the actual
  cell-attach/detach engine backing every cell transition (interior enter/exit,
  coc, worldspace load); confirmed via the `coc` console handler call site.
- Confirms `TES::unk2B0` (RUNTIME_DATA2, offset 0x2B0) is genuinely a
  `LoadedAreaBound*`, consistent with #264/#266.
- Also corrected a mislabeled address-library entry found along the way: id
  13171 was tagged with a third-party mod's own namespace instead of this
  engine function — fixed upstream in
  alandtse/skyrim_vr_address_library#157.

RE'd while following up on `LoadedAreaBound`'s two unexplored TES callers
(both were vague `sub_*` symbols calling `LoadedAreaBound::Clear()`). The
other caller, `FinishLoad()`, was also RE'd and its id registered
(id 13230 in `skyrim_vr_address_library#157`), but it is not exposed here —
its only two callers are internal load-lifecycle finalization
(`FinishLoadGlobalData`/`FinishLoadGlobalData_LoadGame`) with no supported
external call site.

## Test plan

- [x] `all`/`vr`/`se`/`ae`/`flatrim` CMake presets build clean
- [x] Full test suite passes (156 assertions / 34 cases)
