### PR TITLE
build(cmake): match xwin's lib casing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,14 +100,14 @@ if(COMMONLIB_PREBUILT_RESOLVED)
 		"${PROJECT_NAME}" INTERFACE
 		spdlog::spdlog
 		Microsoft::DirectXTK
-		Advapi32.lib
+		advapi32.lib
 		bcrypt.lib
 		D3D11.lib
 		d3dcompiler.lib
-		Dbghelp.lib
+		dbghelp.lib
 		DXGI.lib
-		Ole32.lib
-		Version.lib
+		ole32.lib
+		version.lib
 		"${COMMONLIB_PREBUILT_RESOLVED}/lib/openvr_api.lib"
 	)
 	include(cmake/CommonLibSSE.cmake)  # add_commonlibsse_plugin() helper for consumers
@@ -278,14 +278,14 @@ target_link_libraries(
 	PUBLIC
 	spdlog::spdlog
 	Microsoft::DirectXTK
-	Advapi32.lib
+	advapi32.lib
 	bcrypt.lib
 	D3D11.lib
 	d3dcompiler.lib
-	Dbghelp.lib
+	dbghelp.lib
 	DXGI.lib
-	Ole32.lib
-	Version.lib
+	ole32.lib
+	version.lib
 	"$<$<BOOL:${ENABLE_SKYRIM_VR}>:${OPENVR_LIB_DIR}/openvr_api.lib>"
 )
 


### PR DESCRIPTION
## Summary

Four Windows import libs are linked with Titlecase names (`Advapi32.lib`, `Dbghelp.lib`, `Ole32.lib`, `Version.lib`) that only resolve today because NTFS is case-insensitive. Cross-compiling from a Linux host against a case-sensitive filesystem (e.g. an `xwin`-generated sysroot) breaks on exactly these four, since `xwin`'s default splat only produces UPPERCASE/lowercase variants (e.g. `KERNEL32.lib`/`kernel32.lib`), not this particular Titlecase pattern.

This is a small, standalone fix split out ahead of a larger Linux cross-compilation contribution referenced in #215 - lowercasing these four is safe and useful on its own regardless of what shape that follow-up takes.

## Changes

- Lowercased `Advapi32.lib` → `advapi32.lib`, `Dbghelp.lib` → `dbghelp.lib`, `Ole32.lib` → `ole32.lib`, `Version.lib` → `version.lib` in both `target_link_libraries()` blocks (prebuilt-interface and from-source targets).
- No functional change on native Windows: MSVC/lld-link resolve library names case-insensitively there regardless of source casing.

## Test plan

- [x] Full clean rebuild via the existing `clang-cl`/Ninja preset (`linux-clangcl-release`, cross-compiled from a Linux host against an `xwin` sysroot) links successfully with no case-sensitivity errors, as a consumer via `add_subdirectory` (RecipeConditionPatcher).
- [x] Windows CI (`main_ci.yml`, MSVC + clang-cl matrix) - expected to be unaffected since the change is a no-op there, but flagging for maintainer confirmation since I can't run that CI matrix myself before opening this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Windows library naming for improved compatibility across build configurations.
  * No changes to application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->