### PR TITLE
fix(state): rename unk055 to useEarlyZ

### DIFF
--- a/include/RE/S/State.h
+++ b/include/RE/S/State.h
@@ -229,8 +229,8 @@ namespace RE
 			bool                       letterbox;                          // 051
 			bool                       unk052;                             // 052
 			bool                       compiledShaderThisFrame;            // 053
-			bool                       insideFrame;                        // 054 - previously misnamed useEarlyZ
-			bool                       unk055;                             // 055
+			bool                       insideFrame;                        // 054
+			bool                       useEarlyZ;                          // 055
 #ifndef ENABLE_SKYRIM_AE
 			RUNTIME_DATA_CONTENT;  // 058, AE,VR 060
 #endif


### PR DESCRIPTION
## Summary
`State::insideFrame`'s doc comment claims it was "previously misnamed useEarlyZ," but that's imprecise about which field is actually `useEarlyZ`. Tracing `ConsoleFunc::handler::ToggleEarlyZ` (the "Early Z is now ON/OFF" console command) shows the byte it toggles is the very next field over -- `State+0x55`, currently named `unk055` -- not `insideFrame` at `+0x54`.

Confirmed on two runtimes:
- SE: `ConsoleFunc::handler::ToggleEarlyZ` toggles `State+0x55` directly (already independently named `bUseEarlyZ` as a loose global in this project's Ghidra database).
- Legacy AE (1.6.1170): same console handler toggles the equivalent `State+0x59` (that runtime's own already-known +4 offset drift from SE in this region).

`insideFrame` itself was independently confirmed unrelated: it's set `true` in `Renderer::Begin` and `false` in `Renderer::End`, matching its existing name correctly.

Found as a side effect of RE'ing AE 1.7.99's `State` layout for #307; filed separately since it's an unrelated, self-contained naming fix.

## Test plan
- [x] `unk055` has exactly one reference in the codebase (the field declaration itself) -- pure rename, no logic change
- [x] Full local preset matrix builds clean: se/ae/vr/flatrim/all (clang-cl)

https://claude.ai/code/session_01RBoPQSBLgneHdjZ2ukWj1e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed a graphics state property to clarify that it controls early depth testing.
  * Corrected the associated state field documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->