### PR TITLE
ShowInventoryChangeMessage better approach for negatives

### DIFF
--- a/src/RE/S/SendHUDMessage.cpp
+++ b/src/RE/S/SendHUDMessage.cpp
@@ -26,6 +26,7 @@ namespace RE
 
 		const auto objectName = (a_objectName && a_objectName[0]) ? a_objectName : a_object->GetName();
 		const auto phrase = a_added ? *"sAddItemtoInventory"_gs : *"sRemoveItemfromInventory"_gs;
+		// Widen so that we don't risk overflowing with INT32_MIN
 		auto count = static_cast<std::int64_t>(a_count);
 		if (count < 0) {
 			count = count * -1;

--- a/src/RE/S/SendHUDMessage.cpp
+++ b/src/RE/S/SendHUDMessage.cpp
@@ -26,10 +26,11 @@ namespace RE
 
 		const auto objectName = (a_objectName && a_objectName[0]) ? a_objectName : a_object->GetName();
 		const auto phrase = a_added ? *"sAddItemtoInventory"_gs : *"sRemoveItemfromInventory"_gs;
-		if (a_count < 0) {
-			a_count = a_count * -1;
+		auto count = static_cast<std::int64_t>(a_count);
+		if (count < 0) {
+			count = count * -1;
 		}
-		const std::string message = a_count == 1 ? std::format("{} {}", objectName, phrase) : std::format("{} ({}) {}", objectName, a_count, phrase);
+		const std::string message = count == 1 ? std::format("{} {}", objectName, phrase) : std::format("{} ({}) {}", objectName, count, phrase);
 
 		ShowHUDMessage(message.c_str());
 

--- a/src/RE/S/SendHUDMessage.cpp
+++ b/src/RE/S/SendHUDMessage.cpp
@@ -26,9 +26,10 @@ namespace RE
 
 		const auto objectName = (a_objectName && a_objectName[0]) ? a_objectName : a_object->GetName();
 		const auto phrase = a_added ? *"sAddItemtoInventory"_gs : *"sRemoveItemfromInventory"_gs;
-		// Widen before abs(): abs(INT32_MIN) is UB, since +INT32_MAX+1 doesn't fit back in int32_t.
-		const auto        count = std::abs(static_cast<std::int64_t>(a_count));
-		const std::string message = count == 1 ? std::format("{} {}", objectName, phrase) : std::format("{} ({}) {}", objectName, count, phrase);
+		if (a_count < 0) {
+			a_count = a_count * -1;
+		}
+		const std::string message = a_count == 1 ? std::format("{} {}", objectName, phrase) : std::format("{} ({}) {}", objectName, a_count, phrase);
 
 		ShowHUDMessage(message.c_str());
 

--- a/src/RE/S/SendHUDMessage.cpp
+++ b/src/RE/S/SendHUDMessage.cpp
@@ -26,7 +26,7 @@ namespace RE
 
 		const auto objectName = (a_objectName && a_objectName[0]) ? a_objectName : a_object->GetName();
 		const auto phrase = a_added ? *"sAddItemtoInventory"_gs : *"sRemoveItemfromInventory"_gs;
-		auto count = static_cast<std::int64_t>(a_count);
+		auto       count = static_cast<std::int64_t>(a_count);
 		if (count < 0) {
 			count = count * -1;
 		}


### PR DESCRIPTION
I think actually no need for abs here. Since it's a more expensive operation, just send the regular one. Microoptimization of course.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inventory change notifications now display negative item counts as positive values, ensuring clearer and more accurate messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->