### PR TITLE
ci(release): pin conventionalcommits preset to v9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
             @google/semantic-release-replace-plugin
             @semantic-release/changelog
             @semantic-release/git
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@^9.3.1
 
   # On a published release, build the prebuilt CommonLib bundle and attach it to the
   # GitHub release. The same build + consumer self-test also run on every PR to ng


### PR DESCRIPTION
## Summary
`conventional-changelog-conventionalcommits@10` (released 2026-06-26) dropped its dependency on `conventional-changelog-writer` in favor of a new `@conventional-changelog/template` rendering engine, requiring `conventional-changelog-writer@9+`/`conventional-changelog@8+`. The preset was installed unpinned via `extra_plugins` in this workflow, so it silently resolved to the incompatible v10 — but `cycjimmy/semantic-release-action@v5` bundles `semantic-release@^24.2.9` → `@semantic-release/release-notes-generator@^14` → `conventional-changelog-writer@^8`, which can't render v10's templates. Every release on `ng` since v6.3.4 has failed at the `generateNotes` step with a Handlebars "Missing helper" error.

Fix: pin to the last v9.x release (`^9.3.1`), which depends only on `compare-func` (old writer-compatible template format) — no `.releaserc.json`/`package.json` changes needed, the preset name is unaffected.

## Test plan
- [x] Confirmed via npm registry that `conventional-changelog-conventionalcommits@9.3.1` exists and predates the breaking v10 change
- [x] Confirmed via the action's own `package.json` that it bundles `semantic-release@^24.2.9` → `release-notes-generator@^14` → `conventional-changelog-writer@^8`, matching what v9.3.1 needs
- [ ] Next push to `ng` (or a manual `workflow_dispatch`) confirms the Semantic Release run completes past `generateNotes`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release configuration to use a fixed version range for changelog generation, improving release consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->