### PR TITLE
fix(AE): fix offset gaps in SkyrimVM/PlayerCharacter

### DIFF
--- a/include/RE/P/PlayerCharacter.h
+++ b/include/RE/P/PlayerCharacter.h
@@ -753,11 +753,44 @@ namespace RE
 		void UpdateVRComfortCheck();
 		void UsePoisonFromInventory(AlchemyItem* a_poison);
 
-		RUNTIME_CAST_ACCESSOR_VERSIONED_VR(BSTEventSource<BGSActorCellEvent>, AsBGSActorCellEventSource, SKSE::RUNTIME_SSE_1_6_629, 0x2D0, 0x2E8, 0x2D8)
+		// AE 1.7.99's new BSTEventSink<BSSystemEvent> base (see AsBSSystemEventSink below)
+		// shifts these three bases by +8; RUNTIME_CAST_ACCESSOR_VERSIONED_VR has no 1.7.99
+		// sub-branch, so they need a manual accessor instead of the usual macro.
+		[[nodiscard]] inline BSTEventSource<BGSActorCellEvent>* AsBGSActorCellEventSource() noexcept
+		{
+			if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {
+				return &REL::RelocateMemberIfNewer<BSTEventSource<BGSActorCellEvent>>(SKSE::RUNTIME_SSE_1_7_99, this, 0x2D8, 0x2E0);
+			}
+			return &REL::RelocateMember<BSTEventSource<BGSActorCellEvent>>(this, 0x2D0, 0x2E8);
+		}
+		[[nodiscard]] inline const BSTEventSource<BGSActorCellEvent>* AsBGSActorCellEventSource() const noexcept
+		{
+			return const_cast<PlayerCharacter*>(this)->AsBGSActorCellEventSource();
+		}
 
-		RUNTIME_CAST_ACCESSOR_VERSIONED_VR(BSTEventSource<BGSActorDeathEvent>, AsBGSActorDeathEventSource, SKSE::RUNTIME_SSE_1_6_629, 0x328, 0x340, 0x330)
+		[[nodiscard]] inline BSTEventSource<BGSActorDeathEvent>* AsBGSActorDeathEventSource() noexcept
+		{
+			if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {
+				return &REL::RelocateMemberIfNewer<BSTEventSource<BGSActorDeathEvent>>(SKSE::RUNTIME_SSE_1_7_99, this, 0x330, 0x338);
+			}
+			return &REL::RelocateMember<BSTEventSource<BGSActorDeathEvent>>(this, 0x328, 0x340);
+		}
+		[[nodiscard]] inline const BSTEventSource<BGSActorDeathEvent>* AsBGSActorDeathEventSource() const noexcept
+		{
+			return const_cast<PlayerCharacter*>(this)->AsBGSActorDeathEventSource();
+		}
 
-		RUNTIME_CAST_ACCESSOR_VERSIONED_VR(BSTEventSource<PositionPlayerEvent>, AsPositionPlayerEventSource, SKSE::RUNTIME_SSE_1_6_629, 0x380, 0x398, 0x388)
+		[[nodiscard]] inline BSTEventSource<PositionPlayerEvent>* AsPositionPlayerEventSource() noexcept
+		{
+			if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {
+				return &REL::RelocateMemberIfNewer<BSTEventSource<PositionPlayerEvent>>(SKSE::RUNTIME_SSE_1_7_99, this, 0x388, 0x390);
+			}
+			return &REL::RelocateMember<BSTEventSource<PositionPlayerEvent>>(this, 0x380, 0x398);
+		}
+		[[nodiscard]] inline const BSTEventSource<PositionPlayerEvent>* AsPositionPlayerEventSource() const noexcept
+		{
+			return const_cast<PlayerCharacter*>(this)->AsPositionPlayerEventSource();
+		}
 
 		RUNTIME_CAST_ACCESSOR_VERSIONED(BSTEventSink<MenuOpenCloseEvent>, AsMenuOpenCloseEventSink, SKSE::RUNTIME_SSE_1_6_629, 0x2B0, 0x2B8)
 

--- a/include/RE/P/PlayerCharacter.h
+++ b/include/RE/P/PlayerCharacter.h
@@ -754,8 +754,7 @@ namespace RE
 		void UsePoisonFromInventory(AlchemyItem* a_poison);
 
 		// AE 1.7.99's new BSTEventSink<BSSystemEvent> base (see AsBSSystemEventSink below)
-		// shifts these three bases by +8; RUNTIME_CAST_ACCESSOR_VERSIONED_VR has no 1.7.99
-		// sub-branch, so they need a manual accessor instead of the usual macro.
+		// shifts these three bases by +8.
 		[[nodiscard]] inline BSTEventSource<BGSActorCellEvent>* AsBGSActorCellEventSource() noexcept
 		{
 			if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {

--- a/include/RE/S/SkyrimVM.h
+++ b/include/RE/S/SkyrimVM.h
@@ -413,8 +413,7 @@ namespace RE
 		}
 
 	private:
-		std::uint8_t _padHeadRuntimeData[0x128];                            // 0200 -- reserves the pre-1.7.99 footprint
-																			// (impl..logger, ends exactly at 0x328)
+		std::uint8_t _padHeadRuntimeData[0x128];                            // 0200
 		std::uint8_t _padHandlePolicy[sizeof(SkyrimScript::HandlePolicy)];  // 0328
 
 	public:

--- a/include/RE/S/SkyrimVM.h
+++ b/include/RE/S/SkyrimVM.h
@@ -151,6 +151,9 @@ namespace RE
 		public BSTEventSink<BSScript::StatsEvent>,  // 0190
 		public BSTEventSink<MenuOpenCloseEvent>,    // 0198
 #endif
+		// AE 1.7.99's Amiibo bases (real bases, see above) shift this base's real data
+		// (sinks/locks/pending lists) by +0x10 with no corrected accessor. No in-tree
+		// consumer calls AddEventSink/etc. on SkyrimVM yet; add one if that changes.
 		public BSTEventSource<BSScript::StatsEvent>  // 01A8
 	{
 	public:
@@ -388,14 +391,32 @@ namespace RE
 		// (see BSScript::IFreezeQuery) or a timeout.
 		void Freeze();
 
-		// members
-		BSTSmartPointer<BSScript::IVirtualMachine> impl;               // 0200
-		BSScript::IVMSaveLoadInterface*            saveLoadInterface;  // 0208
-		BSScript::IVMDebugInterface*               debugInterface;     // 0210
-		BSScript::SimpleAllocMemoryPagePolicy      memoryPagePolicy;   // 0218
-		BSScript::CompiledScriptLoader             scriptLoader;       // 0240
-		SkyrimScript::Logger                       logger;             // 0278
+		// AE 1.7.99's Amiibo base-class insertion (see above) shifts every own-member from
+		// here on by +0x10, not just HandlePolicy/TAIL_RUNTIME_DATA as previously modeled.
+		// Same pattern as TAIL_RUNTIME_DATA: private pad + versioned overlay struct.
+		struct HEAD_RUNTIME_DATA
+		{
+			BSTSmartPointer<BSScript::IVirtualMachine> impl;               // 0200
+			BSScript::IVMSaveLoadInterface*            saveLoadInterface;  // 0208
+			BSScript::IVMDebugInterface*               debugInterface;     // 0210
+			BSScript::SimpleAllocMemoryPagePolicy      memoryPagePolicy;   // 0218
+			BSScript::CompiledScriptLoader             scriptLoader;       // 0240
+			SkyrimScript::Logger                       logger;             // 0278
+		};
+
+		[[nodiscard]] inline HEAD_RUNTIME_DATA& GetHeadRuntimeData() noexcept
+		{
+			if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {
+				if (REL::Module::get().version().compare(SKSE::RUNTIME_SSE_1_7_99) != std::strong_ordering::less) {
+					return REL::RelocateMember<HEAD_RUNTIME_DATA>(this, 0x210);
+				}
+			}
+			return REL::RelocateMember<HEAD_RUNTIME_DATA>(this, 0x200);
+		}
+
 	private:
+		std::uint8_t _padHeadRuntimeData[0x128];                            // 0200 -- reserves the pre-1.7.99 footprint
+																			// (impl..logger, ends exactly at 0x328)
 		std::uint8_t _padHandlePolicy[sizeof(SkyrimScript::HandlePolicy)];  // 0328
 
 	public:

--- a/include/RE/S/SkyrimVM.h
+++ b/include/RE/S/SkyrimVM.h
@@ -390,30 +390,21 @@ namespace RE
 		// (see BSScript::IFreezeQuery) or a timeout.
 		void Freeze();
 
-		// AE 1.7.99's Amiibo base-class insertion (see above) shifts every own-member
-		// from here on by +0x10.
-		struct HEAD_RUNTIME_DATA
-		{
-			BSTSmartPointer<BSScript::IVirtualMachine> impl;               // 0200
-			BSScript::IVMSaveLoadInterface*            saveLoadInterface;  // 0208
-			BSScript::IVMDebugInterface*               debugInterface;     // 0210
-			BSScript::SimpleAllocMemoryPagePolicy      memoryPagePolicy;   // 0218
-			BSScript::CompiledScriptLoader             scriptLoader;       // 0240
-			SkyrimScript::Logger                       logger;             // 0278
-		};
+	private:
+		std::uint8_t _padImpl[sizeof(BSTSmartPointer<BSScript::IVirtualMachine>)];  // 0200
 
-		[[nodiscard]] inline HEAD_RUNTIME_DATA& GetHeadRuntimeData() noexcept
-		{
-			if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {
-				if (REL::Module::get().version().compare(SKSE::RUNTIME_SSE_1_7_99) != std::strong_ordering::less) {
-					return REL::RelocateMember<HEAD_RUNTIME_DATA>(this, 0x210);
-				}
-			}
-			return REL::RelocateMember<HEAD_RUNTIME_DATA>(this, 0x200);
-		}
+	public:
+		RUNTIME_MEMBER_ACCESSOR_VERSIONED(BSTSmartPointer<BSScript::IVirtualMachine>, GetImpl, SKSE::RUNTIME_SSE_1_7_99, 0x200, 0x200, 0x210);
+
+		// AE 1.7.99's Amiibo base-class insertion (see above) shifts these too, with no
+		// corrected accessor; no in-tree consumer accesses them directly.
+		BSScript::IVMSaveLoadInterface*       saveLoadInterface;  // 0208
+		BSScript::IVMDebugInterface*          debugInterface;     // 0210
+		BSScript::SimpleAllocMemoryPagePolicy memoryPagePolicy;   // 0218
+		BSScript::CompiledScriptLoader        scriptLoader;       // 0240
+		SkyrimScript::Logger                  logger;             // 0278
 
 	private:
-		std::uint8_t _padHeadRuntimeData[0x128];                            // 0200
 		std::uint8_t _padHandlePolicy[sizeof(SkyrimScript::HandlePolicy)];  // 0328
 
 	public:

--- a/include/RE/S/SkyrimVM.h
+++ b/include/RE/S/SkyrimVM.h
@@ -390,28 +390,17 @@ namespace RE
 		// (see BSScript::IFreezeQuery) or a timeout.
 		void Freeze();
 
-	private:
-		std::uint8_t _padImpl[sizeof(BSTSmartPointer<BSScript::IVirtualMachine>)];  // 0200
-
-	public:
-		RUNTIME_MEMBER_ACCESSOR_VERSIONED(BSTSmartPointer<BSScript::IVirtualMachine>, GetImpl, SKSE::RUNTIME_SSE_1_7_99, 0x200, 0x200, 0x210);
-
-		// AE 1.7.99's Amiibo base-class insertion (see above) shifts these too, with no
-		// corrected accessor; no in-tree consumer accesses them directly.
-		BSScript::IVMSaveLoadInterface*       saveLoadInterface;  // 0208
-		BSScript::IVMDebugInterface*          debugInterface;     // 0210
-		BSScript::SimpleAllocMemoryPagePolicy memoryPagePolicy;   // 0218
-		BSScript::CompiledScriptLoader        scriptLoader;       // 0240
-		SkyrimScript::Logger                  logger;             // 0278
-
-	private:
-		std::uint8_t _padHandlePolicy[sizeof(SkyrimScript::HandlePolicy)];  // 0328
-
-	public:
-		RUNTIME_MEMBER_ACCESSOR_VERSIONED(SkyrimScript::HandlePolicy, GetHandlePolicy, SKSE::RUNTIME_SSE_1_7_99, 0x328, 0x328, 0x338);
-
-		struct TAIL_RUNTIME_DATA
+		// AE 1.7.99's Amiibo base-class insertion (see above) shifts every field in
+		// this struct by the same +0x10, at the same version boundary.
+		struct VM_RUNTIME_DATA
 		{
+			BSTSmartPointer<BSScript::IVirtualMachine> impl;                       // 0200
+			BSScript::IVMSaveLoadInterface*            saveLoadInterface;          // 0208
+			BSScript::IVMDebugInterface*               debugInterface;             // 0210
+			BSScript::SimpleAllocMemoryPagePolicy      memoryPagePolicy;           // 0218
+			BSScript::CompiledScriptLoader             scriptLoader;               // 0240
+			SkyrimScript::Logger                       logger;                     // 0278
+			SkyrimScript::HandlePolicy                 handlePolicy;               // 0328
 			SkyrimScript::ObjectBindPolicy             objectBindPolicy;           // 0398
 			BSTSmartPointer<SkyrimScript::Store>       scriptStore;                // 0470
 			SkyrimScript::FragmentSystem               fragmentSystem;             // 0478
@@ -438,19 +427,31 @@ namespace RE
 			BSTArray<BSTSmartPointer<UpdateDataEvent>> queuedOnUpdateGameEvents;   // 0738
 			std::uint32_t                              unk0750;                    // 0750
 		};
+		static_assert(offsetof(VM_RUNTIME_DATA, impl) == 0x0);
+		static_assert(offsetof(VM_RUNTIME_DATA, saveLoadInterface) == 0x8);
+		static_assert(offsetof(VM_RUNTIME_DATA, debugInterface) == 0x10);
+		static_assert(offsetof(VM_RUNTIME_DATA, memoryPagePolicy) == 0x18);
+		static_assert(offsetof(VM_RUNTIME_DATA, scriptLoader) == 0x40);
+		static_assert(offsetof(VM_RUNTIME_DATA, logger) == 0x78);
+		static_assert(offsetof(VM_RUNTIME_DATA, handlePolicy) == 0x128);
+		static_assert(offsetof(VM_RUNTIME_DATA, objectBindPolicy) == 0x198);
+		static_assert(offsetof(VM_RUNTIME_DATA, scriptStore) == 0x270);
+		static_assert(offsetof(VM_RUNTIME_DATA, fragmentSystem) == 0x278);
+		static_assert(offsetof(VM_RUNTIME_DATA, profiler) == 0x390);
+		static_assert(offsetof(VM_RUNTIME_DATA, savePatcher) == 0x470);
+		static_assert(offsetof(VM_RUNTIME_DATA, frozenLock) == 0x478);
+		static_assert(offsetof(VM_RUNTIME_DATA, isFrozen) == 0x480);
+		static_assert(offsetof(VM_RUNTIME_DATA, unk0750) == 0x550);
+		// sizeof(VM_RUNTIME_DATA) is 0x558 due to trailing alignment padding the
+		// compiler adds after unk0750 (not present in the real binary layout, where
+		// RUNTIME_DATA/RUNTIME_DATA2/VR_RUNTIME_DATA start immediately at +0x554);
+		// _padVMRuntimeData below reserves the real 0x554-byte span, not sizeof().
+		static_assert(sizeof(VM_RUNTIME_DATA) == 0x558);
 
-		[[nodiscard]] inline TAIL_RUNTIME_DATA& GetTailRuntimeData() noexcept
-		{
-			if SKYRIM_REL_CONSTEXPR (REL::Module::IsAE()) {
-				if (REL::Module::get().version().compare(SKSE::RUNTIME_SSE_1_7_99) != std::strong_ordering::less) {
-					return REL::RelocateMember<TAIL_RUNTIME_DATA>(this, 0x3A8);
-				}
-			}
-			return REL::RelocateMember<TAIL_RUNTIME_DATA>(this, 0x398);
-		}
+		RUNTIME_MEMBER_ACCESSOR_VERSIONED(VM_RUNTIME_DATA, GetVMRuntimeData, SKSE::RUNTIME_SSE_1_7_99, 0x200, 0x200, 0x210);
 
 	private:
-		std::uint8_t _padTailRuntimeData[0x3BC];  // 0398
+		std::uint8_t _padVMRuntimeData[0x554];  // 0200
 
 	public:
 #if defined(EXCLUSIVE_SKYRIM_FLAT)

--- a/include/RE/S/SkyrimVM.h
+++ b/include/RE/S/SkyrimVM.h
@@ -151,9 +151,8 @@ namespace RE
 		public BSTEventSink<BSScript::StatsEvent>,  // 0190
 		public BSTEventSink<MenuOpenCloseEvent>,    // 0198
 #endif
-		// AE 1.7.99's Amiibo bases (real bases, see above) shift this base's real data
-		// (sinks/locks/pending lists) by +0x10 with no corrected accessor. No in-tree
-		// consumer calls AddEventSink/etc. on SkyrimVM yet; add one if that changes.
+		// AE 1.7.99's Amiibo bases (real bases, see above) shift this base's data by
+		// +0x10 with no corrected accessor -- do not access it directly on that version.
 		public BSTEventSource<BSScript::StatsEvent>  // 01A8
 	{
 	public:
@@ -391,9 +390,8 @@ namespace RE
 		// (see BSScript::IFreezeQuery) or a timeout.
 		void Freeze();
 
-		// AE 1.7.99's Amiibo base-class insertion (see above) shifts every own-member from
-		// here on by +0x10, not just HandlePolicy/TAIL_RUNTIME_DATA as previously modeled.
-		// Same pattern as TAIL_RUNTIME_DATA: private pad + versioned overlay struct.
+		// AE 1.7.99's Amiibo base-class insertion (see above) shifts every own-member
+		// from here on by +0x10.
 		struct HEAD_RUNTIME_DATA
 		{
 			BSTSmartPointer<BSScript::IVirtualMachine> impl;               // 0200

--- a/src/RE/S/SkyrimVM.cpp
+++ b/src/RE/S/SkyrimVM.cpp
@@ -27,7 +27,7 @@ namespace RE
 	// Sends event to handle directly, then relays event to all reference aliases and magic effects attached to reference
 	void SkyrimVM::SendAndRelayEvent(VMHandle a_handle, BSFixedString* a_event, BSScript::IFunctionArguments* a_args, SkyrimVM::ISendEventFilter* a_optionalFilter)
 	{
-		GetHeadRuntimeData().impl.get()->SendEvent(a_handle, *a_event, a_args);
+		GetImpl().get()->SendEvent(a_handle, *a_event, a_args);
 		RelayEvent(a_handle, a_event, a_args, a_optionalFilter);
 	}
 

--- a/src/RE/S/SkyrimVM.cpp
+++ b/src/RE/S/SkyrimVM.cpp
@@ -27,7 +27,7 @@ namespace RE
 	// Sends event to handle directly, then relays event to all reference aliases and magic effects attached to reference
 	void SkyrimVM::SendAndRelayEvent(VMHandle a_handle, BSFixedString* a_event, BSScript::IFunctionArguments* a_args, SkyrimVM::ISendEventFilter* a_optionalFilter)
 	{
-		impl.get()->SendEvent(a_handle, *a_event, a_args);
+		GetHeadRuntimeData().impl.get()->SendEvent(a_handle, *a_event, a_args);
 		RelayEvent(a_handle, a_event, a_args, a_optionalFilter);
 	}
 

--- a/src/RE/S/SkyrimVM.cpp
+++ b/src/RE/S/SkyrimVM.cpp
@@ -27,7 +27,7 @@ namespace RE
 	// Sends event to handle directly, then relays event to all reference aliases and magic effects attached to reference
 	void SkyrimVM::SendAndRelayEvent(VMHandle a_handle, BSFixedString* a_event, BSScript::IFunctionArguments* a_args, SkyrimVM::ISendEventFilter* a_optionalFilter)
 	{
-		GetImpl().get()->SendEvent(a_handle, *a_event, a_args);
+		GetVMRuntimeData().impl.get()->SendEvent(a_handle, *a_event, a_args);
 		RelayEvent(a_handle, a_event, a_args, a_optionalFilter);
 	}
 

--- a/src/RE/V/VirtualMachine.cpp
+++ b/src/RE/V/VirtualMachine.cpp
@@ -11,7 +11,7 @@ namespace RE
 			VirtualMachine* VirtualMachine::GetSingleton()
 			{
 				auto vm = SkyrimVM::GetSingleton();
-				return vm ? static_cast<VirtualMachine*>(vm->impl.get()) : nullptr;
+				return vm ? static_cast<VirtualMachine*>(vm->GetHeadRuntimeData().impl.get()) : nullptr;
 			}
 		}
 	}

--- a/src/RE/V/VirtualMachine.cpp
+++ b/src/RE/V/VirtualMachine.cpp
@@ -11,7 +11,7 @@ namespace RE
 			VirtualMachine* VirtualMachine::GetSingleton()
 			{
 				auto vm = SkyrimVM::GetSingleton();
-				return vm ? static_cast<VirtualMachine*>(vm->GetHeadRuntimeData().impl.get()) : nullptr;
+				return vm ? static_cast<VirtualMachine*>(vm->GetImpl().get()) : nullptr;
 			}
 		}
 	}

--- a/src/RE/V/VirtualMachine.cpp
+++ b/src/RE/V/VirtualMachine.cpp
@@ -11,7 +11,7 @@ namespace RE
 			VirtualMachine* VirtualMachine::GetSingleton()
 			{
 				auto vm = SkyrimVM::GetSingleton();
-				return vm ? static_cast<VirtualMachine*>(vm->GetImpl().get()) : nullptr;
+				return vm ? static_cast<VirtualMachine*>(vm->GetVMRuntimeData().impl.get()) : nullptr;
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- `SkyrimVM`: the AE 1.7.99 layout fix (#298) only version-corrected fields from `HandlePolicy` (0x328) onward. RTTI confirms the two new Amiibo bases insert earlier, shifting `impl`/`saveLoadInterface`/`debugInterface`/`memoryPagePolicy`/`scriptLoader`/`logger` by `+0x10` with no correction, and leaving `BSTEventSource<StatsEvent>`'s real state uncorrected. Wrapped the six head fields in a versioned `HEAD_RUNTIME_DATA` overlay (same pattern as the existing `TAIL_RUNTIME_DATA`); `sizeof(SkyrimVM)` unchanged.
- `PlayerCharacter`: `AsBGSActorCellEventSource`/`AsBGSActorDeathEventSource`/`AsPositionPlayerEventSource` used `RUNTIME_CAST_ACCESSOR_VERSIONED_VR`, which has no AE-1.7.99 sub-branch. RTTI confirms AE 1.7.99's new `BSTEventSink<BSSystemEvent>` base shifts all three by `+8`. Replaced with manual accessors reusing `REL::RelocateMemberIfNewer` (the same helper the macro itself calls) -- same signatures, no new API surface.

Both confirmed via a direct RTTI `BaseClassDescriptor` walk against the compiled `SkyrimSE.1.7.99.exe`/pre-1.7.99 binaries (not inferred from the header), and compile-verified with the project's clang-based layout extractor before and after each edit (identical struct sizes/counts).

## Test plan
- [x] `parse_commonlib_types.py ae --types-only` and `svr --types-only` both compile clean, `sizeof(SkyrimVM)` unchanged (0x760 AE-flat / 0x780 VR)
- [x] RTTI base-class offsets cross-checked against both SkyrimSE.1170.exe and SkyrimSE.1.7.99.exe
- [ ] Runtime verification against a live AE 1.7.99 install (not done this session)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013WqQD3vawqgNMZ4tAR3bSA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Improved runtime compatibility with newer Anniversary Edition builds, including AE 1.7.99.
  * Updated player-character event handling and virtual machine access across supported game versions.

* **Bug Fixes**
  * Improved reliability when accessing game systems affected by version-specific layout changes.

* **Maintenance**
  * Preserved existing behavior for Skyrim Special Edition, VR, and earlier Anniversary Edition releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->