### PR TITLE
feat: add IOTask header

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -1337,6 +1337,7 @@ set(SOURCES
 	include/RE/I/INIPrefSettingCollection.h
 	include/RE/I/INISettingCollection.h
 	include/RE/I/IOManager.h
+	include/RE/I/IOTask.h
 	include/RE/I/IObjectHandlePolicy.h
 	include/RE/I/IObjectProcessor.h
 	include/RE/I/IPackageData.h

--- a/include/RE/I/IOTask.h
+++ b/include/RE/I/IOTask.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "RE/B/BSTSmartPointer.h"
+#include "RE/B/BSTask.h"
+
+namespace RE
+{
+	class QueuedFile;
+
+	class IOTask : public BSTask
+	{
+	public:
+		inline static constexpr auto RTTI = RTTI_IOTask;
+		inline static constexpr auto VTABLE = VTABLE_IOTask;
+
+		~IOTask() override;  // 00
+
+		// add
+		virtual void Unk_05() { return; }  // 05
+		virtual void Unk_06() { return; }  // 06
+		virtual void Unk_07() { return; }  // 07
+		virtual void Unk_08() { return; }  // 08 - overridden by QueuedFile as NotifyChildrenAndFinalize: recursively invokes this same slot on every child, then notifies IOManager
+
+		// VR inherits BSTask's own +8-byte insertion, shifting this tail by +8.
+		struct RUNTIME_DATA
+		{
+#define RUNTIME_DATA_CONTENT                                                                                                                        \
+	BSTSmartPointer<QueuedFile> dependency; /* 20 - related/dependency task; may be null */                                                         \
+	void*                       children;   /* 28 - pointer to a child-tracking object (finishedCount + a child-task array); null when childless */ \
+	std::int32_t                state;      /* 30 - task state; see QueuedFile::ProcessStateMachine */
+            RUNTIME_DATA_CONTENT
+		};
+		static_assert(sizeof(RUNTIME_DATA) == 0x18);
+
+		struct VR_RUNTIME_DATA
+		{
+#define VR_RUNTIME_DATA_CONTENT                                                                                                                     \
+	BSTSmartPointer<QueuedFile> dependency; /* 28 - related/dependency task; may be null */                                                         \
+	void*                       children;   /* 30 - pointer to a child-tracking object (finishedCount + a child-task array); null when childless */ \
+	std::int32_t                state;      /* 38 - task state; see QueuedFile::ProcessStateMachine */
+            VR_RUNTIME_DATA_CONTENT
+		};
+		static_assert(sizeof(VR_RUNTIME_DATA) == 0x18);
+
+		RUNTIME_DATA_ACCESSOR(RUNTIME_DATA, 0x20, 0x0);
+		VR_ONLY_POINTER_ACCESSOR(VR_RUNTIME_DATA, GetVRRuntimeData, 0x28);
+
+		// members
+#if defined(EXCLUSIVE_SKYRIM_FLAT)
+		RUNTIME_DATA_CONTENT;  // 20
+#elif defined(EXCLUSIVE_SKYRIM_VR)
+		VR_RUNTIME_DATA_CONTENT;  // 28
+#endif
+	};
+#undef RUNTIME_DATA_CONTENT
+#undef VR_RUNTIME_DATA_CONTENT
+	STATIC_ASSERT_SIZE(IOTask, 0x38, 0x40);
+}

--- a/include/RE/I/IOTask.h
+++ b/include/RE/I/IOTask.h
@@ -19,7 +19,7 @@ namespace RE
 		virtual void Unk_05() { return; }  // 05
 		virtual void Unk_06() { return; }  // 06
 		virtual void Unk_07() { return; }  // 07
-		virtual void Unk_08() { return; }  // 08 - overridden by QueuedFile as NotifyChildrenAndFinalize: recursively invokes this same slot on every child, then notifies IOManager
+		virtual void Unk_08() { return; }  // 08
 
 		// VR inherits BSTask's own +8-byte insertion, shifting this tail by +8.
 		struct RUNTIME_DATA

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -1339,6 +1339,7 @@
 #include "RE/I/INIPrefSettingCollection.h"
 #include "RE/I/INISettingCollection.h"
 #include "RE/I/IOManager.h"
+#include "RE/I/IOTask.h"
 #include "RE/I/IObjectHandlePolicy.h"
 #include "RE/I/IObjectProcessor.h"
 #include "RE/I/IPackageData.h"


### PR DESCRIPTION
## Summary
- RE'd across SE 1.5.97/AE 1.6.1170/VR 1.4.15; derives from `BSTask` (#267) -- own tail doesn't diverge in shape between runtimes, just shifts by `BSTask`'s own +8 (0x20 SE/AE -> 0x28 VR)
- Fields: `BSTSmartPointer<QueuedFile> dependency` (confirmed via incref/decref/store idiom, and every `QueuedFile`-derived ctor accepting a sibling `QueuedFile*` at the same argument position), plus 12 bytes zeroed at construction with no reader found -- left unnamed rather than guessed
- 9-slot vtable (5 inherited from `BSTask`, destructor overridden, slots 5-7 new trivial stubs, slot 8 new and later overridden by `QueuedFile`) -- none named beyond the destructor

## Test plan
- [x] Built vr/se/ae/flatrim/all presets clean
- [x] `CommonLibSSETests.exe`: all 156 assertions in 34 test cases pass

Based on #267 (`BSTask`) since `IOTask` publicly inherits it -- depends on that PR merging first.