### PR TITLE
fix(lightning): add BSTEventSource base at 0x48

### DIFF
--- a/include/RE/B/BSProceduralGeomEvent.h
+++ b/include/RE/B/BSProceduralGeomEvent.h
@@ -2,13 +2,15 @@
 
 namespace RE
 {
-	class NiAVObject;
+	class BSDynamicTriShape;
 
+	// Sent by BSProceduralLightningController after it rebuilds its bolt mesh;
+	// the payload is a copy of that controller's own geometry member.
 	struct BSProceduralGeomEvent
 	{
 	public:
 		// members
-		NiAVObject* geometry;  // 00
+		BSDynamicTriShape* geometry;  // 00
 	};
 	static_assert(sizeof(BSProceduralGeomEvent) == 0x8);
 }

--- a/include/RE/B/BSProceduralLightningController.h
+++ b/include/RE/B/BSProceduralLightningController.h
@@ -2,8 +2,10 @@
 
 #include "RE/B/BSDynamicTriShape.h"
 #include "RE/B/BSFixedString.h"
+#include "RE/B/BSProceduralGeomEvent.h"
 #include "RE/B/BSProceduralLightningTasklet.h"
 #include "RE/B/BSTArray.h"
+#include "RE/B/BSTEvent.h"
 #include "RE/B/BSTaskletGroup.h"
 #include "RE/N/NiInterpController.h"
 #include "RE/N/NiInterpolator.h"
@@ -12,7 +14,9 @@
 
 namespace RE
 {
-	class BSProceduralLightningController : public NiInterpController
+	class BSProceduralLightningController :
+		public NiInterpController,                    // 00
+		public BSTEventSource<BSProceduralGeomEvent>  // 48
 	{
 	public:
 		inline static constexpr auto RTTI = RTTI_BSProceduralLightningController;
@@ -113,12 +117,6 @@ namespace RE
 		VR_ONLY_POINTER_ACCESSOR(VR_RUNTIME_DATA, GetVRRuntimeData, 0xE4);
 
 		// members
-		BSTArray<std::uint8_t>       unkArray1;    // 48 - observed always empty; element type unresolved
-		BSTArray<std::uint8_t>       unkArray2;    // 60 - observed always empty; element type unresolved
-		BSTArray<std::uint8_t>       unkArray3;    // 78 - observed always empty; element type unresolved
-		std::uint64_t                unk90;        // 90 - observed always zero
-		bool                         unk98;        // 98 - observed always zero
-		std::uint8_t                 pad99[7];     // 99 - unidentified
 		NiPointer<BSDynamicTriShape> geometry;     // A0 - lightning-bolt mesh geometry; unshifted in VR
 		std::uint8_t                 padA8[0x2C];  // A8 - lightning-path working buffer (point/vertex/branch
 												   //      pointers); owned alloc freed in dtor; feeds cachedBounds


### PR DESCRIPTION
Follow-up to #250/#257, closing out the `BSProceduralGeomEvent` producer question.

Walking the RTTI `ClassHierarchyDescriptor` for `BSProceduralLightningController` on all three runtimes gives the same base list, ending in:

```
mdisp 72  .?AV?$BSTEventSource@VBSProceduralGeomEvent@@@@
```

So `BSProceduralLightningController` **is** the event source, and the `unkArray1/2/3` + `unk90`/`unk98`/`pad99` block at 0x48-0x9F was that base subobject (three `BSTArray<Sink*>`, the spin lock, and `notifying`) — "observed always empty" simply meant no sink was registered. `NiInterpController` (0x48) + `BSTEventSource` (0x58) puts `geometry` back at 0xA0, so no offsets move; `STATIC_ASSERT_SIZE` still passes under the SE, AE, VR and All presets.

Confirmed on the send side: `BSProceduralLightningController::Update` and `SendGeomEvent` call `BSTEventSource<BSProceduralGeomEvent>::SendEvent(this + 0x48, &event)`, and `BeamProjectile` subscribes by walking its 3D for a controller with `NiRTTI_BSProceduralLightningController` and calling `AddEventSink(controller + 0x48, this + 0x1D8)`. `BeamProjectile` is the only sink class and this controller the only source in all three binaries.

Also narrows `BSProceduralGeomEvent::geometry` from `NiAVObject*` to `BSDynamicTriShape*`: every send site copies the controller's own `geometry` member, which this header already types as `NiPointer<BSDynamicTriShape>`. Existing code assigning it to an `NiAVObject*` still compiles.

Practical effect: a plugin can now `AddEventSink` on a lightning controller to be notified when its bolt mesh is rebuilt, which is exactly what `BeamProjectile` does.

Verified: `release-clang-cl-vcpkg-{se,ae,vr,all}` all build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuM742GiWFKuK1c7DgwYTi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved procedural geometry event support for mesh rebuild notifications.
  * Procedural lightning controllers can now receive procedural geometry events.
  * Geometry event data now provides dynamic triangle shape information, improving mesh update handling.
  * Updated procedural lightning controller data to better reflect current geometry state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->