### PR TITLE
feat: flag for address library v5 compatibility

### DIFF
--- a/include/SKSE/Interfaces.h
+++ b/include/SKSE/Interfaces.h
@@ -375,6 +375,7 @@ namespace SKSE
 		enum
 		{
 			kVersionIndependentEx_NoStructUse = 1 << 0,
+			kVersionIndependentEx_AddressLibraryV5 = 1 << 1,
 		};
 
 		constexpr void PluginVersion(REL::Version a_version) noexcept { pluginVersion = a_version.pack(); }
@@ -418,7 +419,7 @@ namespace SKSE
 		char                pluginName[256] = {};
 		char                author[256] = {};
 		char                supportEmail[252] = {};
-		std::uint32_t       versionIndependenceEx = 0;
+		std::uint32_t       versionIndependenceEx = kVersionIndependentEx_AddressLibraryV5;
 		std::uint32_t       versionIndependence = 0;
 		std::uint32_t       compatibleVersions[16] = {};
 		std::uint32_t       xseMinimum = 0;


### PR DESCRIPTION
## Summary
- Matches [ianpatt/skse64@71f41da5](https://github.com/ianpatt/skse64/commit/71f41da518f964345f0050471ec0232fa3a3afc8) and [libxse/commonlibsse#6](https://github.com/libxse/commonlibsse/pull/6).
- SKSE now gates any plugin that declares `UsesAddressLibrary()` and is built after 2026-08-21: on a v5-encoded address library (Skyrim 1.7.99+), it's rejected outright ("must be recompiled for new address library") unless it also sets `kVersionIndependentEx_AddressLibraryV5`.
- Set as the default value of `versionIndependenceEx` (no accessor) so every plugin built against this header picks it up automatically, matching upstream's approach.

## Test plan
- [x] Builds clean (verified downstream against EngineFixesSkyrim64)

https://claude.ai/code/session_013WqQD3vawqgNMZ4tAR3bSA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added default support for the Address Library V5 extended version-independence flag.
* **Bug Fixes**
  * Improved plugin version compatibility by applying the appropriate version-independence setting automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->