### PR TITLE
fix(RE): rename State::RUNTIME_DATA firstCameraStateIndex to eyeIndex

### DIFF
--- a/include/RE/S/State.h
+++ b/include/RE/S/State.h
@@ -108,7 +108,7 @@ namespace RE
 			{
 #if defined(EXCLUSIVE_SKYRIM_VR)  // VR
 #	define RUNTIME_DATA_CONTENT                                                                                               \
-		uint32_t                   eyeIndex;                             /* 058 VR only -- current render eye (0/1) */         \
+		uint32_t                   eyeIndex;                             /* 058 -- current render eye (0/1) */                 \
 		NiPointer<NiSourceTexture> defaultTextureBlack;                  /* SE 058, AE,VR 060 - "BSShader_DefHeightMap"*/      \
 		NiPointer<NiSourceTexture> defaultTextureWhite;                  /* SE 060, AE,VR 068 */                               \
 		NiPointer<NiSourceTexture> defaultTextureGrey;                   /* SE 068, AE,VR 070 */                               \

--- a/include/RE/S/State.h
+++ b/include/RE/S/State.h
@@ -108,7 +108,7 @@ namespace RE
 			{
 #if defined(EXCLUSIVE_SKYRIM_VR)  // VR
 #	define RUNTIME_DATA_CONTENT                                                                                               \
-		uint32_t                   firstCameraStateIndex;                /*	058 VR   only ?*/                                  \
+		uint32_t                   eyeIndex;                             /* 058 VR only -- current render eye (0/1) */         \
 		NiPointer<NiSourceTexture> defaultTextureBlack;                  /* SE 058, AE,VR 060 - "BSShader_DefHeightMap"*/      \
 		NiPointer<NiSourceTexture> defaultTextureWhite;                  /* SE 060, AE,VR 068 */                               \
 		NiPointer<NiSourceTexture> defaultTextureGrey;                   /* SE 068, AE,VR 070 */                               \

--- a/include/RE/S/State.h
+++ b/include/RE/S/State.h
@@ -108,7 +108,7 @@ namespace RE
 			{
 #if defined(EXCLUSIVE_SKYRIM_VR)  // VR
 #	define RUNTIME_DATA_CONTENT                                                                                               \
-		uint32_t                   eyeIndex;                             /* 058 -- current render eye (0/1) */                 \
+		uint32_t                   eyeIndex;                             /* 058 -- current render eye (0 = left, 1 = right) */ \
 		NiPointer<NiSourceTexture> defaultTextureBlack;                  /* SE 058, AE,VR 060 - "BSShader_DefHeightMap"*/      \
 		NiPointer<NiSourceTexture> defaultTextureWhite;                  /* SE 060, AE,VR 068 */                               \
 		NiPointer<NiSourceTexture> defaultTextureGrey;                   /* SE 068, AE,VR 070 */                               \


### PR DESCRIPTION
State.h's VR-exclusive RUNTIME_DATA declares its leading field as `firstCameraStateIndex` with an uncertain `?` comment. Live decompile of SkyrimVR.exe (State + 0x58) shows this field is used exclusively as `(int)eyeIndex` for per-frame VR eye selection (0/1) in `Render`, `Draw`, and `UpdateViewPort` — not as any kind of camera-state index. Renamed and re-commented to match its actual observed behavior.

Cross-checked absolute offsets independently in SkyrimSE.exe, SkyrimSE.1170.exe (AE), and SkyrimVR.exe; no other consumers of this field name exist in the tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the runtime’s render-eye field naming and documentation to accurately reflect the active eye index (`0` or `1`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->