### PR TITLE
fix(shadow): add BSShadowFrustumLight FOV runtime accessor

### DIFF
--- a/include/RE/B/BSShadowFrustumLight.h
+++ b/include/RE/B/BSShadowFrustumLight.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "RE/B/BSShadowLight.h"
+#include "REL/RuntimeDataAccessors.h"
 
 namespace RE
 {
@@ -9,6 +10,18 @@ namespace RE
 	public:
 		inline static constexpr auto RTTI = RTTI_BSShadowFrustumLight;
 		inline static constexpr auto VTABLE = VTABLE_BSShadowFrustumLight;
+
+		struct RUNTIME_DATA
+		{
+#define RUNTIME_DATA_CONTENT                    \
+	float semiWidth;     /* 560, VR 5C0 xFOV */ \
+	float semiHeight;    /* 564, VR 5C4 yFOV */ \
+	float falloff;       /* 568, VR 5C8 */      \
+	float nearDistance;  /* 56C, VR 5CC */      \
+	float farDistance;   /* 570, VR 5D0 */
+            RUNTIME_DATA_CONTENT
+		};
+		static_assert(sizeof(RUNTIME_DATA) == 0x14);
 
 		~BSShadowFrustumLight() override;  // 00
 
@@ -19,18 +32,12 @@ namespace RE
 		void Render(std::uint32_t& a_index) override;                                                                                                                       // 0A
 		bool UpdateCamera(const NiCamera* a_viewCamera) override;                                                                                                           // 10
 
+		RUNTIME_DATA_ACCESSOR_EX(RUNTIME_DATA, GetShadowFrustumLightRuntimeData, 0x560, 0x5C0);
 		// members
-		float semiWidth;     // 560 xFOV
-		float semiHeight;    // 564 yFOV
-		float falloff;       // 568
-		float nearDistance;  // 56C
-		float farDistance;   // 570
-	};
-#if defined(EXCLUSIVE_SKYRIM_FLAT)
-	static_assert(sizeof(BSShadowFrustumLight) == 0x578);
-#elif defined(EXCLUSIVE_SKYRIM_VR)
-	static_assert(sizeof(BSShadowFrustumLight) == 0x5D8);
-	// TODO: Determine correct size for multi-runtime builds
+#ifndef SKYRIM_CROSS_VR
+		RUNTIME_DATA_CONTENT;  // 560, VR 5C0
 #endif
-
+	};
+	STATIC_ASSERT_SIZE(BSShadowFrustumLight, 0x578, 0x578, 0x5D8, 0x148);
 }
+#undef RUNTIME_DATA_CONTENT

--- a/include/RE/B/BSShadowFrustumLight.h
+++ b/include/RE/B/BSShadowFrustumLight.h
@@ -13,13 +13,13 @@ namespace RE
 
 		struct RUNTIME_DATA
 		{
-#define RUNTIME_DATA_CONTENT                    \
-	float semiWidth;     /* 560, VR 5C0 xFOV */ \
-	float semiHeight;    /* 564, VR 5C4 yFOV */ \
-	float falloff;       /* 568, VR 5C8 */      \
-	float nearDistance;  /* 56C, VR 5CC */      \
-	float farDistance;   /* 570, VR 5D0 */
-            RUNTIME_DATA_CONTENT
+#define RUNTIME_DATA_CONTENT                   \
+	float semiWidth;    /* 560, VR 5C0 xFOV */ \
+	float semiHeight;   /* 564, VR 5C4 yFOV */ \
+	float falloff;      /* 568, VR 5C8 */      \
+	float nearDistance; /* 56C, VR 5CC */      \
+	float farDistance;  /* 570, VR 5D0 */
+			RUNTIME_DATA_CONTENT
 		};
 		static_assert(sizeof(RUNTIME_DATA) == 0x14);
 


### PR DESCRIPTION
## Summary
- `BSShadowFrustumLight::semiWidth`/`semiHeight` (and the other trailing members) were declared as plain members placed immediately after the base class, with no runtime-versioned accessor.
- `BSShadowLight`'s own runtime data only compiles inline under `EXCLUSIVE_SKYRIM_FLAT`/`EXCLUSIVE_SKYRIM_VR`; in a multi-runtime (`SKYRIM_CROSS_VR`, e.g. SE+AE+VR together) build it is elided entirely (`sizeof(BSShadowLight) == 0x148`).
- Because `BSShadowFrustumLight` had no equivalent guard, `semiWidth` silently landed at `+0x148`, which is actually `RUNTIME_DATA::shadowmapDescriptors` — a `BSTArray` whose first 8 bytes are its heap data pointer. `semiWidth`/`semiHeight` were reading the low/high dwords of that pointer back as floats.
- `BSShadowDirectionalLight` already handles this correctly via `RUNTIME_DATA_ACCESSOR_EX` + `#ifndef SKYRIM_CROSS_VR`; this PR brings `BSShadowFrustumLight` in line with that established pattern, using its already-documented SE `0x560` / VR `0x5C0` offsets.
- Checked the rest of the `BSShadowLight` hierarchy: `BSShadowParabolicLight` declares no extra data members past the base, so it isn't affected.

Found while debugging Open Shaders (a Skyrim Community Shaders fork): a consumer computing spot-light FOV-based shadow tile sizing was reading this field and getting a denormalized float (~1e-43) from every frustum/spot shadow light in multi-runtime builds — bit-exactly the high dword of a typical process heap pointer.

## Test plan
- [x] `static_assert` sizes verified against existing SE (`0x578`)/VR (`0x5D8`) constants; multi-runtime size falls out to `0x148` (same as base, since no data members are inlined there), matching the `BSShadowDirectionalLight` pattern.
- [x] Downstream consumer in Open Shaders rebuilt against this header and live-verified: `semiWidth`/`semiHeight` now read plausible `tan(halfFOV)` values instead of denormalized floats.

https://claude.ai/code/session_01RBoPQSBLgneHdjZ2ukWj1e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved runtime access to shadow frustum parameters.
  * Standardized shadow frustum data handling across supported flat and VR layouts.
  * Updated structural validation to reflect the revised runtime data layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->