### PR TITLE
feat: add IOManager header

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -1331,6 +1331,7 @@ set(SOURCES
 	include/RE/I/IMovementState.h
 	include/RE/I/INIPrefSettingCollection.h
 	include/RE/I/INISettingCollection.h
+	include/RE/I/IOManager.h
 	include/RE/I/IObjectHandlePolicy.h
 	include/RE/I/IObjectProcessor.h
 	include/RE/I/IPackageData.h

--- a/include/RE/I/IOManager.h
+++ b/include/RE/I/IOManager.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "RE/B/BSTEvent.h"
+#include "RE/I/IMemoryHeap.h"
+#include "RE/N/NiSmartPointer.h"
+
+namespace RE
+{
+	class BSTask;
+
+	// Real event-sink payload type is unresolved; only used here as the template
+	// argument for the embedded BSTEventSource, never dereferenced.
+	class BSTaskManagerWaitAction;
+
+	// Global io-task scheduler; owns the resubmit/notify dispatch called by
+	// BSQueuedResourceCollectionBase::Unk_09/Unk_11. Real inheritance is
+	// SynchronizedMap<int64,NiPointer<BSTask>> -> BSTaskManager -> IOManager,
+	// modeled flatly since BSTaskManager adds no fields of its own.
+	class IOManager
+	{
+	public:
+		static IOManager* GetSingleton()
+		{
+			static REL::Relocation<IOManager**> singleton{ RELOCATION_ID(524542, 411121) };
+			return *singleton;
+		}
+
+		virtual ~IOManager();  // 00
+
+		// add (SynchronizedMap<std::int64_t, NiPointer<BSTask>> base)
+		virtual void Unk_01() { return; }  // 01
+		virtual void Unk_02() { return; }  // 02
+
+		// add (SynchronizedMap base; not overridden by IOManager)
+		virtual bool          FindOrInsert(std::int64_t a_key, NiPointer<BSTask>& a_value, IMemoryHeap* a_heap, bool a_skipDuplicates);        // 03
+		virtual bool          FindOrInsertByHash(std::int64_t a_key, NiPointer<BSTask>& a_value, IMemoryHeap* a_heap, bool a_skipDuplicates);  // 04 - like 03, but hashes the key itself
+		virtual bool          Unk_05(BSTask* a_task);                                                                                          // 05 - predicate gating NotifyTaskComplete's decrement; real signature may take more args than modeled here
+		virtual bool          Erase(std::int64_t a_key, NiPointer<BSTask>& a_valueOut);                                                        // 06
+		virtual bool          FindFirstMatching(NiPointer<BSTask>& a_valueOut);                                                                // 07 - calls 06 with increasing indices until it returns true
+		virtual std::uint32_t Unk_08(std::uint64_t a_packed);                                                                                  // 08 - bucket index = byte0 + byte1*4 of a packed 2-byte key (base class instead does key % bucketCount)
+
+		// add (SynchronizedMap base)
+		virtual void Unk_09() { return; }  // 09
+		virtual void Unk_10() { return; }  // 10 - real signature takes unmodeled args; not yet reconstructed
+		virtual void Unk_11() { return; }  // 11 - real signature takes unmodeled args; not yet reconstructed
+		virtual void Unk_12() { return; }  // 12 - real signature takes unmodeled args; not yet reconstructed
+		virtual void Unk_13() { return; }  // 13 - real signature takes unmodeled args; not yet reconstructed
+		virtual void Unk_14() { return; }  // 14 - increments the counter at +0x30
+		virtual void Unk_15() { return; }  // 15 - decrements the counter at +0x30
+		virtual void Unk_16() { return; }  // 16 - reads the counter at +0x30
+
+		// add (BSTaskManager base)
+		virtual void ResubmitTask(BSTask* a_task);  // 17 - called by BSQueuedResourceCollectionBase::Unk_09
+
+		// add (BSTaskManager base; slot 24 is IOManager's own, BSTaskManager has no slot 24)
+		virtual void Unk_18() { return; }  // 18 - real signature takes unmodeled args; not yet reconstructed
+		virtual void Unk_19() { return; }  // 19 - real signature takes unmodeled args; not yet reconstructed
+		virtual void Unk_20() { return; }  // 20 - drains pending tasks synchronously; IOManager runs extra work after the base drain
+		virtual void Unk_21() { return; }  // 21 - drains and finalizes a list of BSResource::EntryDB entries
+		virtual void Unk_22() { return; }  // 22 - clears a shared flag when not the primary loading thread
+		virtual void Unk_23() { return; }  // 23
+		virtual void Unk_24() { return; }  // 24 - sets the same shared flag slot 22 clears
+
+		// members
+		void NotifyTaskComplete(BSTask* a_task);  // non-virtual; dispatches Unk_08 then Unk_05 to gate a per-bucket decrement
+
+		// SynchronizedMap<std::int64_t, NiPointer<BSTask>> base fields (08-40);
+		// BSTaskManager itself adds no further fields of its own.
+		void*                                   nodePool;         // 08 - pool of preallocated 24-byte nodes (next/key/value), sized threadCount+16
+		std::uint32_t                           bucketCount;      // 10 - 24 in this instantiation
+		std::uint32_t                           unk14;            // 14
+		void*                                   bucketHeads;      // 18 - bucketCount head pointers
+		std::uint32_t                           unk20;            // 20 - per-bucket capacity
+		std::uint32_t                           pad24;            // 24
+		std::uint8_t                            threadCache[24];  // 28 - per-thread lookup cache; contains a Mutex at +0xC guarding all mutating ops
+		BSTEventSource<BSTaskManagerWaitAction> events;           // 40
+		std::uint8_t                            unk98[144];       // 98 - includes a per-bucket int32 array + counter (+0xB0/+0xB8), a BSTArrayHeapAllocator (+0xC0), and a thread-pool-size constant = 6 (+0xE8)
+	};
+	static_assert(sizeof(IOManager) == 0x128);
+}

--- a/include/RE/I/IOManager.h
+++ b/include/RE/I/IOManager.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include "RE/B/BSTEvent.h"
-#include "RE/I/IMemoryHeap.h"
-#include "RE/N/NiSmartPointer.h"
 
 namespace RE
 {
@@ -31,13 +29,13 @@ namespace RE
 		virtual void Unk_01() { return; }  // 01
 		virtual void Unk_02() { return; }  // 02
 
-		// add (SynchronizedMap base; not overridden by IOManager)
-		virtual bool          FindOrInsert(std::int64_t a_key, NiPointer<BSTask>& a_value, IMemoryHeap* a_heap, bool a_skipDuplicates);        // 03
-		virtual bool          FindOrInsertByHash(std::int64_t a_key, NiPointer<BSTask>& a_value, IMemoryHeap* a_heap, bool a_skipDuplicates);  // 04 - like 03, but hashes the key itself
-		virtual bool          Unk_05(BSTask* a_task);                                                                                          // 05 - predicate gating NotifyTaskComplete's decrement; real signature may take more args than modeled here
-		virtual bool          Erase(std::int64_t a_key, NiPointer<BSTask>& a_valueOut);                                                        // 06
-		virtual bool          FindFirstMatching(NiPointer<BSTask>& a_valueOut);                                                                // 07 - calls 06 with increasing indices until it returns true
-		virtual std::uint32_t Unk_08(std::uint64_t a_packed);                                                                                  // 08 - bucket index = byte0 + byte1*4 of a packed 2-byte key (base class instead does key % bucketCount)
+		// add (SynchronizedMap base; not overridden by IOManager, no external call site)
+		virtual void Unk_03() { return; }  // 03 - FindOrInsert
+		virtual void Unk_04() { return; }  // 04 - FindOrInsertByHash; like 03, but hashes the key itself
+		virtual void Unk_05() { return; }  // 05 - predicate gating NotifyTaskComplete's decrement
+		virtual void Unk_06() { return; }  // 06 - Erase
+		virtual void Unk_07() { return; }  // 07 - FindFirstMatching; calls 06 with increasing indices until it returns true
+		virtual void Unk_08() { return; }  // 08 - bucket index = byte0 + byte1*4 of a packed 2-byte key (base class instead does key % bucketCount)
 
 		// add (SynchronizedMap base)
 		virtual void Unk_09() { return; }  // 09
@@ -61,8 +59,8 @@ namespace RE
 		virtual void Unk_23() { return; }  // 23
 		virtual void Unk_24() { return; }  // 24 - sets the same shared flag slot 22 clears
 
-		// members
-		void NotifyTaskComplete(BSTask* a_task);  // non-virtual; dispatches Unk_08 then Unk_05 to gate a per-bucket decrement
+		// NotifyTaskComplete omitted: non-virtual, purely internal bucket-decrement
+		// bookkeeping (dispatches Unk_08 then Unk_05), no external call site.
 
 		// SynchronizedMap<std::int64_t, NiPointer<BSTask>> base fields (08-40);
 		// BSTaskManager itself adds no further fields of its own.

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -1333,6 +1333,7 @@
 #include "RE/I/IMovementState.h"
 #include "RE/I/INIPrefSettingCollection.h"
 #include "RE/I/INISettingCollection.h"
+#include "RE/I/IOManager.h"
 #include "RE/I/IObjectHandlePolicy.h"
 #include "RE/I/IObjectProcessor.h"
 #include "RE/I/IPackageData.h"


### PR DESCRIPTION
## Summary
- Global io-task scheduler; backs `BSQueuedResourceCollectionBase::Unk_09/Unk_11`'s resubmit/notify dispatch (`ResubmitTask`/`NotifyTaskComplete`)
- Constructed inline by TES's own constructor rather than a `GetSingleton()`-style factory; bound here via the raw global pointer the engine stores its result to
- Real inheritance is `SynchronizedMap<int64,NiPointer<BSTask>>` -> `BSTaskManager` -> `IOManager` (confirmed via each level's ctor overwriting the shared vfptr after calling its base ctor); modeled flatly here since `BSTaskManager` contributes no fields of its own and neither intermediate class has a standalone header yet
- `BSTaskManager`'s own vtable is 24 slots (0-23), confirmed by reading past slot 23 into RTTI string data in both SE and VR; `IOManager` adds one genuinely new virtual (24) plus overrides 8, 17, 20, 21, 22 -- all confirmed via direct byte comparison against `BSTaskManager`'s own vtable, not vtable-dump inference. Slots 18/19/23 are confirmed NOT overridden despite differing addresses looking plausible at a glance
- Most base-class slot bodies remain genuinely unconfirmed and are documented as such (with behavioral shape notes where available) rather than assumed no-ops
- Confirmed identical 0x128 size across SE/AE/VR; embeds a `BSTEventSource<BSTaskManagerWaitAction>` matching an existing template exactly at its native offset

## Test plan
- [x] Built vr/se/ae/flatrim/all debug-clang-cl-vcpkg presets clean
- [x] `CommonLibSSETests.exe`: all 156 assertions in 34 test cases pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public task and I/O management interface via a new `IOManager` component.
  * Supports task lookup/insertion/removal, hash-based lookup, task matching, and resubmission/completion notification.
  * Exposed the new interface through the primary `Skyrim` header.
* **Build**
  * Updated build header inputs to include the new `IOManager` header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->