### PR TITLE
fix(hkbBehaviorGraph): variableValueSet type

### DIFF
--- a/include/RE/H/hkbBehaviorGraph.h
+++ b/include/RE/H/hkbBehaviorGraph.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include "RE/H/hkArray.h"
+#include "RE/H/hkRefPtr.h"
 #include "RE/H/hkRefVariant.h"
 #include "RE/H/hkbGenerator.h"
 #include "RE/H/hkbNodeInfo.h"
+#include "RE/H/hkbVariableValueSet.h"
 
 namespace RE
 {
@@ -63,7 +65,7 @@ namespace RE
 		hkRefVariant                             attributeIDMap;                   // 0C0
 		hkRefVariant                             variableIDMap;                    // 0C8
 		hkRefVariant                             characterPropertyIDMap;           // 0D0
-		hkRefVariant                             variableValueSet;                 // 0D8
+		hkRefPtr<hkbVariableValueSet>            variableValueSet;                 // 0D8
 		hkRefVariant                             nodeTemplateToCloneMap;           // 0E0
 		hkRefVariant                             nodeCloneToTemplateMap;           // 0E8
 		hkRefVariant                             stateListenerTemplateToCloneMap;  // 0F0


### PR DESCRIPTION
## Summary
- `hkbBehaviorGraph::variableValueSet` was an opaque `hkRefVariant` (`hkRefPtr<hkReferencedObject>`) even though the type it actually points to (`hkbVariableValueSet`) is already fully and correctly declared elsewhere in the codebase.
- `hkRefVariant` has no type tag -- it's just that base pointer -- so retyping to `hkRefPtr<hkbVariableValueSet>` is a same-bit-pattern upgrade, not a layout change.
- Confirmed by decompiling `BShkbAnimationGraph::GetGraphVariableBool/Float/Int` (already-shipped, `RELOCATION_ID`-pinned API): they index directly into this field's `hkArray<hkbVariableValue>` at `+0x10`, exactly matching `hkbVariableValueSet`'s existing header layout.

## Test plan
- [x] `cmake --preset build-debug-clang-cl-vcpkg-vr` + build succeeds
- [x] `cmake --preset build-debug-clang-cl-vcpkg-all` (SKYRIM_CROSS_VR) + build succeeds