### PR TITLE
fix(shaderprop): correct VR alloc size

### DIFF
--- a/include/RE/B/BSGrassShaderProperty.h
+++ b/include/RE/B/BSGrassShaderProperty.h
@@ -42,5 +42,5 @@ namespace RE
 		BSShaderPropertyLightData      grassLightData;     // 198
 		RenderPassArray                grassShadowPasses;  // 1C0
 	};
-	static_assert(sizeof(BSGrassShaderProperty) == 0x1D0);
+	STATIC_ASSERT_SIZE(BSGrassShaderProperty, 0x1D0, 0x1D0, 0x1E8, 0x1D0);
 }

--- a/include/RE/B/BSLightingShaderProperty.h
+++ b/include/RE/B/BSLightingShaderProperty.h
@@ -88,7 +88,7 @@ namespace RE
 		std::uint32_t             unk130;                         // 130
 		std::uint32_t             unk134;                         // 134
 		BSShaderPropertyLightData lightingLightData;              // 138
-#ifndef SKYRIM_CROSS_VR
+#if defined(EXCLUSIVE_SKYRIM_VR)
 		bool  unk160;  // 160 - VR-only; not copied by CreateClone
 		float unk164;  // 164 - VR-only; not copied by CreateClone
 		float unk168;  // 168 - VR-only; not copied by CreateClone

--- a/include/RE/B/BSLightingShaderProperty.h
+++ b/include/RE/B/BSLightingShaderProperty.h
@@ -88,6 +88,13 @@ namespace RE
 		std::uint32_t             unk130;                         // 130
 		std::uint32_t             unk134;                         // 134
 		BSShaderPropertyLightData lightingLightData;              // 138
+#ifndef SKYRIM_CROSS_VR
+		bool  unk160;  // 160 - VR-only; not copied by CreateClone
+		float unk164;  // 164 - VR-only; not copied by CreateClone
+		float unk168;  // 168 - VR-only; not copied by CreateClone
+		float unk16C;  // 16C - VR-only; not copied by CreateClone
+		bool  unk170;  // 170 - VR-only; copied by CreateClone
+#endif
 	};
-	static_assert(sizeof(BSLightingShaderProperty) == BSLightingShaderProperty::kSizeFlat);
+	STATIC_ASSERT_SIZE(BSLightingShaderProperty, BSLightingShaderProperty::kSizeFlat, BSLightingShaderProperty::kSizeFlat, BSLightingShaderProperty::kSizeVR, BSLightingShaderProperty::kSizeFlat);
 }

--- a/include/RE/B/BSLightingShaderProperty.h
+++ b/include/RE/B/BSLightingShaderProperty.h
@@ -3,6 +3,7 @@
 #include "RE/B/BSShaderProperty.h"
 #include "RE/B/BSShaderPropertyLightData.h"
 #include "RE/B/BSTArray.h"
+#include "RE/M/MemoryManager.h"
 #include "RE/N/NiColor.h"
 
 namespace RE
@@ -48,6 +49,19 @@ namespace RE
 
 		void CopyMembers(BSLightingShaderProperty* a_other);
 		void InvalidateTextures(std::uint32_t a_unk1);
+
+		static BSLightingShaderProperty* Create()
+		{
+			// sizeof(BSLightingShaderProperty) (0x160) is wrong on VR: the vanilla
+			// engine's own CreateClone allocates 0x178 there (Ghidra-confirmed,
+			// AllocateIMemoryHeap call), but the extra ~0x18 bytes aren't mapped to
+			// named fields here yet. See malloc_runtime.
+			auto prop = malloc_runtime<BSLightingShaderProperty>(0x160, 0x178);
+			if (prop) {
+				prop->Ctor();
+			}
+			return prop;
+		}
 
 		BSLightingShaderProperty* Ctor()
 		{

--- a/include/RE/B/BSLightingShaderProperty.h
+++ b/include/RE/B/BSLightingShaderProperty.h
@@ -50,13 +50,13 @@ namespace RE
 		void CopyMembers(BSLightingShaderProperty* a_other);
 		void InvalidateTextures(std::uint32_t a_unk1);
 
+		// Engine's own CreateClone allocates kSizeVR on VR, not sizeof(this).
+		inline static constexpr std::size_t kSizeFlat = 0x160;
+		inline static constexpr std::size_t kSizeVR = 0x178;
+
 		static BSLightingShaderProperty* Create()
 		{
-			// sizeof(BSLightingShaderProperty) (0x160) is wrong on VR: the vanilla
-			// engine's own CreateClone allocates 0x178 there (Ghidra-confirmed,
-			// AllocateIMemoryHeap call), but the extra ~0x18 bytes aren't mapped to
-			// named fields here yet. See malloc_runtime.
-			auto prop = malloc_runtime<BSLightingShaderProperty>(0x160, 0x178);
+			auto prop = malloc_runtime<BSLightingShaderProperty>(kSizeFlat, kSizeVR);
 			if (prop) {
 				prop->Ctor();
 			}
@@ -89,5 +89,5 @@ namespace RE
 		std::uint32_t             unk134;                         // 134
 		BSShaderPropertyLightData lightingLightData;              // 138
 	};
-	static_assert(sizeof(BSLightingShaderProperty) == 0x160);
+	static_assert(sizeof(BSLightingShaderProperty) == BSLightingShaderProperty::kSizeFlat);
 }


### PR DESCRIPTION
## Summary
- `BSLightingShaderProperty`'s header asserts `sizeof == 0x160` with no VR
  branch, but the vanilla engine's own `CreateClone` allocates `0x178` bytes
  on VR (Ghidra-confirmed against `SkyrimSE.exe`/`SkyrimVR.exe`, both via
  `AllocateIMemoryHeap`). A manual allocation sized with `sizeof()` under-
  allocates by 0x18 bytes on VR.
- The extra 0x18 bytes are real fields, not padding (Ghidra-confirmed via
  raw disassembly of `Ctor`/`CreateClone`/`CopyMembers`, not just the
  decompiler's pseudocode): a `bool` (not copied by clone), three `float`s
  defaulting to `1.0` (not copied), and a trailing `bool` (copied). Added
  as named members under `#ifndef SKYRIM_CROSS_VR`, with a
  `Create()` factory using `malloc_runtime<BSLightingShaderProperty>` for
  the `SKYRIM_CROSS_VR` case where the type itself stays `0x160`, matching
  the existing `NiPointLight::Create()` convention for this bug class
  (guards against alandtse/CommonLibSSE-NG#120) instead of a bare
  unconditional `static_assert`.
- `BSGrassShaderProperty` (the class's one subclass) inherits the size
  change under `#ifndef SKYRIM_CROSS_VR`; its own `CreateClone` confirms
  the real VR allocation grows to `0x1E8` (`0x1D0 + 0x18`) with no internal
  member reordering, so only its `STATIC_ASSERT_SIZE` needed updating.

## Test plan
- [x] `release-msvc-vcpkg-vr` preset builds clean (both `BSLightingShaderProperty`
      and `BSGrassShaderProperty` land at their real VR sizes).
- [x] `build-debug-clang-cl-vcpkg-all` (`SKYRIM_CROSS_VR`, the dominant
      real-world build target) builds clean — confirms the extra fields are
      correctly stripped and both classes stay at their SE/AE size there.
- [x] Verified via live Ghidra decompilation + raw disassembly of
      `BSLightingShaderProperty::{Ctor,CreateClone,CopyMembers}` and
      `BSGrassShaderProperty::CreateClone` in `SkyrimVR.exe`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a supported factory method for creating lighting shader properties.
  * Added platform-specific sizing information and fields for VR builds.

* **Bug Fixes**
  * Improved size validation for lighting and grass shader properties across supported builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->