### PR TITLE
fix(VR): select State runtime base by build layout

### DIFF
--- a/include/RE/S/State.h
+++ b/include/RE/S/State.h
@@ -180,7 +180,19 @@ namespace RE
 				return nullptr;
 			}
 
-			RUNTIME_MEMBER_ACCESSOR_VERSIONED(RUNTIME_DATA, GetRuntimeData, SKSE::RUNTIME_SSE_1_6_629, 0x58, 0x60, 0x60);
+#if defined(EXCLUSIVE_SKYRIM_VR)
+			// The exclusive-VR RUNTIME_DATA includes firstCameraStateIndex at State + 0x58.
+			// Cross-runtime RUNTIME_DATA omits that field and therefore begins at State + 0x60.
+			static constexpr std::size_t RUNTIME_DATA_VR_OFFSET = 0x58;
+#else
+			static constexpr std::size_t RUNTIME_DATA_VR_OFFSET = 0x60;
+#endif
+			RUNTIME_MEMBER_ACCESSOR_VERSIONED(RUNTIME_DATA, GetRuntimeData, SKSE::RUNTIME_SSE_1_6_629, 0x58, RUNTIME_DATA_VR_OFFSET, 0x60);
+
+#if defined(ENABLE_SKYRIM_VR)
+			static_assert(RUNTIME_DATA_VR_OFFSET + offsetof(RUNTIME_DATA, dynamicResolutionWidthRatio) == 0x104);
+			static_assert(RUNTIME_DATA_VR_OFFSET + offsetof(RUNTIME_DATA, dynamicResolutionLock) == 0x118);
+#endif
 
 			[[nodiscard]] inline bool GetDoubleDynamicResolutionAdjustmentFrequency() noexcept
 			{


### PR DESCRIPTION
# fix(VR): correct BSGraphics::State runtime-data offset in exclusive builds

## Summary

- Select the Skyrim VR `BSGraphics::State::RUNTIME_DATA` base according to the build layout.
- Keep the existing `0x60` base for cross-runtime builds.
- Use `0x58` for exclusive-VR builds, whose runtime-data type includes `firstCameraStateIndex`.
- Add compile-time checks for two known absolute Skyrim VR field offsets.

## Root cause

The exclusive-VR and cross-runtime definitions of `State::RUNTIME_DATA` do not have the same first member:

- Exclusive VR includes `firstCameraStateIndex` and its runtime data begins at `State + 0x58`.
- Cross-runtime VR omits that member and its runtime data begins at `State + 0x60`.

`GetRuntimeData()` previously selected `State + 0x60` for every VR build. In an exclusive-VR build this shifted every field returned through the accessor eight bytes late. The cross-runtime build happened to be correct, which could mask the defect when comparing consumers built in different modes.

Skyrim VR's dynamic-resolution code accesses the width ratio at absolute offset `0x104` and the lock at `0x118` (with the other ratios at `0x108`, `0x10C`, and `0x110`). The new assertions make the selected base and active layout prove those absolute offsets at compile time.

This is an accessor/layout correction rather than an application-specific workaround. Any exclusive-VR consumer of these runtime-data fields could otherwise read or write the adjacent member.

## Concrete displacement in exclusive VR

Because the accessor itself returned a plausible non-null reference, callers had no immediate indication that every member was shifted. The old accessor mapped the affected state as follows:

| Intended field | Correct absolute offset | Old effective target |
| --- | ---: | --- |
| `dynamicResolutionWidthRatio` | `State + 0x104` | `dynamicResolutionPreviousWidthRatio` at `+0x10C` |
| `dynamicResolutionHeightRatio` | `State + 0x108` | `dynamicResolutionPreviousHeightRatio` at `+0x110` |
| `dynamicResolutionPreviousWidthRatio` | `State + 0x10C` | `increaseFrameWaited` bytes at `+0x114`, interpreted as `float` |
| `dynamicResolutionPreviousHeightRatio` | `State + 0x110` | lock/boolean bytes at `+0x118`, interpreted as `float` |
| `increaseFrameWaited` | `State + 0x114` | boolean triplet/padding at `+0x11C` |
| `dynamicResolutionLock` | `State + 0x118` | `State + 0x120`, one byte beyond the object |

This also explains why downstream behaviour can appear stateful rather than failing deterministically at every frame: consumers often write this cluster during mode transitions and then retain the resulting state. The accessor error corrupts adjacent values whose later interpretation depends on the transition sequence.

## Relation to the prior accessor correction

Commit [`c1e2ef8ec`](https://github.com/alandtse/CommonLibSSE-NG/commit/c1e2ef8ecfea7510e06131de69b22a5cda526d34) corrected the macro introduced by #108 and deliberately changed the VR member-accessor base from `0x58` to `0x60`. That remains correct for cross-runtime builds, where the compiled `RUNTIME_DATA` type omits `firstCameraStateIndex`.

This PR does not revert that correction wholesale. It preserves `RUNTIME_MEMBER_ACCESSOR_VERSIONED` and the cross-runtime `0x60` base, while tightening the selection for exclusive-VR builds whose compiled `RUNTIME_DATA` includes the leading field and must therefore begin at `0x58`.

## Observed impact

The issue was found through Community Shaders Expanded while updating the dynamic-resolution ratios and lock. With the late accessor, CSX and Skyrim VR disagreed about the active render dimensions, producing mismatched eye projections, distortion, and a hard cut in one eye when below-native upscaling was active with Skyrim's render-scale path disabled.

Correcting the CommonLib accessor removed those symptoms in a cold-process headset test: the eyes matched, with no cut and no distortion. CSX is only the reproducing consumer; the fix belongs in CommonLib because the returned object address was wrong.

## Validation

- Compared the active layouts and reversed Skyrim VR's absolute field accesses.
- Confirmed corrected exclusive-VR consumer disassembly accesses `0x104`, `0x108`, `0x10C`, `0x110`, and `0x118`.
- Built the `CommonLibSSE` Release library target from current `ng` in both configurations:
  - `release-msvc-vcpkg-vr`
  - `release-msvc-vcpkg-all`
- Verified the correction in Skyrim VR using a cold-process, below-native AMD FSR run with render scale disabled.

The full VR build also compiled the test sources and the CommonLib library. Its test executable could not link in this local environment because the cached Catch2 binary was produced with a newer MSVC STL (`__std_*` unresolved symbols); this is unrelated to the changed header.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime data handling for VR configurations.
  * Added validation to help ensure dynamic-resolution settings use the correct VR-specific offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
