### PR TITLE
fix(ni): allocate NiNode::Create with runtime-correct size

### DIFF
--- a/src/RE/N/NiNode.cpp
+++ b/src/RE/N/NiNode.cpp
@@ -6,10 +6,8 @@ namespace RE
 {
 	NiNode* NiNode::Create(std::uint16_t a_arrBufLen)
 	{
-		auto node = malloc<NiNode>();
-		std::memset((void*)node, 0, sizeof(NiNode));
-		node->Ctor(a_arrBufLen);
-		return node;
+		auto node = malloc_runtime<NiNode>(0x128, 0x150);
+		return node ? node->Ctor(a_arrBufLen) : nullptr;
 	}
 
 	void NiNode::DetachChild(NiAVObject* a_child)


### PR DESCRIPTION
## What changed

`NiNode::Create` now allocates via `malloc_runtime<NiNode>(0x128, 0x150)` instead of a plain `malloc<NiNode>()` + `sizeof(NiNode)` clear.

## Why

Under `SKYRIM_CROSS_VR`, runtime-data members are stripped from the compile-time `NiNode` wrapper, so `sizeof(NiNode)` collapses to the flat (SE/AE, `0x128`) layout even though `NiNode.h` already declares `STATIC_ASSERT_SIZE(NiNode, 0x128, 0x150)`. The engine constructor still writes the full `0x150`-byte VR object, so the old `malloc<NiNode>()` under-allocates on VR and the ctor overflows the heap — the same class of bug as `ButtonEvent`/`NiPointLight`/`NiDirectionalLight` fixed for issue #120, just missed for `NiNode::Create` itself.

Found via HorizonFix's [PR #7](https://github.com/hakasapl/HorizonFix/pull/7), which worked around this downstream in the consuming plugin with a local `NiNode` subclass calling `malloc_runtime` directly. Fixing it here removes the need for every consumer to reimplement the same workaround.

## Validation

- Audited all self-allocating `malloc<T>()` + `memset(sizeof(T))` factories in the codebase against classes with divergent flat/VR `STATIC_ASSERT_SIZE`; `NiNode::Create` was the only one both self-allocating and genuinely size-divergent that wasn't already using `malloc_runtime`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node creation reliability by handling memory allocation failures safely.
  * Ensured newly created nodes are properly initialized before use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->