### PR TITLE
fix(rel): find exe via GetModuleHandleW(nullptr)

### DIFF
--- a/include/REL/Module.h
+++ b/include/REL/Module.h
@@ -288,18 +288,12 @@ namespace REL
 				stl::report_and_fail("Failed to obtain the process's own module handle."sv);
 			}
 
-			_filePath.resize(REX::W32::MAX_PATH);
-			std::uint32_t length = 0;
-			for (;;) {
-				length = REX::W32::GetModuleFileNameW(
-					moduleHandle, _filePath.data(), static_cast<std::uint32_t>(_filePath.size()));
-				if (length == 0) {
-					stl::report_and_fail("Failed to obtain the process's own module file path."sv);
-				}
-				if (length < _filePath.size()) {
-					break;
-				}
-				_filePath.resize(_filePath.size() * 2);
+			constexpr std::size_t bufferSize = 32767;  // Windows extended-length path limit (\\?\ prefix)
+			_filePath.resize(bufferSize);
+			const auto length = REX::W32::GetModuleFileNameW(
+				moduleHandle, _filePath.data(), static_cast<std::uint32_t>(_filePath.size()));
+			if (length == 0 || length >= bufferSize) {
+				stl::report_and_fail("Failed to obtain the process's own module file path."sv);
 			}
 			_filePath.resize(length);
 			_filename = std::filesystem::path(_filePath).filename().wstring();

--- a/include/REL/Module.h
+++ b/include/REL/Module.h
@@ -283,35 +283,19 @@ namespace REL
 
 		bool init()
 		{
-			const auto getFilename = [&]() {
-				return REX::W32::GetEnvironmentVariableW(
-					ENVIRONMENT.data(),
-					_filename.data(),
-					static_cast<std::uint32_t>(_filename.size()));
-			};
-
-			void* moduleHandle = nullptr;
-			_filename.resize(getFilename());
-			if (const auto result = getFilename();
-				result != _filename.size() - 1 ||
-				result == 0) {
-				for (auto runtime : RUNTIMES) {
-					_filename = runtime;
-					moduleHandle = REX::W32::GetModuleHandleW(_filename.c_str());
-					if (moduleHandle) {
-						break;
-					}
-				}
-			}
-			_filePath = _filename;
+			// nullptr resolves the process's own EXE, not the calling module -- do not swap for
+			// REX::W32::GetCurrentModule(), which returns this DLL's own base instead.
+			const REX::W32::HMODULE moduleHandle = REX::W32::GetModuleHandleW(nullptr);
 			if (!moduleHandle) {
-				stl::report_and_fail(
-					std::format(
-						"Failed to obtain module handle for: \"{0}\".\n"
-						"You have likely renamed the executable to something unexpected. "
-						"Renaming the executable back to \"{0}\" may resolve the issue."sv,
-						stl::utf16_to_utf8(_filename).value_or("<unicode conversion error>"s)));
+				stl::report_and_fail("Failed to obtain the process's own module handle."sv);
 			}
+
+			std::array<wchar_t, 4096> buffer;  // NTFS max path length
+			const auto                length = REX::W32::GetModuleFileNameW(
+                moduleHandle, buffer.data(), static_cast<std::uint32_t>(buffer.size()));
+			_filePath.assign(buffer.data(), length);
+			_filename = std::filesystem::path(_filePath).filename().wstring();
+
 			return load(moduleHandle, true);
 		}
 
@@ -376,11 +360,6 @@ namespace REL
 			std::make_pair(".tls"sv, 0u),
 			std::make_pair(".text"sv, REX::W32::IMAGE_SCN_MEM_WRITE),
 			std::make_pair(".gfids"sv, 0u)
-		};
-
-		static constexpr auto                             ENVIRONMENT = L"SKSE_RUNTIME"sv;
-		static constexpr std::array<std::wstring_view, 2> RUNTIMES{
-			{ L"SkyrimVR.exe", L"SkyrimSE.exe" }
 		};
 
 		static Module                       _instance;

--- a/include/REL/Module.h
+++ b/include/REL/Module.h
@@ -283,17 +283,25 @@ namespace REL
 
 		bool init()
 		{
-			// nullptr resolves the process's own EXE, not the calling module -- do not swap for
-			// REX::W32::GetCurrentModule(), which returns this DLL's own base instead.
 			const REX::W32::HMODULE moduleHandle = REX::W32::GetModuleHandleW(nullptr);
 			if (!moduleHandle) {
 				stl::report_and_fail("Failed to obtain the process's own module handle."sv);
 			}
 
-			std::array<wchar_t, 4096> buffer;  // NTFS max path length
-			const auto                length = REX::W32::GetModuleFileNameW(
-                moduleHandle, buffer.data(), static_cast<std::uint32_t>(buffer.size()));
-			_filePath.assign(buffer.data(), length);
+			_filePath.resize(REX::W32::MAX_PATH);
+			std::uint32_t length = 0;
+			for (;;) {
+				length = REX::W32::GetModuleFileNameW(
+					moduleHandle, _filePath.data(), static_cast<std::uint32_t>(_filePath.size()));
+				if (length == 0) {
+					stl::report_and_fail("Failed to obtain the process's own module file path."sv);
+				}
+				if (length < _filePath.size()) {
+					break;
+				}
+				_filePath.resize(_filePath.size() * 2);
+			}
+			_filePath.resize(length);
 			_filename = std::filesystem::path(_filePath).filename().wstring();
 
 			return load(moduleHandle, true);


### PR DESCRIPTION
## Summary
- `Module::init()` looked up the game's module handle via an `SKSE_RUNTIME` env var (nothing sets it in practice), falling back to a hardcoded `SkyrimVR.exe`/`SkyrimSE.exe` name match via `GetModuleHandleW(name)`. Renaming the executable (proxy launchers, truncated names) broke that lookup and crashed with "Failed to obtain module handle".
- `GetModuleHandleW(nullptr)` always resolves to the calling process's own EXE module unconditionally, regardless of its name.
- Runtime detection (SE/AE/VR) already doesn't depend on the filename — it's driven by `load_version()`'s PE VERSIONINFO read — so resolving the real on-disk path via `GetModuleFileNameW(moduleHandle, ...)` instead of a guessed name keeps that working unconditionally too.
- Drops the now-dead `SKSE_RUNTIME` env var and `RUNTIMES` name list.

## Test plan
- [x] Full VR debug build (`build-debug-clang-cl-vcpkg-vr`, clang-cl): 504/504 files compiled and linked clean
- [x] `CommonLibSSETests.exe`: 128 assertions across 28 test cases, all passing
- [ ] CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executable path detection during application startup.
  * Removed reliance on environment variables and runtime-specific executable probing, improving reliability across supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->