### PR TITLE
feat(havok): add hkbVariableBindingSet header

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -1192,6 +1192,7 @@ set(SOURCES
 	include/RE/H/hkbRigidBodySetup.h
 	include/RE/H/hkbShapeSetup.h
 	include/RE/H/hkbStateMachine.h
+	include/RE/H/hkbVariableBindingSet.h
 	include/RE/H/hkbVariableInfo.h
 	include/RE/H/hkbVariableValueSet.h
 	include/RE/H/hkp3AxisSweep.h

--- a/include/RE/H/hkbBindable.h
+++ b/include/RE/H/hkbBindable.h
@@ -3,11 +3,11 @@
 #include "RE/H/hkArray.h"
 #include "RE/H/hkRefPtr.h"
 #include "RE/H/hkReferencedObject.h"
+#include "RE/H/hkbVariableBindingSet.h"
 
 namespace RE
 {
 	class hkRefVariant;
-	class hkbVariableBindingSet;
 
 	class hkbBindable : public hkReferencedObject
 	{

--- a/include/RE/H/hkbVariableBindingSet.h
+++ b/include/RE/H/hkbVariableBindingSet.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "RE/H/hkArray.h"
+#include "RE/H/hkReferencedObject.h"
+
+namespace RE
+{
+	class hkbVariableBindingSet : public hkReferencedObject
+	{
+	public:
+		inline static constexpr auto RTTI = RTTI_hkbVariableBindingSet;
+		inline static constexpr auto VTABLE = VTABLE_hkbVariableBindingSet;
+
+		enum class BindingMode : std::int8_t
+		{
+			kGet = 0,
+			kSet = 1,
+		};
+
+		struct Binding
+		{
+		public:
+			// members
+			std::uint32_t bindingPath;         // 00
+			std::uint32_t pad04;               // 04
+			std::uint32_t arrayElementSize;    // 08
+			std::uint32_t padC;                // 0C
+			std::int32_t  memberOffset;        // 10
+			std::int32_t  arrayElementOffset;  // 14
+			std::uint32_t unk18;               // 18
+			std::int32_t  variableIndex;       // 1C
+			std::uint8_t  bitIndex;            // 20
+			BindingMode   bindingMode;         // 21
+			std::uint8_t  memberType;          // 22
+			std::uint8_t  unk23;               // 23
+			std::uint8_t  flags;               // 24
+			std::uint8_t  unk25[3];            // 25
+		};
+		static_assert(sizeof(Binding) == 0x28);
+
+		~hkbVariableBindingSet() override;  // 00
+
+		// members
+		hkArray<Binding> bindings;                  // 10
+		std::int32_t     indexOfActivationBinding;  // 20
+		bool             needsValueAtActivation;    // 24
+		std::uint8_t     unk25[3];                  // 25
+	};
+	static_assert(sizeof(hkbVariableBindingSet) == 0x28);
+}

--- a/include/RE/Skyrim.h
+++ b/include/RE/Skyrim.h
@@ -1194,6 +1194,7 @@
 #include "RE/H/hkbRigidBodySetup.h"
 #include "RE/H/hkbShapeSetup.h"
 #include "RE/H/hkbStateMachine.h"
+#include "RE/H/hkbVariableBindingSet.h"
 #include "RE/H/hkbVariableInfo.h"
 #include "RE/H/hkbVariableValueSet.h"
 #include "RE/H/hkp3AxisSweep.h"


### PR DESCRIPTION
## Summary
- `hkbVariableBindingSet` (and its `Binding` member type) were already fully typed in Ghidra from the `SetGraphVariableBool/Float/Int` RE walk, but only forward-declared in `hkbBindable.h` -- never given a real header. Adds `include/RE/H/hkbVariableBindingSet.h` with the struct as RE'd (40 bytes, matches Ghidra's `/types.h` definition field-for-field) and switches `hkbBindable`'s `variableBindingSet` member from forward-declaration to the real type.

## Test plan
- [x] `cmake --preset build-debug-clang-cl-vcpkg-all` + `cmake --build ... --target CommonLibSSE` -- links clean (SE+AE+VR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for defining variable bindings, including read and write binding modes.
  * Added binding metadata for activation behavior and binding indices.
  * Made variable binding functionality available through the standard Skyrim header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->