### PR TITLE
fix(bsbatchrenderer): correct 0x58-0x70 layout

### DIFF
--- a/include/RE/B/BSBatchRenderer.h
+++ b/include/RE/B/BSBatchRenderer.h
@@ -59,9 +59,11 @@ namespace RE
 		std::uint64_t                       unk48;                // 048
 		std::uint32_t                       currentFirstPass;     // 050
 		std::uint32_t                       currentLastPass;      // 054
-		BSSimpleList<uint32_t>              activePassIndexList;  // 060
-		std::uint32_t                       groupingAlphasCount;  // 064
-		bool                                autoClearPasses;      // 068
+		BSSimpleList<uint32_t>              activePassIndexList;  // 058  head node embedded: item 058, next 060
+		std::uint32_t                       groupingAlphasCount;  // 068
+		bool                                autoClearPasses;      // 06C
+		std::uint8_t                        pad06D;               // 06D
+		std::uint16_t                       pad06E;               // 06E
 		GeometryGroup*                      geometryGroups[16];   // 070
 		GeometryGroup*                      alphaGroup;           // 0F0
 		void*                               unk0F8;               // 0F8


### PR DESCRIPTION
`activePassIndexList` was declared at 0x060, so its 0x10-byte `BSSimpleList` overlapped both `groupingAlphasCount` (0x064) and `autoClearPasses` (0x068) — three members sharing bytes.

Re-derived from the binary (SE 1.5.97 and AE 1.6.1170, structurally identical):

| offset | member | evidence |
| --- | --- | --- |
| 0x058 | `BSSimpleList<uint32_t> activePassIndexList` (head node embedded: item 0x058, next 0x060) | callers do `LEA reg,[this+0x58]` then walk `[reg]` / `[reg+8]` (SE `0x14130797e`, `0x14130859f`; AE `0x1414f32b0`, `0x1414f41af`); pop-front writes both (SE `0x141307f05`/`0x141307f0b`); dtor frees 0x10-byte nodes and clears `[this+0x58]` (SE `0x141306eca`/`0x141306ee1`); ctor zeroes both (SE `0x1413063a3`/`0x1413063a7`, AE `0x1414f1c9b`/`0x1414f1c9e`) |
| 0x068 | `std::uint32_t groupingAlphasCount` | `INC dword [this+0x68]` in `StartGroupingAlphas` (SE `0x141309340`, AE `0x1414f51cc`); saturating decrement in the paired helper (SE `0x1413093a9`) |
| 0x06C | `bool autoClearPasses` | ctor stores byte `1` (SE `0x1413063ab`, AE `0x1414f1ca2`); tested as a byte before popping/clearing passes (SE `0x141307ef2`, `0x141307cb5`, `0x1413082ea`) |

Nothing in either binary touches 0x064 as a field; it is the padding inside the list head node.

`sizeof(BSBatchRenderer)` is unchanged at 0x108, so the existing `static_assert` still holds.

VR 1.4.15 was not verified — its executable is not analyzable in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuM742GiWFKuK1c7DgwYTi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected internal rendering state alignment to improve batch rendering reliability.
  * Added safeguards for updated rendering data layout and pass-clearing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->