### PR TITLE
fix(actor): LocalMap key comparison off-by-one

### DIFF
--- a/include/RE/A/Actor.h
+++ b/include/RE/A/Actor.h
@@ -110,11 +110,14 @@ namespace RE
 		private:
 			[[nodiscard]] T* GetAt(char a_actorValue) const
 			{
-				auto akVals = actorValues.data();
+				// keys are stored as (actorValue + 1) so that 0 can terminate the
+				// C-string; see SetBaseValue/GetBaseValue in the game binary.
+				const auto key = static_cast<char>(a_actorValue + 1);
+				auto       akVals = actorValues.data();
 				if (akVals && entries) {
 					std::uint32_t idx = 0;
 					while (akVals[idx] != '\0') {
-						if (akVals[idx] == a_actorValue) {
+						if (akVals[idx] == key) {
 							break;
 						}
 						++idx;


### PR DESCRIPTION
LocalMap<T>::GetAt compared the raw ActorValue against the stored key
byte, but keys are stored as `actorValue + 1` (so `0` can terminate the
BSFixedString key list). This caused GetAt to match the wrong slot or
find nothing at all.

Verified via Ghidra decompile of SetBaseValue/GetBaseValue in all three
runtimes (SE 1.5.97, AE 1.6.1170, VR 1.4.15): each stores/compares the
key as `actorValue + 1` (e.g. VR: `bVar10 = in_DL + 1;` ...
`bVar3 != (byte)(av + 1)`).

Fix: decode the key with the same `+1` offset before comparing in
GetAt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed lookup behavior for actor values in local storage.
  - Actor value data can now be retrieved reliably when stored keys use the internal offset format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->